### PR TITLE
Modular `coreg.py` revision

### DIFF
--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -51,7 +51,7 @@ Examples are given using data close to Longyearbyen on Svalbard. These can be lo
 
 
 
-The ``Coreg`` object
+The Coreg object
 ^^^^^^^^^^^^^^^^^^^^
 :class:`xdem.coreg.Coreg`
 
@@ -202,7 +202,7 @@ Example
         aligned_dem = icp.apply(tba_data, transform=transform)
 
 
-The ``CoregPipeline`` object
+The CoregPipeline object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 :class:`xdem.coreg.CoregPipeline`
 

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -2,17 +2,23 @@
 
 DEM Coregistration
 ==================
+
+.. contents:: Contents 
+   :local:
+
+Introduction
+^^^^^^^^^^^^
+
 Coregistration of a DEM is performed when it needs to be compared to a reference, but the DEM does not align with the reference perfectly.
 There are many reasons for why this might be, for example: poor georeferencing, unknown coordinate system transforms or vertical datums, and instrument- or processing-induced distortion.
 
 A main principle of all coregistration approaches is the assumption that all or parts of the portrayed terrain are unchanged between the reference and the DEM to be aligned.
 This *stable ground* can be extracted by masking out features that are assumed to be unstable.
 Then, the DEM to be aligned is translated, rotated and/or bent to fit the stable surfaces of the reference DEM as well as possible.
-In mountainous environments, unstable areas could be: glaciers, landslides, vegetation, dead-ice terrain and human settlements.
+In mountainous environments, unstable areas could be: glaciers, landslides, vegetation, dead-ice terrain and human structures.
 Unless the entire terrain is assumed to be stable, a mask layer is required.
-``xdem`` supports either shapefiles or rasters to specify the masked (unstable) areas.
 
-There are multiple methods for coregistration, and each have their own strengths and weaknesses.
+There are multiple approaches for coregistration, and each have their own strengths and weaknesses.
 Below is a summary of how each method works, and when it should (and should not) be used.
 
 **Example data**
@@ -28,18 +34,42 @@ Examples are given using data close to Longyearbyen on Svalbard. These can be lo
         # Download the necessary data. This may take a few minutes.
         xdem.examples.download_longyearbyen_examples(overwrite=False)
 
+        ### Load the data using xdem and geoutils (could be with rasterio and geopandas instead)
         # Load a reference DEM from 2009
         reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         # Load a moderately well aligned DEM from 1990
-        dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
+        dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).resample(reference_dem)
         # Load glacier outlines from 1990. This will act as the unstable ground.
         glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
 
-.. contents:: Contents 
-   :local:
+
+        # Prepare the inputs for coregistration.
+        ref_data = reference_dem.data  # This is a numpy 2D array/masked_array
+        tba_data = dem_to_be_aligned.data  # This is a numpy 2D array/masked_array
+        mask = glacier_outlines.create_mask(reference_dem) == 255  # This is a boolean numpy 2D array
+        transform = reference_dem.transform  # This is a rio.transform.Affine object.
+
+
+
+The ``Coreg`` object
+^^^^^^^^^^^^^^^^^^^^
+:class:`xdem.coreg.Coreg`
+
+Each of the coregistration approaches in ``xdem`` inherit their interface from the ``Coreg`` class.
+It is written in a style that should resemble that of ``scikit-learn`` (see their `LinearRegression <https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html#sklearn-linear-model-linearregression>`_ class for example).
+Each coregistration approach has the methods:
+
+* ``.fit()`` for estimating the transform.
+* ``.apply()`` for applying the transform to a DEM.
+* ``.apply_pts()`` for applying the transform to a set of 3D points.
+* ``.to_matrix()`` to convert the transform to a 4x4 transformation matrix, if possible.
+
+First, ``.fit()`` is called to estimate the transform, and then this transform can be used or exported using the subsequent methods.
 
 Nuth and Kääb (2011)
 ^^^^^^^^^^^^^^^^^^^^
+:class:`xdem.coreg.NuthKaab`
+
 - **Performs:** translation and bias corrections.
 - **Supports weights** (soon)
 - **Recommended for:** Noisy data with low rotational differences.
@@ -63,15 +93,17 @@ Example
 *******
 .. code-block:: python
 
-        aligned_dem, error = xdem.coreg.coregister(
-                reference_dem,
-                dem_to_be_aligned,
-                method="nuth_kaab",
-                mask=glacier_outlines
-        )
+        nuth_kaab = coreg.NuthKaab()
+        # Fit the data to a suitable x/y/z offset.
+        nuth_kaab.fit(ref_data, tba_data, transform=transform, mask=mask)
+
+        # Apply the transformation to the data (or any other data)
+        aligned_dem = nuth_kaab.apply(tba_data, transform=transform)
 
 Deramping
 ^^^^^^^^^
+:class:`xdem.coreg.Deramp`
+
 - **Performs:** Bias, linear or nonlinear height corrections.
 - **Supports weights** (soon)
 - **Recommended for:** Data with no horizontal offset and low to moderate rotational differences.
@@ -91,17 +123,51 @@ Example
 *******
 .. code-block:: python
 
-        # Apply a 1st order deramping correction.
-        deramped_dem, error = xdem.coreg.coregister(
-                reference_dem,
-                dem_to_be_aligned,
-                method="deramp",
-                deramp_degree=1,
-                mask=glacier_outlines
-        )
+        # Instantiate a 1st order deramping object.
+        deramp = coreg.Deramp(degree=1)
+        # Fit the data to a suitable polynomial solution.
+        deramp.fit(ref_data, tba_data, transform=transform, mask=mask)
+
+        # Apply the transformation to the data (or any other data)
+        deramped_dem = deramp.apply(dem_to_be_aligned.data, transform=dem_to_be_aligned.transform)
+
+
+Bias correction
+^^^^^^^^^^^^^^^
+:class:`xdem.coreg.BiasCorr`
+
+- **Performs:** (Weighted) bias correction using the mean, median or anything else
+- **Supports weights** (soon)
+- **Recommended for:** A precursor step to e.g. ICP.
+
+``BiasCorr`` has very similar functionality to ``Deramp(degree=0)`` or the z-component of `Nuth and Kääb (2011)`_.
+This function is more customizable, for example allowing changing of the bias algorithm (from weighted average to e.g. median).
+It should also be faster, since it is a single function call.
+
+Limitations
+***********
+Only performs vertical corrections, so it should be combined with another approach.
+
+Example
+*******
+.. code-block:: python
+
+        bias_corr = coreg.BiasCorr()
+        # Note that the transform argument is not needed, since it is a simple vertical correction.
+        bias_corr.fit(ref_data, tba_data, mask=mask)
+
+        # Apply the bias to a DEM
+        corrected_dem = bias_corr.apply(tba_data)
+
+        # Use median bias instead
+        bias_median = coreg.BiasCorr(bias_func=np.median)
+
+        bias_median.fit(... # etc.
 
 ICP
 ^^^
+:class:`xdem.coreg.ICP`
+
 - **Performs:** Rigid transform correction (translation + rotation).
 - **Does not support weights**
 - **Recommended for:** Data with low noise and a high relative rotation.
@@ -117,8 +183,7 @@ This may improve results on noisy data significantly, but care should still be t
 
 Limitations
 ***********
-ICP is notoriously bad on noisy data.
-TODO: Add references for ICP being bad on noisy data.
+ICP often works poorly on noisy data.
 The outlier removal functionality of the opencv implementation is a step in the right direction, but it still does not compete with other coregistration approaches when the relative rotation is small.
 In cases of high rotation, ICP is the only approach that can account for this properly, but results may need refinement, for example with the `Nuth and Kääb (2011)`_ approach.
 
@@ -128,12 +193,63 @@ Example
 *******
 .. code-block:: python
 
-        # Use the opencv ICP implementation. For PDAL, use "icp_pdal")
-        aligned_dem, error = xdem.coreg.coregister(
-                reference_dem,
-                dem_to_be_aligned,
-                method="icp",
-                mask=glacier_outlines
-        )
+        # Instantiate the object with default parameters
+        icp = coreg.ICP()
+        # Fit the data to a suitable transformation.
+        icp.fit(ref_data, tba_data, transform=transform, mask=mask)
 
+        # Apply the transformation matrix to the data (or any other data)
+        aligned_dem = icp.apply(tba_data, transform=transform)
+
+
+The ``CoregPipeline`` object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+:class:`xdem.coreg.CoregPipeline`
+
+Often, more than one coregistration approach is necessary to obtain the best results.
+For example, ICP works poorly with large initial biases, so a ``CoregPipeline`` can be constructed to perform both sequentially:
+
+.. code-block:: python
+
+        pipeline = coreg.CoregPipeline([coreg.BiasCorr(), coreg.ICP()])
+
+        pipeline.fit(...  # etc.
+
+        # This works identically to the syntax above
+        pipeline2 = coreg.BiasCorr() + coreg.ICP()
+
+The ``CoregPipeline`` object exposes the same interface as the ``Coreg`` object.
+The results of a pipeline can be used in other programs by exporting the combined transformation matrix:
+
+.. code-block:: python
+
+        pipeline.to_matrix()
+
+
+This class is heavily inspired by the `Pipeline <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn-pipeline-pipeline>`_ and `make_pipeline() <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.make_pipeline.html#sklearn.pipeline.make_pipeline>`_ functionalities in ``scikit-learn``.
+
+Suggested pipelines
+*******************
+
+For sub-pixel accuracy, the `Nuth and Kääb (2011)`_ approach should almost always be used.
+The approach does not account for rotations in the dataset, however, so a combination is often necessary.
+For small rotations, a 1st degree deramp could be used:
+
+.. code-block:: python
+
+        coreg.NuthKaab() + coreg.Deramp(degree=1)
+
+For larger rotations, ICP is the only reliable approach (but does not outperform in sub-pixel accuracy):
+
+.. code-block:: python
+
+        coreg.ICP() + coreg.NuthKaab()
+
+
+For large biases, rotations and high amounts of noise:
+
+.. code-block:: python
+
+        coreg.BiasCorr() + coreg.ICP() + coreg.NuthKaab()
+        
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(name='xdem',
       packages=['xdem'],
       install_requires=['numpy', 'scipy', 'rasterio', 'geopandas',
                         'pyproj', 'tqdm', 'geoutils @ https://github.com/GlacioHack/GeoUtils/tarball/master', 'scikit-gstat'],
-      extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': ['pdal'], 'opencv': ['opencv']},
+      extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': [
+          'pdal'], 'opencv': ['opencv'], "pytransform3d": ["pytransform3d"]},
       scripts=[],
       zip_safe=False)
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -18,7 +18,7 @@ import numpy as np
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from xdem import coreg, examples
+    from xdem import coreg, examples, spatial_tools
 
 
 def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovector.Vector]:
@@ -248,7 +248,7 @@ class TestCoregClass:
 
         # Try a 0 degree deramp (basically bias correction)
         deramp0 = coreg.Deramp(degree=0)
-        deramp0.fit(self.ref.data, self.tba.data, ~self.inlier_mask, transform=self.ref.transform)
+        deramp0.fit(**self.fit_params)
 
         # Check that only one coefficient exists (y = x + a => coefficients=["a"])
         assert len(deramp0._meta["coefficients"]) == 1
@@ -266,7 +266,7 @@ class TestCoregClass:
 
         # Do a fast an dirty 3 iteration ICP just to make sure it doesn't error out.
         icp = coreg.ICP(max_iterations=3)
-        icp.fit(self.ref.data, self.tba.data, ~self.inlier_mask, transform=self.ref.transform)
+        icp.fit(**self.fit_params)
 
         aligned_dem = icp.apply(self.tba.data, self.ref.transform)
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -175,3 +175,25 @@ class TestCoregClass:
 
         # Check that the original model's bias has not changed (the _meta dicts are two different objects)
         assert biascorr._meta["bias"] == bias
+
+    def test_icp_opencv(self):
+        warnings.simplefilter("error")
+
+        icp = coreg.ICP(max_iterations=3)
+
+        icp.fit(self.ref.data, self.tba.data, ~self.mask, transform=self.ref.transform)
+
+        aligned_dem = icp.apply(self.tba.data, self.ref.transform)
+
+        assert aligned_dem.shape == self.ref.data.squeeze().shape
+
+    def test_pipeline(self):
+        warnings.simplefilter("error")
+
+        pipeline = coreg.CoregPipeline([coreg.BiasCorr(), coreg.ICP(max_iterations=3)])
+
+        pipeline.fit(self.ref.data, self.tba.data, ~self.mask, transform=self.ref.transform)
+
+        aligned_dem = pipeline.apply(self.tba.data, self.ref.transform)
+
+        assert aligned_dem.shape == self.ref.data.squeeze().shape

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -273,3 +273,22 @@ class TestCoregClass:
         pipeline2.pipeline[1]._meta["bias"] = 1
 
         pipeline2.to_matrix()[2, 3] == 2.0
+
+    def test_coreg_add(self):
+        warnings.simplefilter("error")
+
+        bias1 = coreg.BiasCorr()
+        bias2 = coreg.BiasCorr()
+
+        for bias in (bias1, bias2):
+            bias._meta["bias"] = 4
+
+        bias3 = bias1 + bias2
+
+        assert bias3.to_matrix()[2, 3] == 8
+
+        try:
+            bias1 + 1
+        except ValueError as exception:
+            if "Incompatible add type" not in str(exception):
+                raise exception

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -276,19 +276,31 @@ class TestCoregClass:
 
     def test_coreg_add(self):
         warnings.simplefilter("error")
+        # Test with a bias of 4
+        bias = 4
 
         bias1 = coreg.BiasCorr()
         bias2 = coreg.BiasCorr()
 
+        # Set the bias attribute
         for bias in (bias1, bias2):
-            bias._meta["bias"] = 4
+            bias._meta["bias"] = bias
 
+        # Add the two coregs and check that the resulting bias is 2* bias
         bias3 = bias1 + bias2
+        assert bias3.to_matrix()[2, 3] == bias * 2
 
-        assert bias3.to_matrix()[2, 3] == 8
-
+        # Make sure the correct exception is raised on incorrect additions
         try:
             bias1 + 1
         except ValueError as exception:
             if "Incompatible add type" not in str(exception):
                 raise exception
+
+        # Try to add a Coreg step to an already existing CoregPipeline
+        bias4 = bias3 + bias1
+        assert bias4.to_matrix()[2, 3] == bias * 3
+
+        # Try to add two CoregPipelines
+        bias5 = bias3 + bias3
+        assert bias5.to_matrix()[2, 3] == bias * 4

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -142,7 +142,8 @@ class TestCoregClass:
         reference_dem=ref.data,
         dem_to_be_aligned=tba.data,
         inlier_mask=inlier_mask,
-        transform=ref.transform
+        transform=ref.transform,
+        verbose=False,
     )
     # Create some 3D coordinates with Z coordinates being 0 to try the apply_pts functions.
     points = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [0, 0, 0, 0]], dtype="float64").T
@@ -198,7 +199,8 @@ class TestCoregClass:
         shifted_dem += bias
 
         # Fit the synthesized shifted DEM to the original
-        nuth_kaab.fit(self.ref.data.squeeze(), shifted_dem, transform=self.ref.transform)
+        nuth_kaab.fit(self.ref.data.squeeze(), shifted_dem,
+                      transform=self.ref.transform, verbose=self.fit_params["verbose"])
 
         # Make sure that the estimated offsets are similar to what was synthesized.
         assert abs(nuth_kaab._meta["offset_east_px"] - pixel_shift) < 0.03

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -283,8 +283,8 @@ class TestCoregClass:
         bias2 = coreg.BiasCorr()
 
         # Set the bias attribute
-        for bias in (bias1, bias2):
-            bias._meta["bias"] = bias
+        for bias_corr in (bias1, bias2):
+            bias_corr._meta["bias"] = bias
 
         # Add the two coregs and check that the resulting bias is 2* bias
         bias3 = bias1 + bias2

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -156,6 +156,7 @@ def write_geotiff(filepath: str, values: np.ndarray, crs: Optional[rio.crs.CRS],
     :param crs: The coordinate system of the raster.
     :param bounds: The bounding coordinates of the raster.
     """
+    warnings.warn("This function is not needed anymore.", DeprecationWarning)
     transform = rio.transform.from_bounds(*bounds, width=values.shape[1], height=values.shape[0])
 
     nodata_value = np.finfo(values.dtype).min
@@ -276,6 +277,7 @@ def icp_coregistration_pdal(reference_dem: np.ndarray, dem_to_be_aligned: np.nda
 
     # noqa: DAR101 **_
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     dem_to_be_aligned_unmasked = dem_to_be_aligned.copy()
     # Check that PDAL is installed.
     check_for_pdal()
@@ -439,6 +441,7 @@ def icp_coregistration_opencv(reference_dem: np.ndarray, dem_to_be_aligned: np.n
 
     # noqa: DAR101 **_
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     if not _has_cv2:
         raise AssertionError("opencv (cv2) is not available and needs to be installed.")
     dem_to_be_aligned_unmasked = dem_to_be_aligned.copy()
@@ -636,6 +639,7 @@ def deramping(elevation_difference, x_coordinates: np.ndarray, y_coordinates: np
 
     :returns: A callable function to estimate the ramp.
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     # Extract only the finite values of the elevation difference and corresponding coordinates.
     valid_diffs = elevation_difference[np.isfinite(elevation_difference)]
     valid_x_coords = x_coordinates[np.isfinite(elevation_difference)]
@@ -743,6 +747,7 @@ def deramp_dem(reference_dem: np.ndarray, dem_to_be_aligned: np.ndarray, mask: O
 
     # noqa: DAR101 **_
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     elevation_difference = (reference_dem - dem_to_be_aligned)
 
     # Apply the mask if it exists.
@@ -777,6 +782,7 @@ def calculate_nmad(array: np.ndarray) -> float:
 
     :returns: The NMAD of the array.
     """
+    warnings.warn("This function is deprecated in favour of xdem.spatial_tools.nmad().", DeprecationWarning)
     # TODO: Get a reference for why NMAD is used (and make sure the N stands for normalized)
     nmad = 1.4826 * np.nanmedian(np.abs(array - np.nanmedian(array)))
 
@@ -803,6 +809,7 @@ def amaury_coregister_dem(reference_dem: np.ndarray, dem_to_be_aligned: np.ndarr
 
     # noqa: DAR101 **_
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     # TODO: Add offset_east and offset_north as return variables?
     # Make a new DEM which will be modified inplace
     aligned_dem = dem_to_be_aligned.copy()
@@ -932,6 +939,8 @@ def amaury_coregister_dem(reference_dem: np.ndarray, dem_to_be_aligned: np.ndarr
 class CoregMethod(Enum):
     """A selection of a coregistration method."""
 
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
+
     ICP_PDAL = icp_coregistration_pdal
     ICP_OPENCV = icp_coregistration_opencv
     AMAURY = amaury_coregister_dem
@@ -1024,6 +1033,7 @@ def coregister(reference_raster: Union[str, gu.georaster.Raster], to_be_aligned_
 
     :returns: A coregistered Raster and the NMAD of the (potentially) masked offsets.
     """
+    warnings.warn("This function is deprecated in favour of the new Coreg class.", DeprecationWarning)
     # Load GeoUtils Rasters/Vectors if filepaths are given as arguments.
     if isinstance(reference_raster, str):
         reference_raster = gu.georaster.Raster(reference_raster)

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1554,7 +1554,7 @@ class NuthKaab(Coreg):
     https://doi.org/10.5194/tc-5-271-2011
     """
 
-    def __init__(self, max_iterations: int = 50, error_threshold: float = 0.05):
+    def __init__(self, max_iterations: int = 50, error_threshold: float = 0.05):  # pylint: disable=super-init-not-called
         """
         Instantiate a new Nuth and Kääb (2011) coregistration object.
 

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1102,7 +1102,7 @@ class Coreg:
 
     def fit(self, reference_dem: Union[np.ndarray, np.ma.masked_array],
             dem_to_be_aligned: Union[np.ndarray, np.ma.masked_array],
-            mask: Optional[np.ndarray] = None,
+            inlier_mask: Optional[np.ndarray] = None,
             transform: Optional[rio.transform.Affine] = None,
             weights: Optional[np.ndarray] = None,
             subsample: Union[float, int] = 1.0):
@@ -1111,15 +1111,15 @@ class Coreg:
 
         :param reference_dem: 2D array of elevation values acting reference. 
         :param dem_to_be_aligned: 2D array of elevation values to be aligned.
-        :param mask: Optional. 2D boolean array of areas to include in the analysis.
+        :param inlier_mask: Optional. 2D boolean array of areas to include in the analysis (inliers=True).
         :param transform: Optional. Transform of the reference_dem. Mandatory in some cases.
         :param weights: Optional. Per-pixel weights for the coregistration.
         :param subsample: Subsample the input to increase performance. <1 is parsed as a fraction. >1 is a pixel count.
         """
         # Make sure that the mask has an expected format.
-        if mask is not None:
-            mask = np.asarray(mask)
-            assert mask.dtype == bool, f"Invalid mask dtype: '{mask.dtype}'. Expected 'bool'"
+        if inlier_mask is not None:
+            inlier_mask = np.asarray(inlier_mask)
+            assert inlier_mask.dtype == bool, f"Invalid mask dtype: '{inlier_mask.dtype}'. Expected 'bool'"
 
         if weights is not None:
             raise NotImplementedError("Weights have not yet been implemented")
@@ -1132,7 +1132,7 @@ class Coreg:
                                                   if isinstance(dem_to_be_aligned, np.ma.masked_array) else False)
 
         # The full mask (inliers=True) is the inverse of the above masks and the provided mask.
-        full_mask = (~ref_mask & ~tba_mask & (np.asarray(mask) if mask is not None else True)).squeeze()
+        full_mask = (~ref_mask & ~tba_mask & (np.asarray(inlier_mask) if inlier_mask is not None else True)).squeeze()
 
         # If subsample is not equal to one, subsampling should be performed.
         if subsample != 1.0:

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1363,7 +1363,7 @@ class ICP(Coreg):
                 np.linspace(bounds.left, bounds.right, dem.shape[1]) - bounds.left,
                 np.linspace(bounds.bottom, bounds.top, dem.shape[0])[::-1] - bounds.bottom
             )),
-            method="linear"
+            method="cubic"
         )
         aligned_dem[~valid_mask] = np.nan
 

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1175,6 +1175,12 @@ class Coreg:
         """Convert the transform to a 4x4 transformation matrix."""
         return self._to_matrix_func()
 
+    def __add__(self, other: Coreg) -> CoregPipeline:
+        """Return a pipeline consisting of self and the other coreg function."""
+        if not isinstance(other, Coreg):
+            raise ValueError(f"Incompatible add type: {type(other)}. Expected 'Coreg' subclass")
+        return CoregPipeline([self, other])
+
     def _fit_func(self, ref_dem: np.ndarray, tba_dem: np.ndarray, transform: Optional[rio.transform.Affine],
                   weights: Optional[np.ndarray]):
         raise NotImplementedError("This should have been implemented by subclassing")


### PR DESCRIPTION
The entire coregistration structure has been revisited in this PR, with modularity and simplicity in focus.
All approaches are now sublasses of the `Coreg` class, which is heavily inspired by the structure employed in `scikit-learn`. Chaining coregistration functions is as simple as adding them using the "+" operator, or by explicitly constructing a `CoregPipeline` from a `list[Coreg]`.

Right now, I've added a lot of code, and have marked the old stuff with `DeprecationWarning`s. 
Later (or in this PR), I'll remove all of the old code.

### Data
In the following examples, I will use the same data, defined below:
```python
# Download the necessary data. This may take a few minutes.
xdem.examples.download_longyearbyen_examples(overwrite=False)

### Load the data using xdem and geoutils (could be with rasterio and geopandas instead)
# Load a reference DEM from 2009
reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
# Load a moderately well aligned DEM from 1990
dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(reference_dem)
# Load glacier outlines from 1990. This will act as the unstable ground.
glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])


# Prepare the inputs for coregistration.
ref_data = reference_dem.data  # This is a numpy 2D array/masked_array
tba_data = dem_to_be_aligned.data  + 50 # This is a numpy 2D array/masked_array with an artificial bias
mask = glacier_outlines.create_mask(reference_dem) != 255  # This is a boolean numpy 2D array where inliers=True
transform = reference_dem.transform  # This is a rio.transform.Affine object.
```
# Syntax
All coregistration approaches have the same parent class; `Coreg`, which provides the following methods:
* `.fit()` for estimating the transform.                                                                              
* `.apply()` for applying the transform to a DEM.                                                                     
* `.apply_pts()` for applying the transform to a set of 3D points.                                                    
* `.to_matrix()` to convert the transform to a 4x4 transformation matrix, if possible.

The coregistration classes can be stacked sequentially into a `CoregPipeline` using two types of syntax:
```python
step1 = coreg.BiasCorr()
step2 = coreg.ICP()

pipeline = coreg.CoregPipeline([step1, step2])
same_pipeline = step1 + step2
```
The coregistration methods are no longer dependent on `GeoUtils`, to hopefully appeal to a larger audience.

DEMs are `np.ndarray`s or `np.masked_arrays`, masks are boolean `np.ndarray`s, and transforms are `rio.transform.Affine` objects.

I envision the `DEMCollection` object to be a `GeoUtils`-centred interface to coregistration, for example with a `DEMCollection.coregister()` function or similar.

# Examples

## Standard Nuth and Kääb (2011)
This now has a bias correction built in, in case people would use only this one.

```python
from xdem import coreg

nuth_kaab = coreg.NuthKaab(max_iterations=50, error_threshold=0.05)

# Fit the data to a suitable x/y/z offset.
nuth_kaab.fit(ref_data, tba_data, transform=transform, mask=mask)

# Apply the transformation to the data (or any other data)
aligned_dem = nuth_kaab.apply(tba_data, transform=transform)
```


## ICP with bias correction
I like ICP, but it sometimes works poorly if there is a large bias between the products.
As a solution, I will chain a bias correction and ICP to run sequentially:
```python


pipeline = coreg.BiasCorr() + coreg.ICP()

# This will first estimate the bias, apply it, and subsequently estimate the ICP transform 
pipeline.fit(ref_data, tba_data, mask=mask, transform=transform)

# This sequentially applies the Coreg.apply() functions
aligned_dem_array = pipeline.apply(tba_data, transform=transform)

# This prints the combined matrix of all steps
print(pipeline.to_matrix())
```
outputs:
```
[[ 9.99999990e-01  6.10542619e-05 -1.29476318e-04  3.39646143e+00]
 [-6.10697122e-05  9.99999991e-01 -1.19328652e-04  1.73416704e+00]
 [ 1.29469031e-04  1.19336558e-04  9.99999984e-01 -5.48167431e+01]
 [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  1.00000000e+00]]
```
Note the bias (index 2,3) (-4.8 m when removing the artificial bias) which is close to what I get without the bias addition (-5.5 m). I presume that the difference of 7 dm is because ICP is generally bad with biases, so the `BiasCorr + ICP` approach is better.

## Ultimate "bias + ICP + Nuth and Kääb (2011)" combo
@adehecq  and I had some discussions around his KH-9 DEMs.
Nuth and Kääb (2011) is not enough because there are considerable rotations involved, but ICP stops at local minima and provides only sub-acceptable results.
Plus, ICP needs a bias correction since the KH-9 DEMs were something like 1800 m off in the start!
Here's a pipeline that does all of it:
```python
pipeline = coreg.BiasCorr() + coreg.ICP() + coreg.NuthKaab()

pipeline.fit(ref_data, tba_data, mask=mask, transform=transform)

print(pipeline.to_matrix())
```
prints this for the Longyearbyen examples:
```
[[ 9.99999990e-01  6.10542619e-05 -1.29476318e-04 -2.52099627e+00]
 [-6.10697122e-05  9.99999991e-01 -1.19328652e-04 -9.10047542e+00]
 [ 1.29469031e-04  1.19336558e-04  9.99999984e-01 -5.43112118e+01]
 [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  1.00000000e+00]]
```
There's quite a large difference in the x-component (index 1,3; -9.1 m here vs. 1.73 m above) which fits well with the fact that we saw a considerable east-west offset when only using ICP.
While the above step takes a while, I feel like this would be the go-to combination with poorly aligned datasets.


# Making more Coreg sublasses
I wrote all of this with the intention of it being possible to extend by others.
The user interface is defined by the `Coreg` class, which formats the data, and provides it to hidden methods which are defined by the subclass. Making a new subclass therefore only requires the `__init__()`  method and four others:
```python
class NewCoregApproach(Coreg):
    def __init__(self, param1, param2):
        self.param1 = param1
        self.param2 = param2

        # This is where all the metadata and fitting data are stored. 
        # I couldn't find a way to automatically make the attribute, so it has to be repeated in every subclass..
        self._meta: dict[str, Any] = {}

    def _fit_func(self, ref_dem: np.ndarray, tba_dem: np.ndarray, transform: Optional[rio.transform.Affine], weights: Optional[np.ndarray]):
        ## do the fitting magic here, and save it in self._meta

    def _apply_func(dem: np.ndarray, transform: rio.transform.Affine) -> np.ndarray:
          # do the apply magic here and return the result
          # 'dem' will always be a np.ndarray with NaNs as nodata values

    def _apply_pts_func(self, coords: np.ndarray) -> np.ndarray:
        # do the apply-to-points magic here and return the result
        # 'coords' will always have the shape (N, 3)

    def _to_matrix_func(self) -> np.ndarray:
        # do the to_matrix magic here and return the result
```
For a functional example, please see `BiasCorr` as this is the simplest formulation.

And before anyone asks, `_apply_func` always takes a `np.ndarray`, but the `.apply()` userspace function takes either `np.ndarray`s or `np.masked_arrays` and returns the same type as its input.

# Documentation
I have spent quite some time and effort to make the documentation clear for people. You can see examples and explanations that I have written in my fork:
https://xdem-erikm.readthedocs.io/en/coreg_class/index.html

As of right now (05/04/2021), the page index in readthedocs has gone haywire. I don't know what that's about, but the rest looks as it should. (EDIT: [This seems to be an issue that affects others as well](https://github.com/readthedocs/readthedocs.org/issues/8070))

# On the todo list
* Add a `.error()` method or property to all functions. NMAD? But NMAD doesn't show potential biases.
* Allow for @adehecq 's filters to be joined in a pipeline, e.g `coreg.ICP() + filters.NMAD(3) + coreg.NuthKaab()`
* Improve performance on `CoregPipeline.apply()` by combining matrices instead of calling `.apply()` on every `Coreg` class inside. This would mean only one reprojection is done once. It would only work when `.to_matrix()` is supported of course (e.g. `Deramp(degree=2)` cannot be described as a matrix).
* Maybe move `Deramp` and `BiasCorr` into `xdem/biascorr.py`. I propose that they should still be a `Coreg` subclass, however.
* Add subsampling argument to the `.fit()` method to improve performance at the cost of quality. (added in 
593ef00)
* Test the classes on more difficult data than the "best-case" Longyearbyen examples.
* Add `verbose` and/or `callback` arguments for progress updates.

Hope you like it! It's taken quite some time to get right, but I am pretty happy about the result. Especially with the `CoregPipeline` class!