### PR TITLE
Change URLs in accordance with geoutils master->main rename.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,4 +22,4 @@ dependencies:
     - richdem
     - scikit-gstat
     - pytransform3d
-    - https://github.com/GlacioHack/GeoUtils/tarball/master
+    - https://github.com/GlacioHack/GeoUtils/tarball/main

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='xdem',
       install_requires=[
           'numpy', 'scipy', 'rasterio', 'geopandas',
           'pyproj', 'tqdm', 'scikit-gstat', 'scikit-image',
-          "geoutils @ https://github.com/GlacioHack/geoutils/tarball/master"
+          "geoutils @ https://github.com/GlacioHack/geoutils/tarball/main"
       ],
       extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': [
           'pdal'], 'opencv': ['opencv'], "pytransform3d": ["pytransform3d"]},


### PR DESCRIPTION
The default branch name in GeoUtils has been changed from `master` to `main`, so the download URLs have to be changed accordingly.