### PR TITLE
Fix 'pip install' to install all dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(name='xdem',
       license='BSD-3',
       packages=['xdem'],
       install_requires=['numpy', 'scipy', 'rasterio', 'geopandas',
-                        'pyproj', 'tqdm', 'geoutils @ https://github.com/GlacioHack/GeoUtils/tarball/master', 'richdem', 'scikit-gstat'],
+                        'pyproj', 'tqdm', 'geoutils @ https://github.com/GlacioHack/GeoUtils/tarball/master', 'scikit-gstat'],
       extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal'], 'opencv': ['opencv']},
       scripts=[],
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@ setup(name='xdem',
       author='The GlacioHack Team',
       license='BSD-3',
       packages=['xdem'],
-      install_requires=['numpy', 'scipy', 'rasterio', 'geopandas', 'pyproj', 'tqdm', 'geoutils'],
+      install_requires=['numpy', 'scipy', 'rasterio', 'geopandas',
+                        'pyproj', 'tqdm', 'geoutils', 'richdem', 'scikit-gstat'],
       extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal'], 'opencv': ['opencv']},
+      dependency_links=["https://github.com/GlacioHack/GeoUtils.git"],
       scripts=[],
       zip_safe=False)
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,8 @@ setup(name='xdem',
       license='BSD-3',
       packages=['xdem'],
       install_requires=['numpy', 'scipy', 'rasterio', 'geopandas',
-                        'pyproj', 'tqdm', 'geoutils', 'richdem', 'scikit-gstat'],
+                        'pyproj', 'tqdm', 'geoutils @ https://github.com/GlacioHack/GeoUtils/tarball/master', 'richdem', 'scikit-gstat'],
       extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal'], 'opencv': ['opencv']},
-      dependency_links=["https://github.com/GlacioHack/GeoUtils.git"],
       scripts=[],
       zip_safe=False)
 

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -26,13 +26,18 @@ import pyproj.crs
 import rasterio as rio
 import rasterio.warp  # pylint: disable=unused-import
 import rasterio.windows  # pylint: disable=unused-import
-import richdem as rd
 import scipy
 import scipy.interpolate
 import scipy.ndimage
 import scipy.optimize
 from rasterio import Affine
 from tqdm import trange
+
+try:
+    import richdem as rd
+    _has_rd = True
+except ImportError:
+    _has_rd = False
 
 try:
     import cv2


### PR DESCRIPTION
`pip install git+https://github.com/GlacioHack/xdem.git` is now enough to install xdem! See #48 for what was previously needed on a clean install.

```bash
❯ conda create -n clean_env python ipython
❯ conda activate clean_env
❯ pip install git+https://github.com/GlacioHack/xdem.git

❯ ipython

Python 3.9.0 | packaged by conda-forge | (default, Nov 26 2020, 07:57:39)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.19.0 -- An enhanced Interactive Python. Type '?' for help.
                                                                                                                                                                                                                    
In [1]: import geoutils
ERROR 4: Unable to open EPSG support file gcs.csv.  Try setting the GDAL_DATA environment variable to point to the directory containing EPSG csv files.

In [2]: import xdem
```

I guess the geoutils error is because of GDAL... It's always GDAL!

I will mark this as a draft, because I've had to make both `richdem` and `scikit-gstat` into required dependencies. We should discuss this before merging!

`pip install xdem` will work accordingly as soon as we've marked a GitHub release.