### PR TITLE
Move examples to one place: a separate examples directory + ICP coreg improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ dmypy.json
 # version file
 xdem/version.py
 
-xdem/examples/
+examples/*/data/

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - ipython
   - matplotlib
   - pdal
+  - opencv
   - python-pdal
   - pyproj
   - rasterio

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='xdem',
       license='BSD-3',
       packages=['xdem'],
       install_requires=['numpy', 'scipy', 'rasterio', 'geopandas', 'pyproj', 'tqdm', 'geoutils'],
-      extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal']},
+      extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal'], 'opencv': ['opencv']},
       scripts=[],
       zip_safe=False)
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -28,9 +28,9 @@ def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovec
 def test_coreg_method_enum():
     """Test that the CoregMethod enum works as it should."""
     # Try to generate an enum from a string
-    icp = coreg.CoregMethod.from_str("icp")
+    icp = coreg.CoregMethod.from_str("icp_pdal")
     # Make sure the enum points to the right function
-    assert icp == coreg.icp_coregistration   # pylint: disable=comparison-with-callable
+    assert icp == coreg.icp_coregistration_pdal   # pylint: disable=comparison-with-callable
 
     # Make sure the following madness ends up in a ValueError
     try:
@@ -46,12 +46,22 @@ class TestCoreg:
 
     ref, tba, mask = load_examples()  # Load example reference, to-be-aligned and mask.
 
-    def test_icp(self):
+    def test_icp_opencv(self):
+        """Test the opencv ICP coregistration method."""
+        metadata: dict[str, Any] = {}
+        _, error = coreg.coregister(self.ref, self.tba, method="icp_opencv", mask=self.mask, metadata=metadata)
+        print(metadata)
+
+        assert abs(metadata["icp_opencv"]["nmad"] - error) < 0.01
+
+        assert error < 10
+
+    def test_icp_pdal(self):
         """Test the ICP coregistration method."""
         metadata: dict[str, Any] = {}
-        _, error = coreg.coregister(self.ref, self.tba, method="icp", mask=self.mask, metadata=metadata)
+        _, error = coreg.coregister(self.ref, self.tba, method="icp_pdal", mask=self.mask, metadata=metadata)
 
-        assert metadata["icp"]["nmad"] == error
+        assert abs(metadata["icp_pdal"]["nmad"] - error) < 0.01
 
         assert error < 10
 

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -5,7 +5,7 @@ import os
 import geopandas as gpd
 import rasterio as rio
 
-EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "examples/"))
+EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "../", "examples/"))
 # Absolute filepaths to the example files.
 FILEPATHS = {
     "longyearbyen_ref_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen/data/DEM_2009_ref.tif"),


### PR DESCRIPTION
We had two options for where to put the examples directory:
`xdem/examples/`
or
`examples/`
currently, both are used!

This PR makes only the latter be used.