### PR TITLE
Add elevation scale correction `Coreg` approach.

### DIFF
--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1721,7 +1721,7 @@ class ZScaleCorr(Coreg):
     Often useful for nadir image DEM correction, where the focal length is slightly miscalculated.
 
     DISCLAIMER: This function may introduce error when correcting non-photogrammetric biases.
-    See Gardelle et al. (2012) (Figure 2), http://dx.doi.org/10.3189/2012jog11j175.
+    See Gardelle et al. (2012) (Figure 2), http://dx.doi.org/10.3189/2012jog11j175, for curvature-related biases.
     """
 
     def __init__(self, degree=1, bin_count=100):

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1719,6 +1719,9 @@ class ZScaleCorr(Coreg):
     Correct linear or nonlinear elevation scale errors.
 
     Often useful for nadir image DEM correction, where the focal length is slightly miscalculated.
+
+    DISCLAIMER: This function may introduce error when correcting non-photogrammetric biases.
+    See Gardelle et al. (2012) (Figure 2), http://dx.doi.org/10.3189/2012jog11j175.
     """
 
     def __init__(self, degree=1, bin_count=100):

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1712,3 +1712,58 @@ class NuthKaab(Coreg):
         matrix[2, 3] += self._meta["bias"]
 
         return matrix
+
+
+class ZScaleCorr(Coreg):
+    """
+    Correct linear or nonlinear elevation scale errors.
+
+    Often useful for nadir image DEM correction, where the focal length is slightly miscalculated.
+    """
+
+    def __init__(self, degree=1, bin_count=100):
+        """
+        Instantiate a elevation scale correction object.
+
+        :param degree: The polynomial degree to estimate.
+        :param bin_count: The amount of bins to divide the elevation change in.
+        """
+        self.degree = degree
+        self.bin_count = bin_count
+        self._meta: dict[str, Any] = {}
+
+    def _fit_func(self, ref_dem: np.ndarray, tba_dem: np.ndarray, transform: Optional[rio.transform.Affine],
+                  weights: Optional[np.ndarray], verbose: bool = False):
+        """Estimate the scale difference between the two DEMs."""
+        ddem = ref_dem - tba_dem
+
+        medians = xdem.volume.hypsometric_binning(
+            ddem=ddem,
+            ref_dem=tba_dem,
+            bins=self.bin_count,
+            kind="count"
+        )["value"]
+
+        coefficients = np.polyfit(medians.index.mid, medians.values, deg=self.degree)
+        self._meta["coefficients"] = coefficients
+
+    def _apply_func(self, dem: np.ndarray, transform: rio.transform.Affine) -> np.ndarray:
+        """Apply the scaling model to a DEM."""
+        model = np.poly1d(self._meta["coefficients"])
+
+        return dem + model(dem)
+
+    def _apply_pts_func(self, coords: np.ndarray) -> np.ndarray:
+        """Apply the scaling model to a set of points."""
+        model = np.poly1d(self._meta["coefficients"])
+
+        new_coords = coords.copy()
+        new_coords[:, 2] += model(new_coords[:, 2])
+        return new_coords
+
+    def _to_matrix_func(self) -> np.ndarray:
+        """Convert the transform to a matrix, if possible."""
+        if self.degree < 2:
+            raise NotImplementedError
+
+        raise ValueError("Model cannot be described as a rigid transformation matrix.")


### PR DESCRIPTION
Sometimes when working with nadir photogrammetric reconstructions, dDEMs can show elevation-dependent differences due to a miscalculated focal length. Obviously, that is a sign that one should probably redo the photogrammetry! If that is not possible, however, this correction may be used instead.

This function estimates a linear or polynomial model with altitude and corrects for it. Example usage:

```python
dem = xdem.DEM(examples.FILEPATHS["longyearbyen_ref_dem"])

factor = 1.2   # Simulated scale offset
scaled_dem = dem.data * factor

zcorr = xdem.coreg.ZScaleCorr(degree=1)
zcorr.fit(dem.data, scaled_dem)

unscaled_dem = xcorr.apply(dem.data) 

diff = (dem.data - unscaled_dem).filled(np.nan)
assert np.abs(np.nanmedian(diff)) < 0.01
```
This passes, as shown by the tests.

As per #78, maybe this should be moved to `biascorr.py` in the future.