### PR TITLE
Function to merge rasters using any callable (mean, median, sum etc)

### DIFF
--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -4,7 +4,10 @@ Author(s):
     Erik S. Holmlund
 
 """
+import geoutils as gu
+import matplotlib.pyplot as plt
 import numpy as np
+import rasterio as rio
 
 import xdem
 from xdem import examples
@@ -17,3 +20,36 @@ def test_dem_subtraction():
         examples.FILEPATHS["longyearbyen_tba_dem"])
 
     assert np.nanmean(np.abs(diff.data)) < 100
+
+
+def test_merge_rasters():
+    """Split a DEM with some overlap, then merge it, and validate that it's still the same."""
+    dem = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
+
+    # Find the easting midpoint of the DEM
+    x_midpoint = np.mean([dem.bounds.right, dem.bounds.left])
+    x_midpoint -= x_midpoint % dem.res[0]
+
+    # Cut the DEM into two DEMs that slightly overlap each other.
+    dem1 = dem.reproject(dst_bounds=rio.coords.BoundingBox(
+        right=x_midpoint + dem.res[0] * 3,
+        left=dem.bounds.left,
+        top=dem.bounds.top,
+        bottom=dem.bounds.bottom),
+        dst_crs=dem.crs
+    )
+    dem2 = dem.reproject(dst_bounds=rio.coords.BoundingBox(
+        left=x_midpoint - dem.res[0] * 3,
+        right=dem.bounds.right,
+        top=dem.bounds.top,
+        bottom=dem.bounds.bottom),
+        dst_crs=dem.crs
+    )
+
+    # Merge the DEM and check that it closely resembles the initial DEM
+    merged_dem = xdem.spatial_tools.merge_rasters([dem1, dem2])
+    assert dem.data.shape == merged_dem.data.shape
+
+    diff = dem.data - merged_dem.data
+
+    assert np.abs(np.nanmean(diff)) < 0.0001

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -1,7 +1,9 @@
 """
 
 """
-from typing import Union
+from __future__ import annotations
+
+from typing import Callable, Union
 
 import geoutils as gu
 import numpy as np
@@ -20,6 +22,22 @@ def nmad(data: np.ndarray, nfact: float = 1.4826) -> float:
     """
     m = np.nanmedian(data)
     return nfact * np.nanmedian(np.abs(data - m))
+
+
+def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
+    """Get a rasterio resampling method from a string representation, e.g. "cubic_spline"."""
+    # Try to match the string version of the resampling method with a rio Resampling enum name
+    for method in rio.warp.Resampling:
+        if str(method).replace("Resampling.", "") == method_str:
+            resampling_method = method
+            break
+    # If no match was found, raise an error.
+    else:
+        raise ValueError(
+            f"'{resampling_method}' is not a valid rasterio.warp.Resampling method. "
+            f"Valid methods: {[str(method).replace('Resampling.', '') for method in rio.warp.Resampling]}"
+        )
+    return resampling_method
 
 
 def subtract_rasters(first_raster: Union[str, gu.georaster.Raster], second_raster: Union[str, gu.georaster.Raster],
@@ -53,17 +71,7 @@ def subtract_rasters(first_raster: Union[str, gu.georaster.Raster], second_raste
         raise ValueError(f"Invalid reference string: '{reference}', must be either 'first' or 'second'")
     # Parse the resampling method if given as a string.
     if isinstance(resampling_method, str):
-        # Try to match the string version of the resampling method with a rio Resampling enum name
-        for method in rio.warp.Resampling:
-            if str(method).replace("Resampling.", "") == resampling_method:
-                resampling_method = method
-                break
-        # If no match was found, raise an error.
-        else:
-            raise ValueError(
-                f"'{resampling_method}' is not a valid rasterio.warp.Resampling method. "
-                f"Valid methods: {[str(method).replace('Resampling.', '') for method in rio.warp.Resampling]}"
-            )
+        resampling_method = resampling_method_from_str(resampling_method)
 
     # Reproject the non-reference and subtract the two rasters.
     difference = first_raster.data - second_raster.reproject(first_raster, resampling=resampling_method).data if \
@@ -78,3 +86,77 @@ def subtract_rasters(first_raster: Union[str, gu.georaster.Raster], second_raste
     )
 
     return difference_raster
+
+
+def merge_bounding_boxes(bounds: list[rio.coords.BoundingBox], resolution: float) -> rio.coords.BoundingBox:
+    max_bounds = dict(zip(["left", "right", "top", "bottom"], [np.nan] * 4))
+    for bound in bounds:
+        for key in "right", "top":
+            max_bounds[key] = np.nanmax([max_bounds[key], bound.__getattribute__(key)])
+        for key in "bottom", "left":
+            max_bounds[key] = np.nanmin([max_bounds[key], bound.__getattribute__(key)])
+
+    for key in max_bounds:
+        modulo = max_bounds[key] % resolution
+        max_bounds[key] -= modulo
+
+        if key in ["right", "top"] and modulo > 0:
+            max_bounds[key] += resolution
+
+    return rio.coords.BoundingBox(**max_bounds)
+
+
+def merge_rasters(rasters: list[gu.georaster.Raster], reference: int = 0, merge_algorithm: Callable = np.nanmean,
+                  resampling_method: Union[str, rio.warp.Resampling] = "nearest") -> gu.georaster.Raster:
+    """
+    Merge a list of rasters into one larger raster.
+
+    Reprojects the rasters to the reference raster CRS and resolution.
+
+    :param rasters: A list of geoutils Raster objects.
+    :param reference: The reference index (defaults to the first raster in the list).
+    :param merge_algorithm: The algorithm to merge the rasters with. Defaults to the mean.
+    :param resampling_method: The resampling method for the raster reprojections.
+
+    :returns: The merged raster with the same parameters (excl. bounds) as the reference.
+    """
+    # Try to run the merge_algorithm with an arbitrary list. Raise an error if the algorithm is incompatible.
+    try:
+        merge_algorithm([1, 2])
+    except TypeError as exception:
+        raise TypeError(f"merge_algorithm must be able to take a list as its first argument.\n\n{exception}")
+    if isinstance(resampling_method, str):
+        resampling_method = resampling_method_from_str(resampling_method)
+
+    reference_raster = rasters[reference]
+    # Find the maximum covering bounding box
+    max_bounds = merge_bounding_boxes([raster.bounds for raster in rasters], resolution=reference_raster.res[0])
+
+    # Make a data list and add all of the reprojected rasters into it.
+    data: list[np.ndarray] = []
+    for raster in rasters:
+        reprojected_raster = raster.reproject(
+            dst_bounds=max_bounds,
+            dst_crs=reference_raster.crs,
+            dtype=reference_raster.data.dtype,
+            nodata=reference_raster.nodata
+        )
+        data.append(reprojected_raster.data.squeeze())
+
+    # Try to use the keyword axis=0 for the merging algorithm (if it's a numpy ufunc).
+    try:
+        merged_data = merge_algorithm(data, axis=0)
+    # If that doesn't work, use the slower np.apply_along_axis approach.
+    except TypeError as exception:
+        if "'axis' is an invalid keyword" not in str(exception):
+            raise exception
+        merged_data = np.apply_along_axis(merge_algorithm, axis=0, arr=data)
+
+    merged_raster = gu.georaster.Raster.from_array(
+        data=merged_data.reshape((1,) + merged_data.shape),
+        transform=rio.transform.from_bounds(*max_bounds, width=merged_data.shape[1], height=merged_data.shape[0]),
+        crs=reference_raster.crs,
+        nodata=reference_raster.nodata
+    )
+
+    return merged_raster


### PR DESCRIPTION
In GDAL, only the operators "first" and "last" can be applied when merging (mosaicing) rasters. This often creates quite ugly seams, and may hide good data (a NaN in one raster can replace a value in another). Additionally, when dealing with multiple DEMs, one might want to calculate statistics such as the median, standard deviation (or anything else) within each cell.

An example:
```python
dem_west = gu.georaster.Raster("path/to/dem1")
dem_east = gu.georaster.Raster("path/to/dem2")

# This will merge the two DEMs and take the average (np.nanmean) values if they overlap.
# It returns a new Raster with the combined bounds of the two inputs.
merged_dem = xdem.spatial_tools.merge_rasters([dem_west, dem_east])
```

or:
```python
list_of_many_dems = [...]

# Calculate the variation between the different rasters
standard_deviation = xdem.spatial_tools.merge_rasters(list_of_many_dems, merge_algorithm=np.nanstd)
nmad = xdem.spatial_tools.merge_rasters(list_of_many_dems, merge_algorithm=xdem.spatial_tools.nmad)
```