### PR TITLE
Improve merge_rasters

### DIFF
--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -31,25 +31,47 @@ def test_merge_rasters():
     x_midpoint -= x_midpoint % dem.res[0]
 
     # Cut the DEM into two DEMs that slightly overlap each other.
-    dem1 = dem.reproject(dst_bounds=rio.coords.BoundingBox(
+    dem1 = dem.copy()
+    dem1.crop(rio.coords.BoundingBox(
         right=x_midpoint + dem.res[0] * 3,
         left=dem.bounds.left,
         top=dem.bounds.top,
-        bottom=dem.bounds.bottom),
-        dst_crs=dem.crs
+        bottom=dem.bounds.bottom)
     )
-    dem2 = dem.reproject(dst_bounds=rio.coords.BoundingBox(
+    dem2 = dem.copy()
+    dem2.crop(rio.coords.BoundingBox(
         left=x_midpoint - dem.res[0] * 3,
         right=dem.bounds.right,
         top=dem.bounds.top,
-        bottom=dem.bounds.bottom),
-        dst_crs=dem.crs
+        bottom=dem.bounds.bottom)
     )
 
     # Merge the DEM and check that it closely resembles the initial DEM
     merged_dem = xdem.spatial_tools.merge_rasters([dem1, dem2])
     assert dem.data.shape == merged_dem.data.shape
+    assert dem.bounds == merged_dem.bounds
 
     diff = dem.data - merged_dem.data
 
     assert np.abs(np.nanmean(diff)) < 0.0001
+
+    # Check that include_ref works
+    merged_dem2 = xdem.spatial_tools.merge_rasters([dem, dem1, dem2], include_ref=False)
+    assert merged_dem2 == merged_dem
+
+    # Check that use_ref_bounds work - use a DEM that do not cover the whole extent
+    dem2 = dem.copy()
+    dem2.crop(rio.coords.BoundingBox(
+        left=x_midpoint - dem.res[0] * 3,
+        right=dem.bounds.right - dem.res[0]*2,
+        top=dem.bounds.top,
+        bottom=dem.bounds.bottom)
+    )
+
+    # This case should not preserve original extent
+    merged_dem = xdem.spatial_tools.merge_rasters([dem1, dem2])
+    assert merged_dem.bounds != dem.bounds
+
+    # This case should preserve original extent
+    merged_dem2 = xdem.spatial_tools.merge_rasters([dem, dem1, dem2], include_ref = False, use_ref_bounds=True)
+    assert merged_dem2.bounds == dem.bounds

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -55,9 +55,16 @@ def test_merge_rasters():
 
     assert np.abs(np.nanmean(diff)) < 0.0001
 
-    # Check that include_ref works
-    merged_dem2 = xdem.spatial_tools.merge_rasters([dem, dem1, dem2], include_ref=False)
+    # Check that reference works
+    merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference=dem)
     assert merged_dem2 == merged_dem
+
+    # Others than int or gu.Raster should raise a ValueError
+    try:
+        merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference="a string")
+    except ValueError as exception:
+        if "reference should be" not in str(exception):
+            raise exception
 
     # Check that use_ref_bounds work - use a DEM that do not cover the whole extent
     dem2 = dem.copy()
@@ -73,5 +80,5 @@ def test_merge_rasters():
     assert merged_dem.bounds != dem.bounds
 
     # This case should preserve original extent
-    merged_dem2 = xdem.spatial_tools.merge_rasters([dem, dem1, dem2], include_ref = False, use_ref_bounds=True)
+    merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference=dem, use_ref_bounds=True)
     assert merged_dem2.bounds == dem.bounds

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -61,22 +61,22 @@ class TestMerging:
     def test_stack_rasters(self):
         """Test stack_rasters"""
         # Merge the two overlapping DEMs and check that output bounds and shape is correct
-        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2])
+        stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2])
 
-        assert stacked_dem.shape[0] == 2
-        assert self.dem.data.shape[1:] == stacked_dem.shape[1:]
+        assert stacked_dem.count == 2
+        assert self.dem.shape == stacked_dem.shape
 
         merged_bounds = xdem.spatial_tools.merge_bounding_boxes([self.dem1.bounds, self.dem2.bounds],
                                                                 resolution=self.dem1.res[0])
-        assert merged_bounds == out_bounds
+        assert merged_bounds == stacked_dem.bounds
 
         # Check that reference works with input Raster
-        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference=self.dem)
-        assert self.dem.bounds == out_bounds
+        stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference=self.dem)
+        assert self.dem.bounds == stacked_dem.bounds
 
         # Others than int or gu.Raster should raise a ValueError
         try:
-            merged_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference="a string")
+            stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference="a string")
         except ValueError as exception:
             if "reference should be" not in str(exception):
                 raise exception
@@ -84,12 +84,12 @@ class TestMerging:
         # Check that use_ref_bounds works - use a DEM that do not cover the whole extent
 
         # This case should not preserve original extent
-        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3])
-        assert out_bounds != self.dem.bounds
+        stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3])
+        assert stacked_dem.bounds != self.dem.bounds
 
         # This case should preserve original extent
-        stacked_dem2, out_bounds2 = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3], reference=self.dem, use_ref_bounds=True)
-        assert out_bounds2 == self.dem.bounds
+        stacked_dem2 = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3], reference=self.dem, use_ref_bounds=True)
+        assert stacked_dem2.bounds == self.dem.bounds
 
     def test_merge_rasters(self):
         """Test merge_rasters"""

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -22,8 +22,11 @@ def test_dem_subtraction():
     assert np.nanmean(np.abs(diff.data)) < 100
 
 
-def test_merge_rasters():
-    """Split a DEM with some overlap, then merge it, and validate that it's still the same."""
+class TestMerging:
+    """
+    Test cases for stacking and merging DEMs
+    Split a DEM with some overlap, then stack/merge it, and validate bounds and shape.
+    """
     dem = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
 
     # Find the easting midpoint of the DEM
@@ -46,39 +49,59 @@ def test_merge_rasters():
         bottom=dem.bounds.bottom)
     )
 
-    # Merge the DEM and check that it closely resembles the initial DEM
-    merged_dem = xdem.spatial_tools.merge_rasters([dem1, dem2])
-    assert dem.data.shape == merged_dem.data.shape
-    assert dem.bounds == merged_dem.bounds
-
-    diff = dem.data - merged_dem.data
-
-    assert np.abs(np.nanmean(diff)) < 0.0001
-
-    # Check that reference works
-    merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference=dem)
-    assert merged_dem2 == merged_dem
-
-    # Others than int or gu.Raster should raise a ValueError
-    try:
-        merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference="a string")
-    except ValueError as exception:
-        if "reference should be" not in str(exception):
-            raise exception
-
-    # Check that use_ref_bounds work - use a DEM that do not cover the whole extent
-    dem2 = dem.copy()
-    dem2.crop(rio.coords.BoundingBox(
+    # To check that use_ref_bounds work - create a DEM that do not cover the whole extent
+    dem3 = dem.copy()
+    dem3.crop(rio.coords.BoundingBox(
         left=x_midpoint - dem.res[0] * 3,
         right=dem.bounds.right - dem.res[0]*2,
         top=dem.bounds.top,
         bottom=dem.bounds.bottom)
     )
 
-    # This case should not preserve original extent
-    merged_dem = xdem.spatial_tools.merge_rasters([dem1, dem2])
-    assert merged_dem.bounds != dem.bounds
+    def test_stack_rasters(self):
+        """Test stack_rasters"""
+        # Merge the two overlapping DEMs and check that output bounds and shape is correct
+        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2])
 
-    # This case should preserve original extent
-    merged_dem2 = xdem.spatial_tools.merge_rasters([dem1, dem2], reference=dem, use_ref_bounds=True)
-    assert merged_dem2.bounds == dem.bounds
+        assert stacked_dem.shape[0] == 2
+        assert self.dem.data.shape[1:] == stacked_dem.shape[1:]
+
+        merged_bounds = xdem.spatial_tools.merge_bounding_boxes([self.dem1.bounds, self.dem2.bounds],
+                                                                resolution=self.dem1.res[0])
+        assert merged_bounds == out_bounds
+
+        # Check that reference works with input Raster
+        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference=self.dem)
+        assert self.dem.bounds == out_bounds
+
+        # Others than int or gu.Raster should raise a ValueError
+        try:
+            merged_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference="a string")
+        except ValueError as exception:
+            if "reference should be" not in str(exception):
+                raise exception
+
+        # Check that use_ref_bounds works - use a DEM that do not cover the whole extent
+
+        # This case should not preserve original extent
+        stacked_dem, out_bounds = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3])
+        assert out_bounds != self.dem.bounds
+
+        # This case should preserve original extent
+        stacked_dem2, out_bounds2 = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3], reference=self.dem, use_ref_bounds=True)
+        assert out_bounds2 == self.dem.bounds
+
+    def test_merge_rasters(self):
+        """Test merge_rasters"""
+        # Merge the two overlapping DEMs and check that it closely resembles the initial DEM
+        merged_dem = xdem.spatial_tools.merge_rasters([self.dem1, self.dem2])
+        assert self.dem.data.shape == merged_dem.data.shape
+        assert self.dem.bounds == merged_dem.bounds
+
+        diff = self.dem.data - merged_dem.data
+
+        assert np.abs(np.nanmean(diff)) < 0.0001
+
+        # Check that reference works
+        merged_dem2 = xdem.spatial_tools.merge_rasters([self.dem1, self.dem2], reference=self.dem)
+        assert merged_dem2 == merged_dem

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -98,12 +98,10 @@ def merge_bounding_boxes(bounds: list[rio.coords.BoundingBox], resolution: float
         for key in "bottom", "left":
             max_bounds[key] = np.nanmin([max_bounds[key], bound.__getattribute__(key)])
 
-    for key in max_bounds:
-        modulo = max_bounds[key] % resolution
-        max_bounds[key] -= modulo
-
-        if key in ["right", "top"] and modulo > 0:
-            max_bounds[key] += resolution
+    # Make sure that extent is a multiple of resolution
+    for key1, key2 in zip(("left", "bottom"), ("right", "top")):
+        modulo = (max_bounds[key2] - max_bounds[key1]) % resolution
+        max_bounds[key2] += modulo
 
     return rio.coords.BoundingBox(**max_bounds)
 

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -162,6 +162,13 @@ def stack_rasters(rasters: list[gu.georaster.Raster], reference: Union[int, gu.R
     """
     Stack a list of rasters into a common grid as a 3D np array with nodata set to Nan.
 
+    If use_ref_bounds is True, output will have the shape (N, height, width) where N is len(rasters) and \
+height and width is equal to reference's shape.
+    If use_ref_bounds is False, output will have the shape (N, height2, width2) where N is len(rasters) and \
+height2 and width2 are set based on reference's resolution and the maximum extent of all rasters.
+
+    Use diff=True to return directly the difference to the reference raster.
+
     Note that currently all rasters will be loaded once in memory. However, if rasters data is not loaded prior to \
     merge_rasters it will be loaded for reprojection and deleted, therefore avoiding duplication and \
     optimizing memory usage.

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -2,13 +2,14 @@
 
 """
 from __future__ import annotations
-
 from typing import Callable, Union
 
-import geoutils as gu
 import numpy as np
 import rasterio as rio
 import rasterio.warp
+from tqdm import tqdm
+
+import geoutils as gu
 
 
 def get_mask(array: Union[np.ndarray, np.ma.masked_array]) -> np.ndarray:
@@ -157,7 +158,7 @@ def merge_bounding_boxes(bounds: list[rio.coords.BoundingBox], resolution: float
 
 def stack_rasters(rasters: list[gu.georaster.Raster], reference: Union[int, gu.Raster] = 0,
                   resampling_method: Union[str, rio.warp.Resampling] = "bilinear", use_ref_bounds: bool = False,
-                  diff: bool = False) -> tuple[gu.georaster.Raster, rio.coords.BoundingBox]:
+                  diff: bool = False, progress: bool = True) -> tuple[gu.georaster.Raster, rio.coords.BoundingBox]:
     """
     Stack a list of rasters into a common grid as a 3D np array with nodata set to Nan.
 
@@ -171,6 +172,7 @@ def stack_rasters(rasters: list[gu.georaster.Raster], reference: Union[int, gu.R
     :param resampling_method: The resampling method for the raster reprojections.
     :param use_ref_bounds: If True, will use reference bounds, otherwise will use maximum bounds of all rasters.
     :param diff: If True, will return the difference to the reference, rather than the DEMs.
+    :param progress: If True, will display a progress bar. Default is True.
 
     :returns: The stacked raster with the same parameters (optionally bounds) as the reference and output bounds.
     """
@@ -195,7 +197,7 @@ def stack_rasters(rasters: list[gu.georaster.Raster], reference: Union[int, gu.R
     # Make a data list and add all of the reprojected rasters into it.
     data: list[np.ndarray] = []
 
-    for raster in rasters:
+    for raster in tqdm(rasters, disable=~progress):
 
         # Check that data is loaded, otherwise temporarily load it
         if not raster.is_loaded:


### PR DESCRIPTION
Add new optional features to `xdem.spatial_tools.merge_rasters`:
- **include_ref**: set to False will not include reference in the merging
- **use_ref_bounds**: set to True will use ref's bounds rather than max bounds

Fix bug:
- merge_bounding_boxes was checking that bounds were a multiple of resolution, whereas only the extent should be a multiple. @erikmannerfelt you might want to check that

Update the tests accordingly.