### PR TITLE
Add support for nonlinear coregistration

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -50,6 +50,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      # pytest will run asynchronously, so test data need to be downloaded first.
+    - name: Download example data
+      run: |
+        python -c "from xdem.examples import *; download_longyearbyen_examples(overwrite=False)"
     - name: Test with pytest
       run: |
         pytest -rA -n=auto

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniconda-vesrion: "latest"
+        auto-activate-base: true
+        activate-environment: ""
+
     # Set up the conda-forge environment with mamba
     - name: Set up Python ${{ matrix.python-version }} and dependencies
       uses: conda-incubator/setup-miniconda@v2
@@ -52,4 +59,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest -rA
+        pytest -rA -n=auto

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install project
       run: |
-        pip install . --no-dependencies
+        pip install . --no-dependencies --editable
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install project
       run: |
-        pip install . --no-dependencies --editable
+        pip install --no-dependencies --editable .
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,13 +28,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        miniconda-vesrion: "latest"
-        auto-activate-base: true
-        activate-environment: ""
-
     # Set up the conda-forge environment with mamba
     - name: Set up Python ${{ matrix.python-version }} and dependencies
       uses: conda-incubator/setup-miniconda@v2

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -544,3 +544,56 @@ def test_apply_matrix():
     # Check that the NMAD is low
     assert spatial_tools.nmad(diff) < 5
     print(np.nanmedian(diff), spatial_tools.nmad(diff))
+
+
+def test_warp_dem():
+
+    source_coords = np.array(
+            [
+                [1000, 1000, 200],
+                [1200, 1200, 200],
+                [1300, 1300, 200],
+                [1250, 1450, 200]
+            ]
+    )
+
+    dest_coords = source_coords.copy()
+    dest_coords[0, 0] += 1
+    dest_coords[1, 0] += 2
+    dest_coords[2, 0] += 3
+    dest_coords[3, 0] += 2.5
+
+
+    transform = rio.transform.from_origin(1000, 1500, 1, 1)
+
+    shape = (500, 500)
+    corr_size = int(shape[1] / 30)
+    dem = cv2.resize(
+        cv2.GaussianBlur(
+            np.repeat(np.repeat(
+                np.random.randint(0, 255, (shape[0]//corr_size,
+                                           shape[1]//corr_size), dtype='uint8'),
+                corr_size, axis=0), corr_size, axis=1),
+            ksize=(2*corr_size + 1, 2*corr_size + 1),
+            sigmaX=corr_size) / 255,
+        dsize=(shape[1], shape[0])
+    ) * 200
+
+    
+    transformed_dem = coreg.warp_dem(
+            dem=dem,
+            transform=transform,
+            source_coords=source_coords,
+            destination_coords=dest_coords,
+            resampling_order=1
+    )
+
+    return
+
+    import matplotlib.pyplot as plt
+
+    plt.imshow(dem)
+    plt.show()
+
+    assert source_coords.shape == (2, 3)
+

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -418,10 +418,12 @@ class TestCoregClass:
         # Validate that all values are different
         assert np.unique(z_diff).size == z_diff.size
 
-
         # Validate that the PiecewiseCoreg doesn't accept uninstantiated Coreg classes
         with pytest.raises(ValueError, match="instantiated Coreg subclass"):
             coreg.PiecewiseCoreg(coreg=coreg.BiasCorr, subdivision=1)  # type: ignore
+
+
+        transformed_dem = piecewise.apply(self.tba.data, self.tba.transform)
 
 def test_apply_matrix():
     warnings.simplefilter("error")

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -22,7 +22,7 @@ import pytransform3d.transformations
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from xdem import coreg, examples, spatial_tools
+    from xdem import coreg, examples, spatial_tools, misc
 
 
 def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovector.Vector]:
@@ -612,28 +612,6 @@ def test_apply_matrix():
     print(np.nanmedian(diff), spatial_tools.nmad(diff))
 
 
-def generate_random_field(shape: tuple[int, int], corr_size: int) -> np.ndarray:
-    """
-    Generate a semi-random gaussian field (to simulate a DEM or DEM error)
-
-    :param shape: The output shape of the field.
-    :param corr_size: The correlation size of the field.
-
-    :returns: A numpy array of semi-random values from 0 to 1
-    """
-    field = cv2.resize(
-        cv2.GaussianBlur(
-            np.repeat(np.repeat(
-                np.random.randint(0, 255, (shape[0]//corr_size,
-                                           shape[1]//corr_size), dtype='uint8'),
-                corr_size, axis=0), corr_size, axis=1),
-            ksize=(2*corr_size + 1, 2*corr_size + 1),
-            sigmaX=corr_size) / 255,
-        dsize=(shape[1], shape[0])
-    )
-    return field
-
-
 def test_warp_dem():
     """Test that the warp_dem function works expectedly."""
     warnings.simplefilter("error")
@@ -708,7 +686,7 @@ def test_warp_dem():
     # Generate a semi-random DEM
     transform = rio.transform.from_origin(0, 500, 1, 1)
     shape = (500, 550)
-    dem = generate_random_field(shape, 100) * 200 + generate_random_field(shape, 10) * 50
+    dem = misc.generate_random_field(shape, 100) * 200 + misc.generate_random_field(shape, 10) * 50
 
     # Warp the DEM using the source-destination coordinates.
     transformed_dem = coreg.warp_dem(

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -24,9 +24,11 @@ def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovec
     """Load example files to try coregistration methods with."""
     examples.download_longyearbyen_examples(overwrite=False)
 
-    reference_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
-    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_tba_dem"])
-    glacier_mask = gu.geovector.Vector(examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        reference_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
+        to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_tba_dem"])
+        glacier_mask = gu.geovector.Vector(examples.FILEPATHS["longyearbyen_glacier_outlines"])
     return reference_raster, to_be_aligned_raster, glacier_mask
 
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -519,3 +519,28 @@ class TestCoregClass:
         unscaled_dem = zcorr_nonlinear.apply(scaled_dem, None)
         diff = (dem_with_nans - unscaled_dem).filled(np.nan)
         assert np.abs(np.nanmedian(diff)) < 0.05
+
+    def test_piecewise_coreg(self):
+        warnings.simplefilter("error")
+
+        subdivision = 4
+        piecewise = coreg.PiecewiseCoreg(coreg=coreg.BiasCorr(), subdivision=subdivision)
+
+        piecewise.fit(**self.fit_params)
+
+
+        points = piecewise.to_points()
+
+        # Validate that the number of points is equal to the amount of subdivisions.
+        assert points.shape[0] == subdivision
+
+        z_diff = points[:, 2, 1] - points[:, 2, 0]
+
+        # Validate that all values are different
+        assert np.unique(z_diff).size == z_diff.size
+
+
+        # Validate that the PiecewiseCoreg doesn't accept uninstantiated Coreg classes
+        with pytest.raises(ValueError, match="instantiated Coreg subclass"):
+            coreg.PiecewiseCoreg(coreg=coreg.BiasCorr, subdivision=1)  # type: ignore
+

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -457,7 +457,7 @@ class TestCoregClass:
         # Validate that the number of points is equal to the amount of subdivisions.
         assert points.shape[0] == subdivision
 
-        # Validate that the points to not represent only the same location.
+        # Validate that the points do not represent only the same location.
         assert np.sum(np.linalg.norm(points[:, :, 0] - points[:, :, 1], axis=1)) != 0.0
 
         z_diff = points[:, 2, 1] - points[:, 2, 0]
@@ -673,7 +673,7 @@ def test_warp_dem():
         resampling="linear",
     )
 
-    # The warped DEM should have
+    # The warped DEM should have the value 'elev_shift' in the upper left corner.
     assert warped_dem[0, 0] == elev_shift
     # The corner should be zero, so the corner pixel (represents the corner minus resolution / 2) should be close.
     assert warped_dem[-1, -1] < 1.0

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -500,7 +500,7 @@ def test_apply_matrix():
     transformed_dem = coreg.apply_matrix(ref.data.squeeze(), ref.transform, matrix)
     reverted_dem = transformed_dem - bias
 
-    # Check that the revered DEM has the exact same values as the initial one
+    # Check that the reverted DEM has the exact same values as the initial one
     # (resampling is not an exact science, so this will only apply for bias corrections)
     assert np.nanmedian(reverted_dem) == np.nanmedian(np.asarray(ref.data))
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -24,7 +24,10 @@ class TestDocs:
                 # Run everything except plt.show() calls.
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
-                    exec(infile.read().replace("plt.show()", "plt.close()"))
+                    try:
+                        exec(infile.read().replace("plt.show()", "plt.close()"))
+                    except Exception as exception:
+                        raise RuntimeError(f"Failed on {filename}") from exception
 
         filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -35,6 +35,6 @@ class TestDocs:
 
         sphinx.cmd.build.main([
             os.path.join(self.docs_dir, "source/"),
-            os.path.join(self.docs_dir, "build/")
+            os.path.join(self.docs_dir, "build/html")
         ])
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -22,7 +22,9 @@ class TestDocs:
             """Run a python script in one thread."""
             with open(filename) as infile:
                 # Run everything except plt.show() calls.
-                exec(infile.read().replace("plt.show()", ""))
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
+                    exec(infile.read().replace("plt.show()", "plt.close()"))
 
         filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
 
@@ -39,7 +41,7 @@ class TestDocs:
         if os.path.isdir(os.path.join(self.docs_dir, "build/")):
             shutil.rmtree(os.path.join(self.docs_dir, "build/"))
 
-        sphinx.cmd.build.main(
+        return_code = sphinx.cmd.build.main(
             [
                 "-j",
                 str(self.n_threads or "auto"),
@@ -47,3 +49,5 @@ class TestDocs:
                 os.path.join(self.docs_dir, "build/html"),
             ]
         )
+
+        assert return_code == 0

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,4 +1,5 @@
 import os
+import concurrent.futures
 import shutil
 import subprocess
 import sys
@@ -6,8 +7,10 @@ import warnings
 
 import sphinx.cmd.build
 
+
 class TestDocs:
     docs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../", "docs/")
+    n_threads = os.getenv("N_CPUS")
 
     def test_example_code(self):
         """Try running each python script in the docs/source/code\
@@ -15,15 +18,18 @@ class TestDocs:
         current_dir = os.getcwd()
         os.chdir(os.path.join(self.docs_dir, "source"))
 
-        # Copy the environment and unset the DISPLAY variable to hide matplotlib plots.
-        env = os.environ.copy()
-        env["DISPLAY"] = ""
+        def run_code(filename: str) -> None:
+            """Run a python script in one thread."""
+            with open(filename) as infile:
+                # Run everything except plt.show() calls.
+                exec(infile.read().replace("plt.show()", ""))
 
-        for filename in os.listdir("code/"):
-            if not filename.endswith(".py"):
-                continue
-            print(f"Running {os.path.join(os.getcwd(), 'code/', filename)}")
-            subprocess.run([sys.executable, f"code/{filename}"], check=True, env=env)
+        filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=int(self.n_threads) if self.n_threads is not None else None
+        ) as executor:
+            list(executor.map(run_code, filenames))
 
         os.chdir(current_dir)
 
@@ -33,8 +39,11 @@ class TestDocs:
         if os.path.isdir(os.path.join(self.docs_dir, "build/")):
             shutil.rmtree(os.path.join(self.docs_dir, "build/"))
 
-        sphinx.cmd.build.main([
-            os.path.join(self.docs_dir, "source/"),
-            os.path.join(self.docs_dir, "build/html")
-        ])
-
+        sphinx.cmd.build.main(
+            [
+                "-j",
+                str(self.n_threads or "auto"),
+                os.path.join(self.docs_dir, "source/"),
+                os.path.join(self.docs_dir, "build/html"),
+            ]
+        )

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -31,10 +31,14 @@ class TestDocs:
 
         filenames = [os.path.join("code", filename) for filename in os.listdir("code/") if filename.endswith(".py")]
 
+        for filename in filenames:
+            run_code(filename)
+        """
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=int(self.n_threads) if self.n_threads is not None else None
         ) as executor:
             list(executor.map(run_code, filenames))
+        """
 
         os.chdir(current_dir)
 

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import pytest
 import warnings
 
 import geoutils as gu
@@ -176,3 +177,19 @@ def test_hillshade():
 
     # Make sure that this doesn't create weird division warnings.
     xdem.spatial_tools.hillshade(dem.data, dem.res)
+
+
+def test_subdivide_dem():
+
+    test_shape = (6, 4)
+    test_count = 4
+    subdivision_grid = xdem.spatial_tools.subdivide_array(test_shape, test_count)
+
+
+    assert subdivision_grid.shape == test_shape
+    assert np.unique(subdivision_grid).size == test_count
+
+    assert np.unique(xdem.spatial_tools.subdivide_array((10,), 3)).size == 3
+
+    with pytest.raises(ValueError, match=r"Shape.*smaller than.*"):
+        xdem.spatial_tools.subdivide_array((5,), 15)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -1,18 +1,17 @@
-"""Functions to test the spatial tools.
-
-Author(s):
-    Erik S. Holmlund
-
 """
+Functions to test the spatial tools.
+"""
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
 import tempfile
-import pytest
 import warnings
 
 import geoutils as gu
 import numpy as np
+import pytest
 import rasterio as rio
 
 import xdem
@@ -22,8 +21,8 @@ from xdem import examples
 def test_dem_subtraction():
     """Test that the DEM subtraction script gives reasonable numbers."""
     diff = xdem.spatial_tools.subtract_rasters(
-        examples.FILEPATHS["longyearbyen_ref_dem"],
-        examples.FILEPATHS["longyearbyen_tba_dem"])
+        examples.FILEPATHS["longyearbyen_ref_dem"], examples.FILEPATHS["longyearbyen_tba_dem"]
+    )
 
     assert np.nanmean(np.abs(diff.data)) < 100
 
@@ -33,6 +32,7 @@ class TestMerging:
     Test cases for stacking and merging DEMs
     Split a DEM with some overlap, then stack/merge it, and validate bounds and shape.
     """
+
     dem = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
 
     # Find the easting midpoint of the DEM
@@ -41,27 +41,27 @@ class TestMerging:
 
     # Cut the DEM into two DEMs that slightly overlap each other.
     dem1 = dem.copy()
-    dem1.crop(rio.coords.BoundingBox(
-        right=x_midpoint + dem.res[0] * 3,
-        left=dem.bounds.left,
-        top=dem.bounds.top,
-        bottom=dem.bounds.bottom)
+    dem1.crop(
+        rio.coords.BoundingBox(
+            right=x_midpoint + dem.res[0] * 3, left=dem.bounds.left, top=dem.bounds.top, bottom=dem.bounds.bottom
+        )
     )
     dem2 = dem.copy()
-    dem2.crop(rio.coords.BoundingBox(
-        left=x_midpoint - dem.res[0] * 3,
-        right=dem.bounds.right,
-        top=dem.bounds.top,
-        bottom=dem.bounds.bottom)
+    dem2.crop(
+        rio.coords.BoundingBox(
+            left=x_midpoint - dem.res[0] * 3, right=dem.bounds.right, top=dem.bounds.top, bottom=dem.bounds.bottom
+        )
     )
 
     # To check that use_ref_bounds work - create a DEM that do not cover the whole extent
     dem3 = dem.copy()
-    dem3.crop(rio.coords.BoundingBox(
-        left=x_midpoint - dem.res[0] * 3,
-        right=dem.bounds.right - dem.res[0]*2,
-        top=dem.bounds.top,
-        bottom=dem.bounds.bottom)
+    dem3.crop(
+        rio.coords.BoundingBox(
+            left=x_midpoint - dem.res[0] * 3,
+            right=dem.bounds.right - dem.res[0] * 2,
+            top=dem.bounds.top,
+            bottom=dem.bounds.bottom,
+        )
     )
 
     def test_stack_rasters(self):
@@ -72,19 +72,18 @@ class TestMerging:
         assert stacked_dem.count == 2
         assert self.dem.shape == stacked_dem.shape
 
-        merged_bounds = xdem.spatial_tools.merge_bounding_boxes([self.dem1.bounds, self.dem2.bounds],
-                                                                resolution=self.dem1.res[0])
+        merged_bounds = xdem.spatial_tools.merge_bounding_boxes(
+            [self.dem1.bounds, self.dem2.bounds], resolution=self.dem1.res[0]
+        )
         assert merged_bounds == stacked_dem.bounds
 
         # Check that reference works with input Raster
-        stacked_dem = xdem.spatial_tools.stack_rasters(
-            [self.dem1, self.dem2], reference=self.dem)
+        stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference=self.dem)
         assert self.dem.bounds == stacked_dem.bounds
 
         # Others than int or gu.Raster should raise a ValueError
         try:
-            stacked_dem = xdem.spatial_tools.stack_rasters(
-                [self.dem1, self.dem2], reference="a string")
+            stacked_dem = xdem.spatial_tools.stack_rasters([self.dem1, self.dem2], reference="a string")
         except ValueError as exception:
             if "reference should be" not in str(exception):
                 raise exception
@@ -96,8 +95,7 @@ class TestMerging:
         assert stacked_dem.bounds != self.dem.bounds
 
         # This case should preserve original extent
-        stacked_dem2 = xdem.spatial_tools.stack_rasters(
-            [self.dem1, self.dem3], reference=self.dem, use_ref_bounds=True)
+        stacked_dem2 = xdem.spatial_tools.stack_rasters([self.dem1, self.dem3], reference=self.dem, use_ref_bounds=True)
         assert stacked_dem2.bounds == self.dem.bounds
 
     def test_merge_rasters(self):
@@ -112,8 +110,7 @@ class TestMerging:
         assert np.abs(np.nanmean(diff)) < 0.0001
 
         # Check that reference works
-        merged_dem2 = xdem.spatial_tools.merge_rasters(
-            [self.dem1, self.dem2], reference=self.dem)
+        merged_dem2 = xdem.spatial_tools.merge_rasters([self.dem1, self.dem2], reference=self.dem)
         assert merged_dem2 == merged_dem
 
 
@@ -124,17 +121,18 @@ def test_hillshade():
     def make_gdal_hillshade(filepath) -> np.ndarray:
         # rasterio strongly recommends against importing gdal along rio, so this is done here instead.
         from osgeo import gdal
+
         temp_dir = tempfile.TemporaryDirectory()
         temp_hillshade_path = os.path.join(temp_dir.name, "hillshade.tif")
         # gdal_commands = ["gdaldem", "hillshade",
         #                 filepath, temp_hillshade_path,
         #                 "-az", "315", "-alt", "45"]
-        #subprocess.run(gdal_commands, check=True, stdout=subprocess.PIPE)
+        # subprocess.run(gdal_commands, check=True, stdout=subprocess.PIPE)
         gdal.DEMProcessing(
             destName=temp_hillshade_path,
             srcDS=filepath,
             processing="hillshade",
-            options=gdal.DEMProcessingOptions(azimuth=315, altitude=45)
+            options=gdal.DEMProcessingOptions(azimuth=315, altitude=45),
         )
 
         data = gu.Raster(temp_hillshade_path).data
@@ -174,8 +172,7 @@ def test_hillshade():
 
     # Introduce some nans
     dem.data.mask = np.zeros_like(dem.data, dtype=bool)
-    dem.data.mask.ravel()[np.random.choice(
-        dem.data.size, 50000, replace=False)] = True
+    dem.data.mask.ravel()[np.random.choice(dem.data.size, 50000, replace=False)] = True
 
     # Make sure that this doesn't create weird division warnings.
     xdem.spatial_tools.hillshade(dem.data, dem.res)
@@ -197,3 +194,84 @@ def test_subdivide_array():
 
     with pytest.raises(ValueError, match=r"Shape.*smaller than.*"):
         xdem.spatial_tools.subdivide_array((5, 2), 15)
+
+
+@pytest.mark.parametrize("dtype", ["uint8", "uint16", "int32", "float32", "float16"])
+@pytest.mark.parametrize(
+    "mask_and_viewable",
+    [
+        (None, True),  # An ndarray with no mask should support views
+        (False, True),  # A masked array with an empty mask should support views
+        ([True, False, False, False], False),  # A masked array with an occupied mask should not support views.
+        ([False, False, False, False], True),  # A masked array with an empty occupied mask should support views.
+    ],
+)
+@pytest.mark.parametrize(
+    "shape_and_check_passes",
+    [
+        ((1, 2, 2), True),  # A 3D array with a shape[0] == 1 is okay.
+        ((2, 1, 2), False),  # A 3D array with a shape[0] != 1 is not okay.
+        ((2, 2), True),  # A 2D array is okay.
+        ((4,), True),  # A 1D array is okay.
+    ],
+)
+def test_get_array_and_mask(
+    dtype: str,
+    mask_and_viewable: tuple[None | bool | list[bool], bool],
+    shape_and_check_passes: tuple[tuple[int, ...], bool],
+):
+    """Validate that the function returns views when expected, and copies otherwise."""
+    warnings.simplefilter("error")
+
+    masked_values, view_should_be_possible = mask_and_viewable
+    shape, check_should_pass = shape_and_check_passes
+
+    # Create an array of the specified dtype
+    array = np.ones(shape, dtype=dtype)
+    if masked_values is not None:
+        if masked_values is False:
+            array = np.ma.masked_array(array)
+        else:
+            array = np.ma.masked_array(array, mask=np.reshape(masked_values, array.shape))
+
+    # Validate that incorrect shapes raise the correct error.
+    if not check_should_pass:
+        with pytest.raises(ValueError, match="Invalid array shape given"):
+            xdem.spatial_tools.get_array_and_mask(array, check_shape=True)
+
+        # Stop the test here as the failure is now validated.
+        return
+
+    # Get a copy of the array and check its shape (it should always pass at this point)
+    arr, _ = xdem.spatial_tools.get_array_and_mask(array, copy=True, check_shape=True)
+
+    # Validate that the array is a copy
+    assert not np.shares_memory(arr, array)
+
+    # If it was an integer dtype and it had a mask, validate that the array is now "float32"
+    if np.issubdtype(dtype, np.integer) and np.any(masked_values or False):
+        assert arr.dtype == "float32"
+
+    # If there was no mask or the mask was empty, validate that arr and array are equivalent
+    if not np.any(masked_values or False):
+        assert np.sum(np.abs(array - arr)) == 0.0
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+
+        # Try to create a view.
+        arr_view, mask = xdem.spatial_tools.get_array_and_mask(array, copy=False)
+
+        # If it should be possible, validate that there were no warnings.
+        if view_should_be_possible:
+            assert len(caught_warnings) == 0, (caught_warnings[0].message, array)
+        # Otherwise, validate that one warning was raised with the correct text.
+        else:
+            assert len(caught_warnings) == 1
+            assert "Copying is required" in str(caught_warnings[0].message)
+
+    # Validate that the view shares memory if it was possible, or otherwise that it is a copy.
+    if view_should_be_possible:
+        assert np.shares_memory(array, arr_view)
+    else:
+        assert not np.shares_memory(array, arr_view)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -142,7 +142,9 @@ def test_hillshade():
         return data
 
     filepath = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
-    dem = xdem.DEM(filepath, silent=True)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dem = xdem.DEM(filepath)
 
     xdem_hillshade = xdem.spatial_tools.hillshade(dem.data, resolution=dem.res)
     gdal_hillshade = make_gdal_hillshade(filepath)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -142,7 +142,7 @@ def test_hillshade():
         return data
 
     filepath = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
-    dem = xdem.DEM(filepath)
+    dem = xdem.DEM(filepath, silent=True)
 
     xdem_hillshade = xdem.spatial_tools.hillshade(dem.data, resolution=dem.res)
     gdal_hillshade = make_gdal_hillshade(filepath)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -179,17 +179,19 @@ def test_hillshade():
     xdem.spatial_tools.hillshade(dem.data, dem.res)
 
 
-def test_subdivide_dem():
+def test_subdivide_array():
 
     test_shape = (6, 4)
     test_count = 4
     subdivision_grid = xdem.spatial_tools.subdivide_array(test_shape, test_count)
 
-
     assert subdivision_grid.shape == test_shape
     assert np.unique(subdivision_grid).size == test_count
 
-    assert np.unique(xdem.spatial_tools.subdivide_array((10,), 3)).size == 3
+    assert np.unique(xdem.spatial_tools.subdivide_array((3, 3), 3)).size == 3
+
+    with pytest.raises(ValueError, match=r"Expected a 2D shape, got 1D shape.*"):
+        xdem.spatial_tools.subdivide_array((5,), 2)
 
     with pytest.raises(ValueError, match=r"Shape.*smaller than.*"):
-        xdem.spatial_tools.subdivide_array((5,), 15)
+        xdem.spatial_tools.subdivide_array((5, 2), 15)

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1799,37 +1799,6 @@ def warp_dem(
     :raises ValueError: If the inputs are poorly formatted.
     :raises AssertionError: For unexpected outputs.
 
-    :examples:
-        >>> dem = np.ones((5, 5), dtype=float)
-        >>> dem
-        array([[1., 1., 1., 1., 1.],
-               [1., 1., 1., 1., 1.],
-               [1., 1., 1., 1., 1.],
-               [1., 1., 1., 1., 1.],
-               [1., 1., 1., 1., 1.]])
-        >>> transform = rio.transform.from_origin(0, 5, 1, 1)
-        >>> source_coords = np.array([
-        ...     [0, 0, 0],
-        ...     [5, 0, 0],
-        ...     [5, 5, 0],
-        ...     [0, 5, 0]
-        ... ]).astype("float32")
-        >>> destination_coords = source_coords.copy()
-        >>> destination_coords[3, 2] = 4
-        >>> warped_dem = warp_dem(
-        ...     dem=dem,
-        ...     transform=transform,
-        ...     source_coords=source_coords,
-        ...     destination_coords=destination_coords,
-        ...     resampling="nearest"
-        ... )
-        >>> warped_dem
-        array([[5., 5., 5., 1., 1.],
-               [5., 5., 5., 1., 1.],
-               [5., 5., 5., 1., 1.],
-               [1., 1., 1., 1., 1.],
-               [1., 1., 1., 1., 1.]])
-
     :returns: A warped DEM with the same shape as the input.
     """
     if source_coords.shape != destination_coords.shape:

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1483,9 +1483,9 @@ class ZScaleCorr(Coreg):
         else:
             raise ValueError("A 2nd degree or higher ZScaleCorr cannot be described as a 4x4 matrix!")
 
-class PiecewiseCoreg(Coreg):
+class BlockwiseCoreg(Coreg):
     """
-    Piece-wise coreg class for nonlinear estimations.
+    Block-wise coreg class for nonlinear estimations.
 
     A coreg class of choice is run on an arbitrary subdivision of the raster. When later applying the coregistration,\
         the optimal warping is interpolated based on X/Y/Z shifts from the coreg algorithm at the grid points.
@@ -1497,7 +1497,7 @@ class PiecewiseCoreg(Coreg):
 
     def __init__(self, coreg: Coreg | CoregPipeline, subdivision: int, success_threshold: float = 0.8, n_threads: int | None = None):
         """
-        Instantiate a piecewise coreg object.
+        Instantiate a blockwise coreg object.
 
         :param coreg: An instantiated coreg object to fit in the subdivided DEMs.
         :param subdivision: The number of chunks to divide the DEMs in. E.g. 4 means four different transforms.
@@ -1643,7 +1643,7 @@ class PiecewiseCoreg(Coreg):
 
     def to_points(self) -> np.ndarray:
         """
-        Convert the piecewise coregistration matrices to 3D (source -> destination) points.
+        Convert the blockwise coregistration matrices to 3D (source -> destination) points.
 
         The returned shape is (N, 3, 2) where the dimensions represent:
             0. The point index where N is equal to the amount of subdivisions.
@@ -1675,7 +1675,7 @@ class PiecewiseCoreg(Coreg):
 
     def stats(self) -> pd.DataFrame:
         """
-        Return statistics for each chunk in the piecewise coregistration.
+        Return statistics for each chunk in the blockwise coregistration.
 
             * center_{x,y,z}: The center coordinate of the chunk in georeferenced units.
             * {x,y,z}_off: The calculated offset in georeferenced units.

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -1,4 +1,5 @@
 """Small functions for testing, examples, and other miscellaneous uses."""
+from __future__ import annotations
 
 import cv2
 import numpy as np

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -1,0 +1,33 @@
+"""Small functions for testing, examples, and other miscellaneous uses."""
+
+import cv2
+import numpy as np
+
+def generate_random_field(shape: tuple[int, int], corr_size: int) -> np.ndarray:
+    """
+    Generate a semi-random gaussian field (to simulate a DEM or DEM error)
+
+    :param shape: The output shape of the field.
+    :param corr_size: The correlation size of the field.
+
+    :examples:
+        >>> np.random.seed(1)
+        >>> generate_random_field((4, 5), corr_size=2).round(2)
+        array([[0.47, 0.5 , 0.56, 0.63, 0.65],
+               [0.49, 0.51, 0.56, 0.62, 0.64],
+               [0.56, 0.56, 0.57, 0.59, 0.59],
+               [0.57, 0.57, 0.57, 0.58, 0.58]])
+
+    :returns: A numpy array of semi-random values from 0 to 1
+    """
+    field = cv2.resize(
+        cv2.GaussianBlur(
+            np.repeat(np.repeat(
+                np.random.randint(0, 255, (shape[0]//corr_size,
+                                           shape[1]//corr_size), dtype='uint8'),
+                corr_size, axis=0), corr_size, axis=1),
+            ksize=(2*corr_size + 1, 2*corr_size + 1),
+            sigmaX=corr_size) / 255,
+        dsize=(shape[1], shape[0])
+    )
+    return field

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -406,7 +406,7 @@ def subdivide_array(shape: tuple[int, ...], count: int) -> np.ndarray:
     :param count: The amount of subdivisions to make.
 
     :examples:
-        >>> subdivide_dem((4, 4), 3)
+        >>> subdivide_array((4, 4), 3)
         array([[0, 0, 0, 0],
                [0, 0, 1, 1],
                [1, 1, 1, 2],

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -425,3 +425,5 @@ def subdivide_array(shape: tuple[int, ...], count: int) -> np.ndarray:
 
     return indices
 
+
+

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -396,3 +396,32 @@ def hillshade(dem: Union[np.ndarray, np.ma.masked_array], resolution: Union[floa
     # Return the hillshade, scaled to uint8 ranges.
     # The output is scaled by "(x + 0.6) / 1.84" to make it more similar to GDAL.
     return np.clip(255 * (shaded + 0.6) / 1.84, 0, 255).astype("float32")
+
+
+def subdivide_array(shape: tuple[int, ...], count: int) -> np.ndarray:
+    """
+    Generate indices for subdivision of an array.
+
+    :param dem_shape: The shape of a array to be subdivided.
+    :param count: The amount of subdivisions to make.
+
+    :examples:
+        >>> subdivide_dem((4, 4), 3)
+        array([[0, 0, 0, 0],
+               [0, 0, 1, 1],
+               [1, 1, 1, 2],
+               [2, 2, 2, 2]])
+
+    :raises ValueError: If the 'shape' size (`np.prod(shape)`) is smallern than 'count'
+
+    :returns: An array of shape 'shape' with 'count' unique indices.
+    """
+    if count > np.prod(shape):
+        raise ValueError(f"Shape '{shape}' size ({np.prod(shape)}) is smaller than 'count' ({count}).")
+    indices = np.zeros(shape=shape, dtype="int64") - 1
+
+    for i, view in enumerate(np.array_split(indices.ravel(), count)):
+        view[:] = i
+
+    return indices
+


### PR DESCRIPTION
Solves #142.

# The new PiecewiseCoreg object
In many cases, biases are not systematic throughout the DEM, so a nonlinear correction is required. This new class takes an arbitrary Coreg class and makes it nonlinear!

The class takes two required arguments; the `Coreg` object to apply non-lienarly and the amount of `subdivisions` to calculate it within. In short, what it does is:
###  To get the coregistration fit:
1. Subdivide the DEM in N (`=subdivison`) equally sized chunks.
2. For each chunk, run the coregistration separately, and save the results.
### To apply the coregistration:
1. Take all the coregistration results and describe them as  X/Y/Z shifts in the middle of the grid. These shifts are then spatially interpolated to generate three offset fields.
2. Apply the Z shifts as a simple `dem - shift` correction
3. Apply the X/Y shifts using `skimage.transform.warp`

Below is an example of the Nuth & Kääb approach, running it "globally" and in 64 (8x8) chunks. What we can see quite visibly in the "global" correction (middle figure) is that there is some kind of mosaic seam near 525000 m east. This cannot be accounted for in a "global" approach. The 64 chunk version, however, brings the error down considerably! There are still some weridnesses, but the NMAD has gone down from 2.5 m to 1.7 m. In the upper left corner, you see the Z correction that was estimated from the 64 chunks.

![image](https://user-images.githubusercontent.com/33550973/121698606-716d6300-cace-11eb-97d2-97893c5395e9.png)

Another big feature is that the approach is multithreaded, so running coregistration 64 times took just 4 seconds on my computer. I think I've done it in a memory-saving way (some copying is needed, but it's only done for each grid separately, so it's relatively small for each thread; then it gets garbage-collected).

I've attached the code for the figure below.

## Subdivide array
Subdividing a 2D array into chunks was harder than I thought! I looked everywhere and didn't find a good function that did "divide my 2D array into N unique parts that are more or less identical in size" (the "more or less" occurs because the shape can be odd). Therefore, I made my own!

I thought it  might have some other uses, so I'll present it here:
```python
>>> subdivide_array((4, 4), 4)
array([[0, 0, 1, 1],
       [0, 0, 1, 1],
       [2, 2, 3, 3],
       [2, 2, 3, 3]])
```
Here, we tell it "divide the contents of a 4x4 matrix into four unique groups". It will try to divide the groups so that the count is equal, but this only applies when the `count` argument is divisible by the product of the shape, e.g:
```python
>>> subdivide_array((5, 4), 3)
array([[0, 0, 0, 0],
       [0, 0, 0, 0],
       [1, 1, 2, 2],
       [1, 1, 2, 2],
       [1, 1, 2, 2]])
```

## Unreated fixes
Some tests that shouldn't fail started failing for me, so I had to make some fixes.
1.  The `test_apply_matrix` is now a separate test for a few reasons: it ensures the inputs weren't mutated by other functions, it didn't fit the `TestCoregClass` name, and keeping it separate will make it slightly easier to extend going forward.
2. Documentation is now generated in multiple threads. On my laptop, it reduces the time from ~90s to ~30s!
3. The GitHub actions are now testing in multiple threads. Two cores are available, so it goes about twice as fast! Dependency solving is still the slowest part, but it's now down to about 8 minutes from 10 minutes before. Testing only takes about two minutes now.
4. The `Coreg` and `CoregPipeline` classes now have a `copy()` method with associated tests.
5. `Coreg.error()` can now accept a list of error statistics to calculate, as per @adehecq's suggestion in #121

## TODO:
* Test the function on more datasets
* Create some way of using these results as synthetic GCPs in photogrammetric software such as Metashape (this may not fit in xdem, but in a separate toolbox perhaps)
* The new `warp_dem()` function slightly repeats what's in `apply_matrix()`. I think `apply_matrix()` can be improved by using `warp_dem()` under the hood, but that's for a future PR!