### PR TITLE
Add a filter module and several filters.

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,3 +1,8 @@
+"""
+Functions to test the filters.py submodule.
+"""
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -13,11 +18,6 @@ class TestFilters:
     # Load example data.
     dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
     dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
-    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
-    # Filter to only look at the Scott Turnerbreen glacier
-    outlines.ds = outlines.ds.loc[outlines.ds["NAME"] == "Scott Turnerbreen"]
-    # Create a mask where glacier areas are True
-    mask = outlines.create_mask(dem_2009)
 
     def test_gauss(self):
         """Test applying the various Gaussian filters on DEMs with/without NaNs"""

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,95 @@
+import numpy as np
+import pytest
+
+import geoutils as gu
+import xdem
+
+xdem.examples.download_longyearbyen_examples(overwrite=False)
+
+
+class TestFilters:
+    """Test cases for the filter functions."""
+
+    # Load example data.
+    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
+    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
+    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    # Filter to only look at the Scott Turnerbreen glacier
+    outlines.ds = outlines.ds.loc[outlines.ds["NAME"] == "Scott Turnerbreen"]
+    # Create a mask where glacier areas are True
+    mask = outlines.create_mask(dem_2009)
+
+    def test_gauss(self):
+        """Test applying the various Gaussian filters on DEMs with/without NaNs"""
+
+        # Test applying scipy's Gaussian filter
+        # smoothing should not yield values below.above original DEM
+        dem_array = self.dem_1990.data
+        dem_sm = xdem.filters.gaussian_filter_scipy(dem_array, sigma=5)
+        assert np.min(dem_array) < np.min(dem_sm)
+        assert np.max(dem_array) > np.max(dem_sm)
+        assert dem_array.shape == dem_sm.shape
+
+        # Test applying OpenCV's Gaussian filter
+        dem_sm2 = xdem.filters.gaussian_filter_cv(dem_array, sigma=5)
+        assert np.min(dem_array) < np.min(dem_sm2)
+        assert np.max(dem_array) > np.max(dem_sm2)
+        assert dem_array.shape == dem_sm2.shape
+        
+        # Assert that both implementations yield similar results
+        assert np.nanmax(np.abs(dem_sm - dem_sm2)) < 1e-3
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        cols = np.random.randint(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = np.random.randint(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_sm = xdem.filters.gaussian_filter_scipy(dem_with_nans, sigma=10)
+        assert np.nanmin(dem_with_nans) < np.min(dem_sm)
+        assert np.nanmax(dem_with_nans) > np.max(dem_sm)
+
+        dem_sm = xdem.filters.gaussian_filter_cv(dem_with_nans, sigma=10)
+        assert np.nanmin(dem_with_nans) < np.min(dem_sm)
+        assert np.nanmax(dem_with_nans) > np.max(dem_sm)
+
+        # Test that it works with 3D arrays
+        array_3d = np.vstack((dem_array, dem_array))
+        dem_sm = xdem.filters.gaussian_filter_scipy(array_3d, sigma=5)
+        assert array_3d.shape == dem_sm.shape
+
+        # 3D case not implemented with OpenCV
+        pytest.raises(NotImplementedError, xdem.filters.gaussian_filter_cv, array_3d, sigma=5)
+
+        # Tests that it fails with 1D arrays with appropriate error
+        data = dem_array[0, :, 0]
+        pytest.raises(ValueError, xdem.filters.gaussian_filter_scipy, data, sigma=5)
+        pytest.raises(ValueError, xdem.filters.gaussian_filter_cv, data, sigma=5)
+
+    def test_dist_filter(self):
+        """Test that distance_filter works"""
+
+        # Calculate dDEM
+        ddem = self.dem_2009.data - self.dem_1990.data
+
+        # Add random outliers
+        count = 1000
+        cols = np.random.randint(0, high=self.dem_1990.width - 1, size=count, dtype=int)
+        rows = np.random.randint(0, high=self.dem_1990.height - 1, size=count, dtype=int)
+        ddem.data[0, rows, cols] = 5000
+
+        # Filter gross outliers
+        filtered_ddem = xdem.filters.distance_filter(ddem.data, radius=20, outlier_threshold=50)
+
+        # Check that all outliers were properly filtered
+        assert np.all(np.isnan(filtered_ddem[0, rows, cols]))
+
+        # Assert that non filtered pixels remain the same
+        assert ddem.data.shape == filtered_ddem.shape        
+        assert np.all(ddem.data[np.isfinite(filtered_ddem)] == filtered_ddem[np.isfinite(filtered_ddem)])
+
+        # Check that it works with NaNs too
+        ddem.data[0, rows[:500], cols[:500]] = np.nan
+        filtered_ddem = xdem.filters.distance_filter(ddem.data, radius=20, outlier_threshold=50)
+        assert np.all(np.isnan(filtered_ddem[0, rows, cols]))

--- a/xdem/__init__.py
+++ b/xdem/__init__.py
@@ -1,4 +1,4 @@
-from . import coreg, dem, examples, spatial_tools, spstats, volume
+from . import coreg, dem, examples, spatial_tools, spstats, volume, filters
 from .ddem import dDEM
 from .dem import DEM
 from .demcollection import DEMCollection

--- a/xdem/filters.py
+++ b/xdem/filters.py
@@ -1,0 +1,144 @@
+"""
+A set of 2D filters that can be used to filter outliers or reduce noise in DEMs.
+"""
+from __future__ import annotations
+
+import cv2 as cv
+import numpy as np
+import scipy
+import warnings
+
+
+# Gaussian filters
+
+def gaussian_filter_scipy(array: np.ndarray, sigma: float) -> np.ndarray:
+    """
+    Apply a Gaussian filter to a raster that may contain NaNs, using scipy's implementation.
+    gaussian_filter_cv is recommended as it is usually faster, but this depends on the value of sigma.
+
+    N.B: kernel_size is set automatically based on sigma.
+
+    :param array: the input array to be filtered.
+    :param sigma: the sigma of the Gaussian kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(
+            f"Invalid array shape given: {array.shape}. Expected 2D or 3D array"
+        )
+
+    # In case array does not contain NaNs, use scipy's gaussian filter directly
+    if np.count_nonzero(np.isnan(array)) == 0:
+        return scipy.ndimage.gaussian_filter(array, sigma=sigma)
+
+    # If array contain NaNs, need a more sophisticated approach
+    # Inspired by https://stackoverflow.com/a/36307291
+    else:
+
+        # Run filter on a copy with NaNs set to 0
+        array_no_nan = array.copy()
+        array_no_nan[np.isnan(array)] = 0
+        gauss_no_nan = scipy.ndimage.gaussian_filter(array_no_nan, sigma=sigma)
+        del array_no_nan
+
+        # Mask of NaN values
+        nan_mask = 0 * array.copy() + 1
+        nan_mask[np.isnan(array)] = 0
+        gauss_mask = scipy.ndimage.gaussian_filter(nan_mask, sigma=sigma)
+        del nan_mask
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="invalid value encountered")
+            gauss = gauss_no_nan / gauss_mask
+
+        return gauss
+
+
+def gaussian_filter_cv(array: np.ndarray, sigma) -> np.ndarray:
+    """
+    Apply a Gaussian filter to a raster that may contain NaNs, using OpenCV's implementation.
+    Arguments are for now hard-coded to be identical to scipy.
+
+    N.B: kernel_size is set automatically based on sigma
+
+    :param array: the input array to be filtered.
+    :param sigma: the sigma of the Gaussian kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2, or can be squeezed to 2D
+    orig_shape = array.shape
+    if len(orig_shape) == 2:
+        pass
+    elif len(orig_shape) == 3:
+        if orig_shape[0] == 1:
+            array = array.squeeze()
+        else:
+            raise NotImplementedError("Case of array of dimension 3 not implemented")
+    else:
+        raise ValueError(
+            f"Invalid array shape given: {orig_shape}. Expected 2D or 3D array"
+        )
+
+    # In case array does not contain NaNs, use OpenCV's gaussian filter directly
+    # With kernel size (0, 0), i.e. set to default, and borderType=BORDER_REFLECT, the output is equivalent to scipy
+    if np.count_nonzero(np.isnan(array)) == 0:
+        gauss = cv.GaussianBlur(array, (0, 0), sigmaX=sigma, borderType=cv.BORDER_REFLECT)
+
+    # If array contain NaNs, need a more sophisticated approach
+    # Inspired by https://stackoverflow.com/a/36307291
+    else:
+
+        # Run filter on a copy with NaNs set to 0
+        array_no_nan = array.copy()
+        array_no_nan[np.isnan(array)] = 0
+        gauss_no_nan = cv.GaussianBlur(array_no_nan, (0, 0), sigmaX=sigma, borderType=cv.BORDER_REFLECT)
+        del array_no_nan
+
+        # Mask of NaN values
+        nan_mask = 0 * array.copy() + 1
+        nan_mask[np.isnan(array)] = 0
+        gauss_mask = cv.GaussianBlur(nan_mask, (0, 0), sigmaX=sigma, borderType=cv.BORDER_REFLECT)
+        del nan_mask
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", message="invalid value encountered")
+            gauss = gauss_no_nan / gauss_mask
+
+    return gauss.reshape(orig_shape)
+
+
+# Median filters
+
+# To be added
+
+# Min/max filters
+
+# To be added
+
+
+def distance_filter(array: np.ndarray, radius: float, outlier_threshold: float) -> np.ndarray:
+    """
+    Filter out pixels whose value is distant more than a set threshold from the average value of all neighbor \
+pixels within a given radius.
+    Filtered pixels are set to NaN.
+
+    TO DO: Add an option on how the "average" value should be calculated, i.e. using a Gaussian, median etc filter.
+
+    :param array: the input array to be filtered.
+    :param radius: the radius in which the average value is calculated (for Gaussian filter, this is sigma).
+    :param outlier_threshold: the minimum difference abs(array - mean) for a pixel to be considered an outlier.
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Calculate the average value within the radius
+    smooth = gaussian_filter_cv(array, sigma=radius)
+
+    # Filter outliers
+    outliers = (np.abs(array - smooth)) > outlier_threshold
+    out_array = np.copy(array)
+    out_array[outliers] = np.nan
+
+    return out_array


### PR DESCRIPTION
I've added several filters to the newly created filters module. For now it features:
- several implementations of the Gaussian filters (openCV, scipy)
- all filters are insensitive to NaNs, i.e. the filtered value ignore NaNs
- an outlier filtering based on a threshold distance to the Gaussian filtered raster

There are some differences between opencv's and scipy's Gaussian filters that I don't understand, in particular regarding the kernel size. So for now, the kernel size is left to default, which seem to yield similar results for both implementations. This is not a big deal as most users won't care about the kernel size, only on the sigma value.
For example:
```
V1 = scipy.ndimage.gaussian_filter(V, sigma=10, truncate=4)
V2 = cv.GaussianBlur(V, (40, 40), sigmaX=10, borderType=cv.BORDER_REFLECT)
```
do not yield the same results, while:
```
V2 = cv.GaussianBlur(V, (65, 65), sigmaX=10, borderType=cv.BORDER_REFLECT)
```
does approximately... I don't understand where the value of 65 comes from.

Note that in most cases, opencv's implementation is faster (up to 4x), but it seems to depend on the value of sigma, so I leave both options.

TO DO:
- median filters
- min/max filters