### PR TITLE
Local and regional hypsometric dDEM interpolation

### DIFF
--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -4,6 +4,41 @@ DEM subtraction and volume change
 .. contents:: Contents 
    :local:
 
+**Example data**
+
+
+Example data in this chapter are loaded as follows:
+
+.. code-block:: python
+
+        from datetime import datetime        
+
+        import geoutils as gu
+        import xdem
+
+        # Download the necessary data. This may take a few minutes.
+        xdem.examples.download_longyearbyen_examples(overwrite=False)
+
+        # Load a reference DEM from 2009
+        dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], datetime=datetime(2009, 8, 1))
+        # Load a DEM from 1990
+        dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], datetime=datetime(1990, 8, 1))
+        # Load glacier outlines from 1990.
+        glaciers_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+        glaciers_2010 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines_2010"])
+        
+        # Make a dictionary of glacier outlines where the key represents the associated date.
+        outlines = {
+                datetime(1990, 8, 1): glaciers_1990,
+                datetime(2009, 8, 1): glaciers_2010
+        }
+
+        # Fake a future DEM to have a time-series of three DEMs
+        dem_2060 = dem_2009.copy()
+        # Assume that all glacier values will be 30 m lower than in 2009
+        dem_2060.data[glaciers_2010.create_mask(dem_2060) == 255] -= 30
+        dem_2060.datetime.year = 2060
+
 Subtracting rasters
 ^^^^^^^^^^^^^^^^^^^
 Calculating the difference of DEMs (dDEMs) is theoretically simple, but can in practice often be time consuming.
@@ -19,6 +54,7 @@ Calculating a dDEM would then be as simple as:
         ddem_raster = xdem.DEM.from_array(ddem_data, dem1.transform, dem1.crs)
 
 But in practice, our two DEMs are most often not perfectly aligned, which is why we might need a helper function for this:
+:func:`xdem.spatial_tools.subtract_rasters`
 
 .. code-block:: python
         
@@ -32,53 +68,74 @@ This can be changed with the ``resampling_method=`` keyword, for example to ``"b
 Most often, ``xdem`` works with Masked Arrays, where the mask signifies cells to exclude (presumably areas of no data).
 The ``subtract_rasters()`` function makes sure that the outgoing mask is the union of the two ingoing masks.
 
-The DEMCollection object
-^^^^^^^^^^^^^^^^^^^^^^^^
-Keeping track of multiple DEMs can be difficult when many different extents, resolutions and CRSs are involved, and the ``DEMCollection`` is ``xdem``'s answer to make this simple.
-Let's first load some example data:
+dDEM interpolation
+^^^^^^^^^^^^^^^^^^
+There are many approaches to interpolate a dDEM.
+A good comparison study for glaciers is McNabb et al., (`2019 <https://doi.org/10.5194/tc-13-895-2019>`_).
+So far, ``xdem`` has three types of interpolation:
 
+- Linear spatial interpolation
+- Local hypsometric interpolation
+- Regional hypsometric interpolation
+
+Let's first create a :class:`xdem.ddem.dDEM` object to experiment on:
 
 .. code-block:: python
 
-        import geoutils as gu
-        import xdem
+        ddem = xdem.dDEM(
+                raster=xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990),
+                start_time=dem_1990.datetime,
+                end_time=dem_2009.datetime
+        )
 
-        # Download the necessary data. This may take a few minutes.
-        xdem.examples.download_longyearbyen_examples(overwrite=False)
+        # The example DEMs are void-free, so let's make some random voids.
+        ddem.data.mask = np.zeros_like(ddem.data, dtype=bool)  # Reset the mask
+        # Introduce 50000 nans randomly throughout the dDEM.
+        ddem.data.mask.ravel()[np.random.choice(ddem.data.size, 50000, replace=False)] = True
 
-        # Load a reference DEM from 2009
-        dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-        # Load a DEM from 1990
-        dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-        # Load glacier outlines from 1990.
-        glaciers_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
-        glaciers_2010 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines_2010"])
 
-        # Fake a future DEM to have a time-series of three DEMs
-        dem_2060 = dem_2009.copy()
-        # Assume that all glacier values will be 30 m lower than in 2009
-        dem_2060.data[glaciers_2010.create_mask(dem_2060) == 255] -= 30
 
-We also need some metadata on the timing of these products.
+Linear spatial interpolation
+****************************
+Linear spatial interpolation (also often called bilinear interpolation) of dDEMs is arguably the simplest approach: voids are filled by a an average of the surrounding pixels values, weighted by their distance to the void pixel.
+
+.. code-block:: python
+
+        ddem.interpolate(method="linear")
+
+Local hypsometric interpolation
+*******************************
+This approach assumes that there is a relationship between the elevation and the elevation change in the dDEM, which is often the case for glaciers.
+Elevation change gradients in late 1900s and 2000s on glaciers often have the signature of large melt in the lower parts, while the upper parts might be less negative, or even positive.
+This relationship is strongly correlated for a specific glacier, and weakly correlated on regional scales (see `Regional hypsometric interpolation`_).
+With the local (glacier specific) hypsometric approach, elevation change gradients are estimated for each glacier separately.
+This is simply a linear or polynomial model estimated with the dDEM and a reference DEM.
+Then, voids are interpolated by replacing them with what "should be there" at that elevation, according to the model.
+
+.. code-block:: python
+        
+        ddem.interpolate(method="local_hypsometric", reference_elevation=dem_2009, mask=outlines_1990)
+
+Regional hypsometric interpolation
+**********************************
+Similarly to `Local hypsometric interpolation`_, the elevation change is assumed to be largely elevation-dependent.
+With the regional approach (often also called "global"), elevation change gradients are estimated for all glaciers in an entire region, instead of estimating one by one.
+This is advantageous in respect to areas where voids are frequent, as not even a single dDEM value has to exist on a glacier in order to reconstruct it.
+Of course, the accuracy of such an averaging is much lower than if the local hypsometric approach is used (assuming it is possible).
+
+.. code-block:: python
+        
+        ddem.interpolate(method="regional_hypsometric", reference_elevation=dem_2009, mask=outlines_1990)
+
+The DEMCollection object
+^^^^^^^^^^^^^^^^^^^^^^^^
+Keeping track of multiple DEMs can be difficult when many different extents, resolutions and CRSs are involved, and :class:`xdem.demcollection.DEMCollection` is ``xdem``'s answer to make this simple.
+We need metadata on the timing of these products.
 The DEMs can be provided with the ``datetime=`` argument upon instantiation, or the attribute could be set later.
 Multiple outlines are provided as a dictionary in the shape of ``{datetime: outline}``:
 
 
-.. code-block:: python
-
-        from datetime import datetime
-
-        dem_1990.datetime = datetime(1990, 8, 1)
-        dem_2009.datetime = datetime(2009, 8, 1)
-        dem_2060.datetime = datetime(2060, 8, 1)
-
-        outlines = {
-                datetime(1990, 8, 1): glaciers_1990,
-                datetime(2009, 8, 1): glaciers_2010
-        }
-
-        
-Now that we have three DEMs and glacier outlines with known dates, we can create a collection from them:
+In the examples, we have three DEMs and glacier outlines with known dates, so we can create a collection from them:
 
 .. code-block:: python
 

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -108,6 +108,9 @@ Linear spatial interpolation (also often called bilinear interpolation) of dDEMs
         
         import xdem
         import geoutils as gu
+
+        xdem.examples.download_longyearbyen_examples(overwrite=False)
+
         dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
         outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
@@ -164,6 +167,9 @@ Then, voids are interpolated by replacing them with what "should be there" at th
         import xdem
         import geoutils as gu
         import matplotlib.pyplot as plt
+        
+        xdem.examples.download_longyearbyen_examples(overwrite=False)
+
         dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
         outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
@@ -233,6 +239,9 @@ Of course, the accuracy of such an averaging is much lower than if the local hyp
         import xdem
         import geoutils as gu
         import matplotlib.pyplot as plt
+
+        xdem.examples.download_longyearbyen_examples(overwrite=False)
+
         dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
         outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,6 +34,7 @@ release = '0.0.1'
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
+    'matplotlib.sphinxext.plot_directive',
     "numpydoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.doctest",

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -57,6 +57,9 @@ The loop is stopped either when the maximum iteration limit is reached, or when 
         import xdem
         import geoutils as gu
         import matplotlib.pyplot as plt
+
+        xdem.examples.download_longyearbyen_examples(overwrite=False)
+
         dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
         outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -52,6 +52,42 @@ A cosine function is solved using these products to find the most probable offse
 This is an iterative process, and cosine functions with suggested shifts are applied in a loop, continuously refining the total offset.
 The loop is stopped either when the maximum iteration limit is reached, or when the :ref:`spatial_stats_nmad` between the two products stops improving significantly.
 
+.. plot::
+
+        import xdem
+        import geoutils as gu
+        import matplotlib.pyplot as plt
+        dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
+        dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
+        outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+
+        dem_coreg, error = xdem.coreg.coregister(dem_2009, dem_1990, method="nuth_kaab", mask=outlines_1990, max_iterations=5)
+
+        ddem_pre = xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest")
+        ddem_post = xdem.spatial_tools.subtract_rasters(dem_2009, dem_coreg, resampling_method="nearest")
+
+        nmad_pre = xdem.spatial_tools.nmad(ddem_pre.data.data)
+
+        vlim = 20
+        plt.figure(figsize=(8, 5))
+        plt.subplot2grid((1, 15), (0, 0), colspan=7) 
+        plt.title(f"Before coregistration. NMAD={nmad_pre:.1f} m")
+        plt.imshow(ddem_pre.data.squeeze(), cmap="coolwarm_r", vmin=-vlim, vmax=vlim)
+        plt.axis("off")
+        plt.subplot2grid((1, 15), (0, 7), colspan=7) 
+        plt.title(f"After coregistration. NMAD={error:.1f} m")
+        img = plt.imshow(ddem_post.data.squeeze(), cmap="coolwarm_r", vmin=-vlim, vmax=vlim) 
+        plt.axis("off")
+        plt.subplot2grid((1, 15), (0, 14), colspan=1) 
+        cbar = plt.colorbar(img, fraction=0.4)
+        cbar.set_label("Elevation change (m)")
+        plt.axis("off")
+
+        plt.tight_layout()
+        plt.show()
+
+*Caption: Demonstration of the Nuth and Kääb (2011) approach from Svalbard. Note that large improvements are seen, but nonlinear offsets still exist. The NMAD is calculated from the off-glacier surfaces.*
+
 Limitations
 ***********
 The Nuth and Kääb (2011) coregistation approach does not take rotation into account.

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -1,16 +1,94 @@
 
+import warnings
+
+import geoutils as gu
 import numpy as np
 
-import xdem
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import xdem
 
 
 class TestdDEM:
     dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
     dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
+    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+
+    ddem = xdem.dDEM(
+        xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),
+        start_time=np.datetime64("1990-08-01"),
+        end_time=np.datetime64("2009-08-01")
+    )
 
     def test_init(self):
-        ddem = xdem.dDEM(
-            xdem.spatial_tools.subtract_rasters(self.dem_2009, self.dem_1990, resampling_method="nearest"),
-            start_time=np.datetime64("1990-08-01"),
-            end_time=np.datetime64("2009-08-01")
+        """Test that the dDEM object was instantiated correctly."""
+        assert isinstance(self.ddem, xdem.dDEM)
+        assert isinstance(self.ddem.data, np.ma.masked_array)
+
+    def test_copy(self):
+        """Test that copying works as it should."""
+        ddem2 = self.ddem.copy()
+
+        assert isinstance(ddem2, xdem.dDEM)
+
+        ddem2.data += 1
+
+        assert self.ddem != ddem2
+
+    def test_filled_data(self):
+        """Test that the filled_data property points to the right data."""
+        ddem2 = self.ddem.copy()
+
+        assert not np.any(np.isnan(ddem2.data)) or np.all(~ddem2.data.mask)
+        assert ddem2.filled_data is not None
+
+        assert np.count_nonzero(np.isnan(ddem2.data)) == 0
+        ddem2.data.ravel()[0] = np.nan
+
+        assert np.count_nonzero(np.isnan(ddem2.data)) == 1
+
+        assert ddem2.filled_data is None
+
+        ddem2.interpolate(method="linear")
+
+        assert ddem2.fill_method is not None
+
+    def test_regional_hypso(self):
+        """Test the regional hypsometric approach."""
+        ddem = self.ddem.copy()
+        ddem.data.mask = np.zeros_like(ddem.data, dtype=bool)
+        ddem.data.mask.ravel()[np.random.choice(ddem.data.size, 50000, replace=False)] = True
+        assert np.count_nonzero(ddem.data.mask) > 0
+
+        assert ddem.filled_data is None
+
+        ddem.interpolate(
+            method="regional_hypsometric",
+            reference_elevation=self.dem_2009,
+            mask=self.outlines_1990
         )
+
+        assert ddem._filled_data is not None
+        assert type(ddem.filled_data) == np.ndarray
+        assert np.count_nonzero(np.isnan(ddem.filled_data)) == 0
+
+        assert ddem.filled_data.shape == ddem.data.shape
+
+        assert np.abs(np.mean(self.ddem.data - ddem.filled_data)) < 1
+
+    def test_local_hypso(self):
+        """Test the local hypsometric approach."""
+        ddem = self.ddem.copy()
+        scott_1990 = self.outlines_1990.query("NAME == 'Scott Turnerbreen'")
+        ddem.data.mask = np.zeros_like(ddem.data, dtype=bool)
+        ddem.data.mask.ravel()[np.random.choice(ddem.data.size, 50000, replace=False)] = True
+        assert np.count_nonzero(ddem.data.mask) > 0
+
+        assert ddem.filled_data is None
+
+        ddem.interpolate(
+            method="local_hypsometric",
+            reference_elevation=self.dem_2009.data,
+            mask=self.outlines_1990
+        )
+        assert np.abs(np.mean(self.ddem.data - ddem.filled_data)) < 1

--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import copy
 import warnings
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import geoutils as gu
 import numpy as np
-import rasterio.fill
+import shapely
 
 import xdem
 
@@ -25,17 +26,23 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
 
         :returns: A new dDEM instance.
         """
-        super().__init__(raster)
+        # super().__init__(raster)
 
-        #self.__dict__ = raster.__dict__
+        self.__dict__ = raster.__dict__
         self.start_time = start_time
         self.end_time = end_time
         self.error = error
         self._filled_data: Optional[np.ndarray] = None
+        self._fill_method = ""
 
     def __str__(self) -> str:
         """Return a summary of the dDEM."""
         return f"dDEM from {self.start_time} to {self.end_time}.\n\n{super().__str__()}"
+
+    def copy(self) -> dDEM:
+        """Return a copy of the DEM."""
+        new_ddem = dDEM.from_array(self.data.copy(), self.transform, self.crs, self.start_time, self.end_time)
+        return new_ddem
 
     @property
     def filled_data(self) -> Optional[np.ndarray]:
@@ -51,7 +58,7 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
         if (isinstance(self.data, np.ma.masked_array) and np.any(self.data.mask)) or np.any(np.isnan(self.data)):
             return None
 
-        return self.data
+        return np.asarray(self.data)
 
     @filled_data.setter
     def filled_data(self, array: np.ndarray):
@@ -62,7 +69,12 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
         if (isinstance(array, np.ma.masked_array) and np.any(array.mask)) or np.any(np.isnan(array)):
             raise ValueError("Data contains NaNs")
 
-        self._filled_data = array
+        self._filled_data = np.asarray(array)
+
+    @property
+    def fill_method(self) -> str:
+        """Return the fill method used for the filled_data."""
+        return self._fill_method
 
     @property
     def time(self) -> np.timedelta64:
@@ -95,29 +107,87 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
             error=error,
         )
 
-    def interpolate(self, method: str = "linear"):
+    def interpolate(self, method: str = "linear",
+                    reference_elevation: Optional[Union[np.ndarray, np.ma.masked_array, xdem.DEM]] = None,
+                    mask: Optional[Union[np.ndarray, xdem.DEM, gu.Vector]] = None):
         """
         Interpolate the dDEM using the given method.
 
         :param method: The method to use for interpolation.
+        :param reference_elevation: Reference DEM. Only required for hypsometric approaches.
         """
+        if reference_elevation is not None:
+            try:
+                reference_elevation = reference_elevation.reproject(self, silent=True)  # type: ignore
+            except AttributeError as exception:
+                if "object has no attribute 'reproject'" not in str(exception):
+                    raise exception
+
+            if isinstance(reference_elevation, np.ndarray):
+                reference_elevation = np.ma.masked_array(reference_elevation, mask=np.isnan(reference_elevation))
+
+            assert reference_elevation.data.shape == self.data.shape, (
+                f"'reference_elevation' shape ({reference_elevation.data.shape})"
+                f" different from 'self' ({self.data.shape})"
+            )
+
         if method == "linear":
-            coords = self.coords(offset="center")
-            # Create a mask for where nans exist
-            nan_mask = self.data.mask | np.isnan(self.data.data) if isinstance(
-                self.data, np.ma.masked_array) else np.isnan(self.data)
+            self.filled_data = xdem.volume.linear_interpolation(self.data)
+        elif method == "local_hypsometric":
+            assert reference_elevation is not None
+            assert mask is not None
 
-            interpolated_ddem = rasterio.fill.fillnodata(self.data, mask=~nan_mask.astype("uint8"))
+            if not isinstance(mask, gu.Vector):
+                mask = gu.Vector(mask)
 
-            # Fill the nans (values outside of the value boundaries) with the median value
-            # This triggers a warning with np.masked_array's because it ignores the mask
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                interpolated_ddem[np.isnan(interpolated_ddem)] = np.nanmedian(self.data)
+            nans = np.isnan(np.asarray(self.data)) | (self.data.mask
+                                                      if isinstance(self.data, np.ma.masked_array)
+                                                      else False)
+            interpolated_ddem = np.where(nans, np.nan, np.asarray(self.data))
+            entries = mask.ds[mask.ds.intersects(shapely.geometry.box(*self.bounds))]
 
-            self.filled_data = interpolated_ddem.reshape(self.data.shape)
+            ddem_mask = nans.copy()
+            for i in entries.index:
+                feature_mask = (gu.Vector(entries.loc[entries.index == i]).create_mask(
+                    self) == 255).reshape(self.data.shape)
+                if np.count_nonzero(feature_mask) == 0:
+                    continue
+                try:
+                    interpolated_ddem = xdem.volume.hypsometric_interpolation(
+                        interpolated_ddem,
+                        reference_elevation.data,
+                        mask=feature_mask
+                    ).data
+                except ValueError as exception:
+                    # Skip the feature if too few glacier values exist.
+                    if "x and y arrays must have at least 2 entries" in str(exception):
+                        continue
+                    raise exception
+                # Set the validity flag of all values within the feature to be valid
+                ddem_mask[feature_mask] = False
+
+                # All values that were nan in the start and are without the updated validity mask should now be nan
+                # The above interpolates values outside of the dDEM, so this is necessary.
+                interpolated_ddem[ddem_mask] = np.nan
+
+            diff = abs(np.nanmean(interpolated_ddem - self.data))
+            assert diff < 0.01, (diff, self.data.mean())
+
+            self.filled_data = xdem.volume.linear_interpolation(interpolated_ddem)
+
+        elif method == "regional_hypsometric":
+            assert reference_elevation is not None
+            assert mask is not None
+
+            mask_array = xdem.coreg.mask_as_array(self, mask).reshape(self.data.shape)
+
+            self.filled_data = xdem.volume.hypsometric_interpolation(
+                self.data,
+                reference_elevation.data,
+                mask=mask_array
+            ).data
 
         else:
-            raise NotImplementedError
+            raise NotImplementedError(f"Interpolation method '{method}' not supported")
 
         return self.filled_data

--- a/xdem/demcollection.py
+++ b/xdem/demcollection.py
@@ -122,7 +122,7 @@ class DEMCollection:
         """
         # TODO: Change is loop to run concurrently
         for ddem in self.ddems:
-            ddem.interpolate(method=method)
+            ddem.interpolate(method=method, reference_elevation=self.reference_dem, mask=self.get_ddem_mask(ddem))
 
         return [ddem.filled_data for ddem in self.ddems]
 


### PR DESCRIPTION
I've added local and hypsometric interpolation for the `dDEM` and `DEMCollection` classes. They are functional right now, but will be given some improvements. Hence, I will create a draft PR.

The regional approach works as follows:

1. Mask out the glacier areas using a provided mask or glacier outlines
2. Calculate a regional elevation change gradient from the masked dDEM.
3. Apply the gradient model to the reference DEM to get an "idealized dDEM"
4. Calculate the difference between the idealized dDEM and the actual dDEM, and linearly interpolate it.
5. Correct the idealized dDEM with the difference in 4) to get the final interpolated dDEM

The local approach does approximately the same thing, but it calculates it for each `Vector.ds` row separately. So point nr 2-5 are done iteratively for each glacier in the `Vector`.

If you consider that 4-5 should be optional, I can certainly make it so.

An example with a DEMCollection:
```python
from datetime import datetime

import xdem                                                                                                     
import geoutils as gu                                                                                           
                                                                         
                                                                                                                          
xdem.examples.download_longyearbyen_examples(overwrite=false)                                                   
                                                                                                                          
dem_2009 = xdem.dem(xdem.examples.filepaths["longyearbyen_ref_dem"], datetime=datetime(2009, 8, 1))                                            
dem_1990 = xdem.dem(xdem.examples.filepaths["longyearbyen_tba_dem"], datetime=datetime(1990, 8, 1))                                            
outlines_1990 = gu.Vector(xdem.examples.filepaths["longyearbyen_glacier_outlines"])

dems = xdem.DEMCollection([dem_2009, dem_1990], outlines=outlines_1990)

dems.subtract_dems()
dems.interpolate_ddems(method="local_hypsometric")

```

I've also tried to describe these methods as easy as possible, and I've experimented with matplotlib figures to visualise this! I would love some input on the text or just the general structure. [Here's a link to the documentation of the associated branch on my fork](https://xdem-erikm.readthedocs.io/en/spatial_hypsometric/comparison.html).