### PR TITLE
Fix failing test and add handlers for warnings.

### DIFF
--- a/docs/source/code/coregistration_plot_nuth_kaab.py
+++ b/docs/source/code/coregistration_plot_nuth_kaab.py
@@ -33,7 +33,7 @@ plt.title(f"After coregistration. NMAD={nmad_post:.1f} m")
 img = plt.imshow(ddem_post, cmap="coolwarm_r", vmin=-vlim, vmax=vlim)
 plt.axis("off")
 plt.subplot2grid((1, 15), (0, 14), colspan=1)
-cbar = plt.colorbar(img, fraction=0.4)
+cbar = plt.colorbar(img, fraction=0.4, ax=plt.gca())
 cbar.set_label("Elevation change (m)")
 plt.axis("off")
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -25,7 +25,6 @@ class TestDEM:
         """
         Test that inputs work properly in DEM class init
         """
-
         fn_img = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
 
         # from filename
@@ -42,7 +41,9 @@ class TestDEM:
         assert isinstance(dem3, DEM)
 
         # from SatelliteImage
-        img = si.SatelliteImage(fn_img)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "Parse metadata from file not implemented")
+            img = si.SatelliteImage(fn_img)
         dem4 = DEM(img)
         assert isinstance(dem4, DEM)
 

--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -147,13 +147,15 @@ class dDEM(xdem.dem.DEM):   # pylint: disable=invalid-name
                 if np.count_nonzero(feature_mask) == 0:
                     continue
                 try:
-                    interpolated_ddem = np.asarray(
-                        xdem.volume.hypsometric_interpolation(
-                            interpolated_ddem,
-                            reference_elevation.data,
-                            mask=feature_mask
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings("ignore", "Not enough valid bins")
+                        interpolated_ddem = np.asarray(
+                            xdem.volume.hypsometric_interpolation(
+                                interpolated_ddem,
+                                reference_elevation.data,
+                                mask=feature_mask
+                            )
                         )
-                    )
                 except ValueError as exception:
                     # Skip the feature if too few glacier values exist.
                     if "x and y arrays must have at least 2 entries" in str(exception):

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -6,6 +6,7 @@ import pyproj
 import warnings
 from geoutils.georaster import Raster
 from geoutils.satimg import SatelliteImage
+import geoutils as gu
 from pyproj import Transformer
 import json
 import subprocess
@@ -67,9 +68,11 @@ class DEM(SatelliteImage):
             for key in filename_or_dataset.__dict__:
                 setattr(self, key, filename_or_dataset.__dict__[key])
             return
-        # Else rely on parent Raster class options (including raised errors)
+        # Else rely on parent SatelliteImage class options (including raised errors)
         else:
-            super().__init__(filename_or_dataset, silent=silent, **kwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message="Parse metadata from file not implemented")
+                super().__init__(filename_or_dataset, silent=silent, **kwargs)
 
         if self.nbands > 1:
             raise ValueError('DEM rasters should be composed of one band only')


### PR DESCRIPTION
As mentioned in https://github.com/GlacioHack/GeoUtils/issues/211, a warning was triggered by `SatelliteImage` (and thus `DEM`) upon instantiation. This made some tests fail, as they have a "no warning" policy.

This PR fixes that, together with two warnings that have been bugging me for a while:
1. dDEM.interpolate("local_hypsometric") triggered an interpolation warning (which is supposed to be okay)
2. A matplotlib deprecation warning was triggered for a documentation code snippet, which I've fixed.