### PR TITLE
Fix typo which made docs fail

### DIFF
--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -102,8 +102,8 @@ The loop is stopped either when the maximum iteration limit is reached, or when 
         ddem_pre = (dem_2009.data - dem_1990.data).filled(np.nan).squeeze()
         ddem_post = (dem_2009.data - dem_coreg).filled(np.nan).squeeze()
 
-        nmad_pre = xdem.spatial_tools.nmad(ddem_pre[inlier_mask])
-        nmad_post = xdem.spatial_tools.nmad(ddem_post[inlier_mask])
+        nmad_pre = xdem.spatial_tools.nmad(ddem_pre[inlier_mask.squeeze()])
+        nmad_post = xdem.spatial_tools.nmad(ddem_post[inlier_mask.squeeze()])
 
         vlim = 20
         plt.figure(figsize=(8, 5))

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -93,7 +93,7 @@ The loop is stopped either when the maximum iteration limit is reached, or when 
         dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
         dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
         outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
-        inlier_mask = outlines_1990.create_mask(dem_2009) != 255
+        inlier_mask = ~outlines_1990.create_mask(dem_2009)
 
         nuth_kaab = xdem.coreg.NuthKaab()
         nuth_kaab.fit(dem_2009.data, dem_1990.data, transform=dem_2009.transform, inlier_mask=inlier_mask)


### PR DESCRIPTION
Docs failed to build in 470ad6a, hehe...

I have successfully built this PR in my fork, so it works now: https://readthedocs.org/projects/xdem-erikm/builds/13507007/

Maybe we should add an action soon to make sure our PRs don't mess up the docs?