### PR TITLE
Make hyspometric interpolation methods more gap-friendly

### DIFF
--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -157,7 +157,7 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
                         interpolated_ddem,
                         reference_elevation.data,
                         mask=feature_mask
-                    ).data
+                    )#.data   # This causes an issue at l 172: NotImplementedError: sub-views are not implemented
                 except ValueError as exception:
                     # Skip the feature if too few glacier values exist.
                     if "x and y arrays must have at least 2 entries" in str(exception):

--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -153,11 +153,13 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
                 if np.count_nonzero(feature_mask) == 0:
                     continue
                 try:
-                    interpolated_ddem = xdem.volume.hypsometric_interpolation(
-                        interpolated_ddem,
-                        reference_elevation.data,
-                        mask=feature_mask
-                    )#.data   # This causes an issue at l 172: NotImplementedError: sub-views are not implemented
+                    interpolated_ddem = np.asarray(
+                        xdem.volume.hypsometric_interpolation(
+                            interpolated_ddem,
+                            reference_elevation.data,
+                            mask=feature_mask
+                        )
+                    )
                 except ValueError as exception:
                     # Skip the feature if too few glacier values exist.
                     if "x and y arrays must have at least 2 entries" in str(exception):

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -183,9 +183,9 @@ def linear_interpolation(array: Union[np.ndarray, np.ma.masked_array]) -> np.nda
     :returns: A filled array with no NaNs
     """
     # Create a mask for where nans exist
-    nan_mask = (array.mask | np.isnan(array)) if isinstance(array, np.ma.masked_array) else np.isnan(array)
+    nan_mask = (array.mask | np.isnan(array.data)) if isinstance(array, np.ma.masked_array) else np.isnan(array)
 
-    interpolated_array = rasterio.fill.fillnodata(array.copy(), mask=~nan_mask.astype("uint8"))
+    interpolated_array = rasterio.fill.fillnodata(array.copy(), mask=(~nan_mask).astype("uint8"))
 
     # Fill the nans (values outside of the value boundaries) with the median value
     # This triggers a warning with np.masked_array's because it ignores the mask
@@ -241,8 +241,8 @@ def hypsometric_interpolation(voided_ddem: Union[np.ndarray, np.ma.masked_array]
     )
 
     # Create an idealized dDEM (only considering the dH gradient)
-    idealized_ddem = gradient_model(dem)
-    idealized_ddem[~mask] = 0.0
+    idealized_ddem = np.zeros_like(dem)
+    idealized_ddem[mask] = gradient_model(dem[mask])
 
     # Measure the difference between the original dDEM and the idealized dDEM
     assert ddem.shape == idealized_ddem.shape


### PR DESCRIPTION
These are some fix I had to make to run the local hypsometric interpolation on a ddem with very large gaps, for example with outlines falling completely outside of valid range.
@erikmannerfelt please check if what I've made makes sense and we can discuss how to better account for such cases.