### PR TITLE
Update dependencies and version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,30 +11,47 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os }}, python ${{ matrix.python-version}}
+    runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        os: ["ubuntu-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
+
+
+    # Run all shells using bash (including Windows)
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
     - uses: actions/checkout@v2
+
+    # Set up the conda-forge environment with mamba
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: conda-incubator/setup-miniconda@v2
       with:
+        auto-update-conda: true
         python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        channels: conda-forge
+        channel-priority: strict
+        environment-file: environment.yml
+        activate-environment: xdem
+
+    # Install the dependencies that are not in the environment file
     - name: Install dependencies
       run: |
-        $CONDA/bin/conda install -c conda-forge mamba -y
-        $CONDA/bin/mamba env update --file environment.yml --name base
-        $CONDA/bin/pip install -r dev-requirements.txt
-        $CONDA/bin/pip install .
+        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest pylint
+        pip install . --no-dependencies
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        $CONDA/bin/flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        $CONDA/bin/flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        $CONDA/bin/pytest -rA
+        pytest -rA

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
 
     # Set up the conda-forge environment with mamba
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} and dependencies
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
@@ -40,8 +40,7 @@ jobs:
         environment-file: dev-environment.yml
         activate-environment: xdem-dev
 
-    # Install the dependencies that are not in the environment file
-    - name: Install dependencies
+    - name: Install project
       run: |
         pip install . --no-dependencies
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,13 +37,12 @@ jobs:
         mamba-version: "*"
         channels: conda-forge
         channel-priority: strict
-        environment-file: environment.yml
-        activate-environment: xdem
+        environment-file: dev-environment.yml
+        activate-environment: xdem-dev
 
     # Install the dependencies that are not in the environment file
     - name: Install dependencies
       run: |
-        mamba install sphinx numpydoc sphinx_rtd_theme sphinx-autodoc-typehints sphinxcontrib-programoutput flake8 pytest pylint
         pip install . --no-dependencies
 
     - name: Lint with flake8

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -7,6 +7,13 @@ on:
   release:
     types: [created]
 
+  workflow_dispatch:
+     inputs:
+        reason:
+          description: 'Reason for manual trigger'     
+          required: true
+          default: 'testing' 
+
 jobs:
   deploy:
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: false
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+python:
+  version: 3.7
+  install:
+    - requirements: dev-requirements.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: doc/source/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: false
 
 # Optionally build your docs in additional formats such as PDF and ePub

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ More documentation to come!
 [![build](https://github.com/GlacioHack/xdem/actions/workflows/python-package.yml/badge.svg)](https://github.com/GlacioHack/xdem/actions/workflows/python-package.yml)
 
 
-## Installation ##
+## Installation
 
+Recommended: Use conda for depencency solving.
 ```
 $ git clone https://github.com/GlacioHack/xdem.git
 $ cd ./xdem
@@ -16,18 +17,18 @@ $ conda env create -f environment.yml
 $ conda activate xdem
 $ pip install .
 ```
-or
-```bash
-pip install git+https://github.com/GlacioHack/xdem.git
-```
-
-To update, please use the `--force-reinstall` flag for `conda` or `pip` to ensure the latest version is installed (`geoutils` and `xdem` do not yet have proper release schedules as of 2021-05-13).
-
 After installing, we recommend to check that everything is working by running the tests:
 
 ```
 $ pytest -rA
 ```
+
+### Installing with pip
+**NOTE**: Setting up GDAL and PROJ may need some extra steps, depending on your operating system and configuration.
+```bash
+pip install xdem
+```
+
 
 ## Structure 
 
@@ -40,6 +41,8 @@ xdem are for now composed of three libraries:
 
 You can find ways to improve the libraries in the [issues](https://github.com/GlacioHack/xdem/issues) section. All contributions are welcome.
 To avoid conflicts, it is suggested to use separate branches for each implementation. All changes must then be submitted to the dev branch using pull requests. Each PR must be reviewed by at least one other person.
+
+Please see our [contribution page](CONTRIBUTING.md) for more detailed instructions.
 
 ### Documentation
 See the documentation at https://xdem.readthedocs.io

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - sphinx
+  - sphinx_rtd_theme
   - numpydoc
   - sphinxcontrib-programoutput
   - flake8

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,0 +1,28 @@
+name: xdem-dev
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.7
+  - proj>=7.2
+  - geopandas
+  - numba
+  - matplotlib
+  - opencv
+  - pyproj
+  - rasterio
+  - scipy
+  - tqdm
+  - scikit-image
+  - proj-data
+  - scikit-gstat
+  - pytransform3d
+  - geoutils
+
+  # Development-specific
+  - pytest
+  - pytest-xdist
+  - sphinx
+  - numpydoc
+  - sphinxcontrib-programoutput
+  - flake8
+  - sphinx-autodoc-typehints

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-#import xdem.version
+import xdem.version
 
 # Allow conf.py to find the xdem module
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
@@ -25,7 +25,7 @@ copyright = '2021, xdem contributors'
 author = 'xdem contributors'
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = xdem.version.version
 
 
 os.environ["PYTHON"] = sys.executable

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,10 +13,10 @@
 import os
 import sys
 
+# Allow conf.py to find the xdem module
+sys.path.insert(0, os.path.abspath("../xdem/'"))
 import xdem.version
 
-# Allow conf.py to find the xdem module
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
 # -- Project information -----------------------------------------------------
 
 project = 'xdem'
@@ -45,6 +45,8 @@ extensions = [
     "sphinx_autodoc_typehints",  # Include type hints in the API documentation.
     "sphinxcontrib.programoutput"
 ]
+
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/environment.yml
+++ b/environment.yml
@@ -2,24 +2,18 @@ name: xdem
 channels:
   - conda-forge
 dependencies:
-  - python>=3
+  - python>=3.7
   - proj>=7.2
   - geopandas
-  - ipython
   - numba
   - matplotlib
-  - pdal
   - opencv
-  - pytest
   - pyproj
   - rasterio
   - scipy
   - tqdm
   - scikit-image
-  - pip
   - proj-data
-  - pip:
-    - richdem
-    - scikit-gstat
-    - pytransform3d
-    - https://github.com/GlacioHack/GeoUtils/tarball/main
+  - scikit-gstat
+  - pytransform3d
+  - geoutils

--- a/setup.py
+++ b/setup.py
@@ -5,31 +5,44 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-FULLVERSION = '0.0.2-2'
+FULLVERSION = "0.0.2-2"
 VERSION = FULLVERSION
 
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as infile:
     LONG_DESCRIPTION = infile.read()
 
-setup(name='xdem',
-      version=FULLVERSION,
-      description='Set of tools to manipulate Digital Elevation Models (DEMs) ',
-      long_description=LONG_DESCRIPTION,
-      long_description_content_type="text/markdown",
-      url='https://github.com/GlacioHack/xdem',
-      author='The GlacioHack Team',
-      author_email="this-is-not-an-email@a.com",  # This is needed for PyPi unfortunately.
-      license='BSD-3',
-      packages=['xdem'],
-      install_requires=[
-          'numpy', 'scipy', 'rasterio', 'geopandas',
-          'pyproj', 'tqdm', 'scikit-gstat', 'scikit-image',
-          "geoutils @ https://github.com/GlacioHack/geoutils/tarball/main"
-      ],
-      extras_require={'rioxarray': ['rioxarray'], 'richdem': ['richdem'], 'pdal': [
-          'pdal'], 'opencv': ['opencv'], "pytransform3d": ["pytransform3d"]},
-      scripts=[],
-      zip_safe=False)
+setup(
+    name="xdem",
+    version=FULLVERSION,
+    description="Set of tools to manipulate Digital Elevation Models (DEMs) ",
+    long_description=LONG_DESCRIPTION,
+    long_description_content_type="text/markdown",
+    url="https://github.com/GlacioHack/xdem",
+    author="The GlacioHack Team",
+    author_email="this-is-not-an-email@a.com",  # This is needed for PyPi unfortunately.
+    license="BSD-3",
+    packages=["xdem"],
+    install_requires=[
+        "numpy",
+        "scipy",
+        "rasterio",
+        "geopandas",
+        "pyproj",
+        "tqdm",
+        "scikit-gstat",
+        "scikit-image",
+        "geoutils @ https://github.com/GlacioHack/geoutils/tarball/main",
+    ],
+    extras_require={
+        "rioxarray": ["rioxarray"],
+        "richdem": ["richdem"],
+        "opencv": ["opencv"],
+        "pytransform3d": ["pytransform3d"],
+    },
+    python_requires=">=3.7",
+    scripts=[],
+    zip_safe=False,
+)
 
 write_version = True
 
@@ -40,10 +53,9 @@ version = '%s'
 short_version = '%s'
 """
     if not filename:
-        filename = os.path.join(os.path.dirname(__file__), 'xdem',
-                             'version.py')
+        filename = os.path.join(os.path.dirname(__file__), "xdem", "version.py")
 
-    a = open(filename, 'w')
+    a = open(filename, "w")
     try:
         a.write(cnt % (FULLVERSION, VERSION))
     finally:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import setup
 from setuptools.command.install import install
 
-FULLVERSION = "0.0.2-2"
+FULLVERSION = "0.0.3"
 VERSION = FULLVERSION
 
 with open(os.path.join(os.path.dirname(__file__), "README.md")) as infile:

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -150,7 +150,7 @@ class TestCoregClass:
 
         # Create random noise and see if the standard deviation is equal (it should)
         dem3 = dem1 + np.random.random(size=dem1.size).reshape(dem1.shape)
-        assert biascorr.error(dem1, dem3, transform=affine, error_type="std") == np.std(dem3)
+        assert abs(biascorr.error(dem1, dem3, transform=affine, error_type="std") - np.std(dem3)) < 1e-6
 
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import warnings
 
+import sphinx.cmd.build
 
 class TestDocs:
     docs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../", "docs/")
@@ -28,36 +29,12 @@ class TestDocs:
 
     def test_build(self):
         """Try building the docs and see if it works."""
-        current_dir = os.getcwd()
-        # Change into the docs directory.
-        os.chdir(self.docs_dir)
-
         # Remove the build directory if it exists.
-        if os.path.isdir("build/"):
-            shutil.rmtree("build/")
+        if os.path.isdir(os.path.join(self.docs_dir, "build/")):
+            shutil.rmtree(os.path.join(self.docs_dir, "build/"))
 
-        # Copy the environment and set the SPHINXBUILD variable to call the module.
-        # This is for it to work properly with GitHub Workflows
-        env = os.environ.copy()
-        env["SPHINXBUILD"] = f"{sys.executable} -m sphinx"
+        sphinx.cmd.build.main([
+            os.path.join(self.docs_dir, "source/"),
+            os.path.join(self.docs_dir, "build/")
+        ])
 
-        # Run the makefile
-        build_commands = ["make", "html"]
-        result = subprocess.run(
-            build_commands,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            env=env
-        )
-
-        # Raise an error if the string "error" is in the stderr.
-        if "error" in str(result.stderr).lower():
-            raise RuntimeError(result.stderr)
-
-        # If "error" is not in the stderr string but it exists, show it as a warning.
-        if len(result.stderr) > 0:
-            warnings.warn(result.stderr)
-
-        os.chdir(current_dir)


### PR DESCRIPTION
* All dependencies are now on conda-forge!
* Removed `richdem` from the `environment.yml` as it is an optional dependency
* Removed `pdal` as it is no longer in use.
* Set minimum python version to 3.7 (because of type annotations)
* Ran `black` on `setup.py` since formatting was all over the place.
* The `build` workflow no longer uses pip to install dependencies.
* Prepared `build` workflow to build on Windows and MacOS (didn't enable it yet).
* Updated `README.md` accordingly.

In 0c3c06f, I also added:
* Documentation versioning now dynamically follows the setup.py version (it was hardcoded before..)
* Added manual dispatch to PyPi publishing workflow (see https://github.com/GlacioHack/GeoUtils/pull/192)
* Bumped version to `v0.0.3` (bugfixes on all fronts)

In aa3485f, I added a `dev-environment.yml`, making #123  obsolete.

In ccb4885 and 82b702b:
* Added missing dev requirement
* Fixed test in `test_coreg.py` that sometimes fails randomly!
* Simplified doc building test, making it easier to read, and easier to work with on Windows.