### PR TITLE
Use `xdem-data` repo for example data

### DIFF
--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -34,7 +34,7 @@ def download_longyearbyen_examples(overwrite: bool = False):
     # Static commit hash to be bumped every time it needs to be.
     commit = "321f84d5a67666f45a196a31a2697e22bfaf3c59"
     # The URL from which to download the repository
-    url = f"https://github.com/erikmannerfelt/xdem-data/tarball/main#commit={commit}"
+    url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
 
     # Create a temporary directory to extract the tarball in.
     temp_dir = tempfile.TemporaryDirectory()

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -31,8 +31,10 @@ def download_longyearbyen_examples(overwrite: bool = False):
         print("Datasets exist")
         return
 
+    # Static commit hash to be bumped every time it needs to be.
+    commit = "321f84d5a67666f45a196a31a2697e22bfaf3c59"
     # The URL from which to download the repository
-    url = "https://github.com/erikmannerfelt/xdem-data/tarball/main"
+    url = f"https://github.com/erikmannerfelt/xdem-data/tarball/main#commit={commit}"
 
     # Create a temporary directory to extract the tarball in.
     temp_dir = tempfile.TemporaryDirectory()

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -1,9 +1,9 @@
 """Utility functions to download and find example data."""
-import asyncio
 import os
-
-import geopandas as gpd
-import rasterio as rio
+import shutil
+import tarfile
+import tempfile
+import urllib.request
 
 EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "../", "examples/"))
 # Absolute filepaths to the example files.
@@ -18,64 +18,7 @@ FILEPATHS = {
         EXAMPLES_DIRECTORY,
         "Longyearbyen/data/glacier_mask/CryoClim_GAO_SJ_2010.shp"
     )
-
 }
-
-# The URLs for where to find the data.
-URLS = {
-    "longyearbyen_ref_dem": ("zip+https://publicdatasets.data.npolar.no/kartdata/S0_Terrengmodell/"
-                             "Mosaikk/NP_S0_DTM20.zip!NP_S0_DTM20/S0_DTM20.tif"),
-    "longyearbyen_tba_dem": ("zip+https://publicdatasets.data.npolar.no/kartdata/S0_Terrengmodell/"
-                             "Historisk/NP_S0_DTM20_199095_33.zip!NP_S0_DTM20_199095_33/S0_DTM20_199095_33.tif"),
-    "longyearbyen_glacier_outlines": "http://public.data.npolar.no/cryoclim/CryoClim_GAO_SJ_1990.zip",
-    "longyearbyen_glacier_outlines_2010": "https://public.data.npolar.no/cryoclim/CryoClim_GAO_SJ_2001-2010.zip"
-}
-
-
-async def _async_load_svalbard():
-    """Load the datasets asynchronously."""
-    # The bounding coordinates to crop the datasets.
-    bounds = {
-        "west": 502810,
-        "east": 529450,
-        "south": 8654330,
-        "north": 8674030
-    }
-
-    async def crop_dem(input_path, output_path, bounds):
-        """Read the input path and crop it to the given bounds."""
-        dem = rio.open(input_path)
-
-        upper, left = dem.index(bounds["west"], bounds["north"])
-        lower, right = dem.index(bounds["east"], bounds["south"])
-        window = rio.windows.Window.from_slices((upper, lower), (left, right))
-
-        data = dem.read(1, window=window)
-        meta = dem.meta.copy()
-        meta.update({
-            "transform": dem.window_transform(window),
-            "height": window.height,
-            "width": window.width
-        })
-        with rio.open(output_path, "w", **meta) as raster:
-            raster.write(data, 1)
-        print(f"Saved {output_path}")
-
-    async def read_outlines(input_path, output_path):
-        """Read outlines from a path and save them."""
-        outlines = gpd.read_file(input_path)
-        for col in outlines:
-            if outlines[col].dtype == "object":
-                outlines[col] = outlines[col].astype(str)
-        outlines.to_file(output_path)
-        print(f"Saved {output_path}")
-
-    await asyncio.gather(
-        crop_dem(URLS["longyearbyen_ref_dem"], FILEPATHS["longyearbyen_ref_dem"], bounds=bounds),
-        crop_dem(URLS["longyearbyen_tba_dem"], FILEPATHS["longyearbyen_tba_dem"], bounds=bounds),
-        read_outlines(URLS["longyearbyen_glacier_outlines"], FILEPATHS["longyearbyen_glacier_outlines"]),
-        read_outlines(URLS["longyearbyen_glacier_outlines_2010"], FILEPATHS["longyearbyen_glacier_outlines_2010"])
-    )
 
 
 def download_longyearbyen_examples(overwrite: bool = False):
@@ -87,7 +30,32 @@ def download_longyearbyen_examples(overwrite: bool = False):
     if not overwrite and all(map(os.path.isfile, list(FILEPATHS.values()))):
         print("Datasets exist")
         return
-    print("Downloading datasets from Longyearbyen")
-    os.makedirs(os.path.dirname(FILEPATHS["longyearbyen_glacier_outlines"]), exist_ok=True)
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_async_load_svalbard())
+
+    # The URL from which to download the repository
+    url = "https://github.com/erikmannerfelt/xdem-data/tarball/main"
+
+    # Create a temporary directory to extract the tarball in.
+    temp_dir = tempfile.TemporaryDirectory()
+    tar_path = os.path.join(temp_dir.name, "data.tar.gz")
+
+    response = urllib.request.urlopen(url)
+    # If the response was right, download the tarball to the temporary directory
+    if response.getcode() == 200:
+        with open(tar_path, "wb") as outfile:
+            outfile.write(response.read())
+    else:
+        raise ValueError(f"Longyearbyen data fetch gave non-200 response: {response.status_code}")
+
+    # Extract the tarball
+    with tarfile.open(tar_path) as tar:
+        tar.extractall(temp_dir.name)
+
+    # Find the first directory in the temp_dir (should only be one) and construct the Longyearbyen data dir path.
+    dir_name = os.path.join(
+        temp_dir.name,
+        [dirname for dirname in os.listdir(temp_dir.name) if os.path.isdir(os.path.join(temp_dir.name, dirname))][0],
+        "data/Longyearbyen"
+    )
+
+    # Copy the data to the examples directory.
+    shutil.copytree(dir_name, os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen/data"), dirs_exist_ok=True)


### PR DESCRIPTION
As you may have noticed, testing and doc-building takes a very long time because data are quite inefficiently downloaded from the source.

On my computer, this download takes about 3 minutes. When using GitHub Actions, it takes around 13 minutes on their servers! 

I have created a new repo: https://github.com/erikmannerfelt/xdem-data, which could replace the way we fetch data. There, scripts exist for fetching the data from source, but the modified data are in the repo itself. Therefore, `xdem` can get the data by just fetching the latest `xdem-data` tarball and extracting whatever is needed.

Downloading the Longyearbyen data takes 2.23 s on my computer. That's a 81x performance increase!

Above just making docs, CI and general testing easier, this would ensure that testing data are not modified without us knowing about it. Imagine in 3 years if tests suddenly start failing because the Norwegian Polar Institute has decided to change their link structure...

If you think this is not a terrible idea, I can change ownership of the `xdem-data` repo to GlacioHack, further solidifying its future.