### PR TITLE
Improve sampling for variogram estimation: circular and ring sampling + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project setting
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -162,39 +162,53 @@ class TestSubSampling:
         """Test that the circular masking works as intended"""
 
         # using default (center should be [2,2], radius 2)
-        circ = xdem.spstats.create_circular_mask(5,5)
-        circ2 = xdem.spstats.create_circular_mask(5,5,center=[2,2],radius=2)
+        circ = xdem.spstats.create_circular_mask((5,5))
+        circ2 = xdem.spstats.create_circular_mask((5,5),center=[2,2],radius=2)
 
+        # check default center and radius are derived properly
         assert np.array_equal(circ,circ2)
 
+        # check mask
+        # masking is not inclusive, i.e. exactly radius=2 won't include the 2nd pixel from the center, but radius>2 will
+        eq_circ = np.zeros((5,5), dtype=bool)
+        eq_circ[1:4,1:4]=True
+        assert np.array_equal(circ,eq_circ)
+
         # check distance is not a multiple of pixels (more accurate subsampling)
-
         # will create a 1-pixel mask around the center
-        circ3 = xdem.spstats.create_circular_mask(5,5,center=[1,1],radius=1)
-        # will create a square mask (<1.5 pixel) around the center
-        circ4 = xdem.spstats.create_circular_mask(5,5,center=[1,1],radius=1.5)
+        circ3 = xdem.spstats.create_circular_mask((5,5),center=[1,1],radius=1)
 
+        eq_circ3 = np.zeros((5,5), dtype=bool)
+        eq_circ3[1,1] = True
+        assert np.array_equal(circ3, eq_circ3)
+
+        # will create a square mask (<1.5 pixel) around the center
+        circ4 = xdem.spstats.create_circular_mask((5,5),center=[1,1],radius=1.5)
+        # should not be the same as radius = 1
         assert not np.array_equal(circ3,circ4)
 
 
     def test_ring_masking(self):
         """Test that the ring masking works as intended"""
 
-        # by default, the mask is only False (ring of size 0)
-        ring1 = xdem.spstats.create_ring_mask(5,5)
+        # by default, the mask is only an outside circle (ring of size 0)
+        ring1 = xdem.spstats.create_ring_mask((5,5))
+        circ1 = xdem.spstats.create_circular_mask((5,5))
 
-        assert np.array_equal(ring1,np.zeros((5,5)))
+        assert np.array_equal(ring1,circ1)
 
         # test rings with different inner radius
-        ring2 = xdem.spstats.create_ring_mask(5,5,in_radius=1,out_radius=2)
-        ring3 = xdem.spstats.create_ring_mask(5,5,in_radius=0,out_radius=2)
-        ring4 = xdem.spstats.create_ring_mask(5,5,in_radius=1.5,out_radius=2)
+        ring2 = xdem.spstats.create_ring_mask((5,5),in_radius=1,out_radius=2)
+        ring3 = xdem.spstats.create_ring_mask((5,5),in_radius=0,out_radius=2)
+        ring4 = xdem.spstats.create_ring_mask((5,5),in_radius=1.5,out_radius=2)
 
         assert np.logical_and(~np.array_equal(ring2,ring3),~np.array_equal(ring3,ring4))
 
-        eq_ring3 = xdem.spstats.create_circular_mask(5,5)
-        eq_ring3[2,2] = 0
-        assert np.array_equal(ring3,eq_ring3)
+        # check default
+        eq_ring2 = np.zeros((5,5), dtype=bool)
+        eq_ring2[1:4,1:4] = True
+        eq_ring2[2,2] = False
+        assert np.array_equal(ring2,eq_ring2)
 
 
 class TestPatchesMethod:

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -94,7 +94,7 @@ def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
     # If no match was found, raise an error.
     else:
         raise ValueError(
-            f"'{resampling_method}' is not a valid rasterio.warp.Resampling method. "
+            f"'{method_str}' is not a valid rasterio.warp.Resampling method. "
             f"Valid methods: {[str(method).replace('Resampling.', '') for method in rio.warp.Resampling]}"
         )
     return resampling_method

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -9,7 +9,7 @@ import os
 import random
 import warnings
 from functools import partial
-from typing import Callable, Union, Optional, Tuple, Any, Sequence
+from typing import Callable, Union, Optional, Any, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -69,7 +69,7 @@ def wrapper_get_empirical_variogram(argdict: dict, **kwargs) -> pd.DataFrame:
     return get_empirical_variogram(dh=argdict['dh'], coords=argdict['coords'], **kwargs)
 
 
-def random_subset(dh: np.ndarray, coords: np.ndarray, nsamp: int) -> Tuple[Union[np.ndarray, Any], Union[np.ndarray, Any]]:
+def random_subset(dh: np.ndarray, coords: np.ndarray, nsamp: int) -> tuple[Union[np.ndarray, Any], Union[np.ndarray, Any]]:
 
     """
     Subsampling of elevation differences with random coordinates
@@ -145,7 +145,7 @@ def create_ring_mask(shape: Union[int, Sequence[int]], center: Optional[list[flo
     return mask_ring
 
 
-def ring_subset(dh: np.ndarray, coords: np.ndarray, inside_radius: float = 0, outside_radius: float = 0) -> Tuple[Union[np.ndarray, Any], Union[np.ndarray, Any]]:
+def ring_subset(dh: np.ndarray, coords: np.ndarray, inside_radius: float = 0, outside_radius: float = 0) -> tuple[Union[np.ndarray, Any], Union[np.ndarray, Any]]:
     """
     Subsampling of elevation differences within a ring/disk (to sample points at similar pairwise distances)
 
@@ -428,7 +428,7 @@ def exact_neff_sphsum_circular(area: float, crange1: float, psill1: float, crang
 
     return (psill1 + psill2)/std_err**2
 
-def neff_circ(area: float, list_vgm: list[Tuple[float,str,float]]) -> float:
+def neff_circ(area: float, list_vgm: list[tuple[float,str,float]]) -> float:
 
     """
     Number of effective samples derived from numerical integration for any sum of variogram models a circular area

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -70,7 +70,6 @@ def wrapper_get_empirical_variogram(argdict: dict, **kwargs) -> pd.DataFrame:
 
 def random_subset(dh: np.ndarray, coords: np.ndarray, nsamp: int) -> Tuple[Union[np.ndarray, Any], Union[np.ndarray, Any]]:
 
-    # TODO: add methods that might be more relevant with the multi-distance sampling?
     """
     Subsampling of elevation differences with random coordinates
 
@@ -295,6 +294,7 @@ def sample_multirange_empirical_variogram(dh: np.ndarray, gsd: float = None, coo
         df = df_mean
 
     return df
+
 
 
 def fit_model_sum_vgm(list_model: list[str], emp_vgm_df: pd.DataFrame) -> tuple[Callable, list[float]]:

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -9,7 +9,7 @@ import os
 import random
 import warnings
 from functools import partial
-from typing import Callable, Union, Iterable, Optional, Sequence
+from typing import Callable, Union, Iterable, Optional, Sequence, Any
 
 import itertools
 import matplotlib.pyplot as plt

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -682,7 +682,7 @@ def double_sum_covar(list_tuple_errs: list[float], corr_ranges: list[float], lis
 
 
 def patches_method(dh : np.ndarray, mask: np.ndarray[bool], gsd : float, area_size : float, perc_min_valid: float = 80.,
-                   patch_shape: str = 'circular',nmax : int = 1000) -> pd.DataFrame:
+                   patch_shape: str = 'circular',nmax : int = 1000, verbose: bool = False) -> pd.DataFrame:
 
     """
     Patches method for empirical estimation of the standard error over an integration area
@@ -699,31 +699,6 @@ def patches_method(dh : np.ndarray, mask: np.ndarray[bool], gsd : float, area_si
 
     :return: tile, mean, median, std and count of each patch
     """
-
-    def create_circular_mask(h, w, center=None, radius=None):
-
-        """
-        Create circular mask on a raster
-
-        :param h: height position
-        :param w: width position
-        :param center: center
-        :param radius: radius
-        :return:
-        """
-
-        if center is None:  # use the middle of the image
-            center = [int(w / 2), int(h / 2)]
-        if radius is None:  # use the smallest distance between the center and image walls
-            radius = min(center[0], center[1], w - center[0], h - center[1])
-
-        Y, X = np.ogrid[:h, :w]
-        dist_from_center = np.sqrt((X - center[0]) ** 2 + (Y - center[1]) ** 2)
-
-        mask = dist_from_center <= radius
-
-        return mask
-
 
     # first, remove non sampled area (but we need to keep the 2D shape of raster for patch sampling)
     dh = dh.squeeze()
@@ -778,7 +753,8 @@ def patches_method(dh : np.ndarray, mask: np.ndarray[bool], gsd : float, area_si
         nb_pixel_valid = len(patch[np.isfinite(patch)])
         if nb_pixel_valid > np.ceil(perc_min_valid / 100. * nb_pixel_total):
             u=u+1
-            print('Found valid cadrant ' + str(u)+ ' (maximum: '+str(nmax)+')')
+            if verbose:
+                print('Found valid cadrant ' + str(u)+ ' (maximum: '+str(nmax)+')')
             mean_patch.append(np.nanmean(patch))
             med_patch.append(np.nanmedian(patch))
             std_patch.append(np.nanstd(patch))


### PR DESCRIPTION
Added ring/circular shape masking to subsample rasters.
This will extremely useful to better estimate empirical variograms from the raster samples. Because we generally have millions of samples in a raster, we can't calculate the millions^{squared} pairwise differences. Sampling 10,000 points is already quite a long calculation (~1min). If we subsample within rings of different radius, we limit the samples to similar pairwise distances, thus improving the empirical estimation with less unused samples.
TODO: write the parent function to subsample with the ring method, iteratively, for different radius sizes.
