### PR TITLE
Add hillshade function.

### DIFF
--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -5,6 +5,7 @@ Author(s):
 
 """
 import os
+import shutil
 import subprocess
 import tempfile
 import warnings
@@ -68,7 +69,7 @@ def test_hillshade():
         temp_hillshade_path = os.path.join(temp_dir.name, "hillshade.tif")
         gdal_commands = ["gdaldem", "hillshade",
                          filepath, temp_hillshade_path,
-                         "-az", "30", "-alt", "30"]
+                         "-az", "315", "-alt", "45"]
         subprocess.run(gdal_commands, check=True, stdout=subprocess.PIPE)
 
         data = gu.Raster(temp_hillshade_path).data
@@ -78,13 +79,14 @@ def test_hillshade():
     filepath = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
     dem = xdem.DEM(filepath)
 
-    gdal_hillshade = make_gdal_hillshade(filepath)
     xdem_hillshade = xdem.spatial_tools.hillshade(dem.data, resolution=dem.res)
-    diff = gdal_hillshade - xdem_hillshade
+    if shutil.which("gdaldem") is not None:  # Compare with a GDAL version if GDAL commands are available.
+        gdal_hillshade = make_gdal_hillshade(filepath)
+        diff = gdal_hillshade - xdem_hillshade
 
-    # Check that the xdem and gdal hillshades are relatively similar.
-    assert np.mean(diff) < 5
-    assert xdem.spatial_tools.nmad(diff.filled(np.nan)) < 5
+        # Check that the xdem and gdal hillshades are relatively similar.
+        assert np.mean(diff) < 5
+        assert xdem.spatial_tools.nmad(diff.filled(np.nan)) < 5
 
     # Try giving the hillshade invalid arguments.
     try:

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -12,7 +12,6 @@ import warnings
 import geoutils as gu
 import numpy as np
 import rasterio as rio
-import scipy.optimize
 
 import xdem
 from xdem import examples

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -3,7 +3,7 @@
 """
 from __future__ import annotations
 
-from typing import Callable, Union
+from typing import Callable, Sequence, Union
 
 import geoutils as gu
 import numpy as np
@@ -211,3 +211,72 @@ def merge_rasters(rasters: list[gu.georaster.Raster], reference: int = 0, merge_
     )
 
     return merged_raster
+
+
+def hillshade(dem: Union[np.ndarray, np.ma.masked_array], resolution: Union[float, tuple[float, float]],
+              azimuth: float = 30., altitude: float = 30., z_factor: float = 1.0) -> np.ndarray:
+    """
+    Generate a hillshade from the given DEM.
+
+    :param dem: The input DEM to calculate the hillshade from.
+    :param resolution: One or two values specifying the resolution of the DEM.
+    :param azimuth: The azimuth in degrees (0-360°) going clockwise, starting from north.
+    :param altitude: The altitude in degrees (0-90°). 90° is straight from above.
+    :param z_factor: Vertical exaggeration factor.
+
+    :raises AssertionError: If the given DEM is not a 2D array.
+    :raises ValueError: If invalid argument types or ranges were given.
+
+    :returns: A hillshade with the dtype "float32" with value ranges of 0-255.
+    """
+    # Extract the DEM and mask
+    dem_values, mask = get_array_and_mask(dem.squeeze())
+    # The above is not guaranteed to copy the data, so this needs to be done first.
+    demc = dem_values.copy()
+
+    # Validate the inputs.
+    assert len(demc.shape) == 2, f"Expected a 2D array. Got shape: {dem.shape}"
+    if (azimuth < 0.0) or (azimuth > 360.0):
+        raise ValueError(f"Azimuth must be a value between 0 and 360 degrees (given value: {azimuth})")
+    if (altitude < 0.0) or (altitude > 90):
+        raise ValueError("Altitude must be a value between 0 and 90 degress (given value: {altitude})")
+    if (z_factor < 0.0) or not np.isfinite(z_factor):
+        raise ValueError(f"z_factor must be a non-negative finite value (given value: {z_factor})")
+
+    # Fill the nonfinite values with the median (or maybe just 0?) to not interfere with the gradient analysis.
+    demc[~np.isfinite(demc)] = np.nanmedian(demc)
+
+    # Multiply the DEM with the z_factor to increase the apparent height.
+    demc *= z_factor
+
+    # Parse the resolution argument. If it's subscriptable, it's assumed to be [X, Y] resolution.
+    try:
+        resolution[0]  # type: ignore
+    # If that fails, it's assumed to be the X&Y resolution.
+    except TypeError as exception:
+        if "not subscriptable" not in str(exception):
+            raise exception
+        resolution = (resolution,) * 2  # type: ignore
+
+    # Calculate the gradient of each pixel.
+    x_gradient, y_gradient = np.gradient(demc)
+    # Normalize by the radius of the resolution to make it resolution variant.
+    x_gradient /= resolution[0] * 0.5  # type: ignore
+    y_gradient /= resolution[1] * 0.5  # type: ignore
+
+    azimuth_rad = np.deg2rad(360 - azimuth)
+    altitude_rad = np.deg2rad(altitude)
+
+    # Calculate slope and aspect maps.
+    slope = np.pi / 2.0 - np.arctan(np.sqrt(x_gradient ** 2 + y_gradient ** 2))
+    aspect = np.arctan2(-x_gradient, y_gradient)
+
+    # Create a hillshade from these products.
+    shaded = np.sin(altitude_rad) * np.sin(slope) + np.cos(altitude_rad) * \
+        np.cos(slope) * np.cos((azimuth_rad - np.pi / 2.0) - aspect)
+
+    # Set (potential) masked out values to nan
+    shaded[mask] = np.nan
+
+    # Return the hillshade, scaled to uint8 ranges.
+    return np.clip(255 * (shaded + 0.5) / 2, 0, 255).astype("float32")

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -279,4 +279,5 @@ def hillshade(dem: Union[np.ndarray, np.ma.masked_array], resolution: Union[floa
     shaded[mask] = np.nan
 
     # Return the hillshade, scaled to uint8 ranges.
-    return np.clip(255 * (shaded + 0.5) / 2, 0, 255).astype("float32")
+    # The output is scaled by "(x + 0.6) / 1.84" to make it more similar to GDAL.
+    return np.clip(255 * (shaded + 0.6) / 1.84, 0, 255).astype("float32")

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -3,7 +3,7 @@
 """
 from __future__ import annotations
 
-from typing import Callable, Sequence, Union
+from typing import Callable, Union
 
 import geoutils as gu
 import numpy as np
@@ -214,7 +214,7 @@ def merge_rasters(rasters: list[gu.georaster.Raster], reference: int = 0, merge_
 
 
 def hillshade(dem: Union[np.ndarray, np.ma.masked_array], resolution: Union[float, tuple[float, float]],
-              azimuth: float = 30., altitude: float = 30., z_factor: float = 1.0) -> np.ndarray:
+              azimuth: float = 315.0, altitude: float = 45.0, z_factor: float = 1.0) -> np.ndarray:
     """
     Generate a hillshade from the given DEM.
 


### PR DESCRIPTION
This was harder than I thought!

Initially inspired by [earthpy](https://earthpy.readthedocs.io/en/latest/_modules/earthpy/spatial.html) (since we wanted to avoid more dependencies), I set on to remake their function in the style of xdem. Turns out, however, that their hillshade function is not accurate! 

As noted by @adehecq  in #102, the input DEM of `earthpy.spatial.hillshade()` needed to be divided by an (at the time) arbitrary value to get the right z-scale. Turns out, hillshades need the resolution to generate properly! Makes sense in hindsight, considering that the `np.gradient` just  gets the pixel differences, so the horizontal scale is needed for a proper z-scale.

So here we have it: our very own hillshade function. I've made sure that it works well with nans/ masked_arrays as well. The syntax is pretty straightforward:
```python
import xdem

dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])

hillshade = xdem.spatial_tools.hillshade(
    dem=dem.data,  # This can be an array or masked array. Required.
    resolution=dem.res,  # This is either a float or a sequence of floats. Required.
    azimuth=315,  # This is in degrees going clockwise from north between 0 and 360. Defaults to 315
    altitude=45,  # This is in degrees between 0 and 90. 90 is straight up. Defaults to 45
    z_factor=1  # Vertical exaggeration. Can be any positive finite float. Defaults to 1
)
```
The function returns a `float32` array of shape `(height, width)` with values ranging from 0 to 255.
Thus, it can safely be saved as an `uint8`, but that simplification is up to the user.

In the test, I quantitatively compare with a hillshade generated by GDAL to make sure that they are approximately equal, which they are! I also tested on other DEMs I had lying around, and they were good as well.
