### PR TITLE
Add N-dimensional binning function (for biases, non-stationarity quantification etc..)

### DIFF
--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -45,6 +45,29 @@ def load_diff() -> tuple[gu.georaster.Raster, np.ndarray]:
 
     return diff, mask
 
+def load_ref_and_diff() -> tuple[gu.georaster.Raster, gu.georaster.Raster, np.ndarray]:
+    """Load example files to try coregistration methods with."""
+    examples.download_longyearbyen_examples(overwrite=False)
+
+    reference_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
+    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_tba_dem"])
+    glacier_mask = gu.geovector.Vector(examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    inlier_mask = ~glacier_mask.create_mask(reference_raster)
+
+    metadata = {}
+    # aligned_raster, _ = xdem.coreg.coregister(reference_raster, to_be_aligned_raster, method="amaury", mask=glacier_mask,
+    #                                          metadata=metadata)
+    nuth_kaab = xdem.coreg.NuthKaab()
+    nuth_kaab.fit(reference_raster.data, to_be_aligned_raster.data,
+                  inlier_mask=inlier_mask, transform=reference_raster.transform)
+    aligned_raster = nuth_kaab.apply(to_be_aligned_raster.data, transform=reference_raster.transform)
+
+    diff = gu.Raster.from_array((reference_raster.data - aligned_raster),
+                                transform=reference_raster.transform, crs=reference_raster.crs)
+    mask = glacier_mask.create_mask(diff)
+
+    return reference_raster, diff, mask
+
 
 class TestVariogram:
 
@@ -171,3 +194,30 @@ class TestPatchesMethod:
             gsd=diff.res[0],
             area_size=10000
         )
+
+class TestBinning:
+
+    def test_nd_binning(self):
+
+        ref, diff, mask = load_ref_and_diff()
+
+        slp, asp = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
+
+        # 1d binning
+        output = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'])
+
+        # nmad goes up quite a bit with slope, we can expect a 10 m measurement error difference
+        assert output[0][0].nmad_slope.values[-1] - output[0][0].nmad_slope.values[0] > 10
+
+        # try custom stat
+        def percentile_80(a):
+            return np.nanpercentile(a, 80)
+
+        xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
+
+        # 2d binning
+        output_2d = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
+
+        # nd binning
+        output_3d = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten(),asp.flatten()],list_var_names=['slope','elevation','aspect'])
+

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -177,10 +177,10 @@ class TestBinning:
 
         ref, diff, mask = load_ref_and_diff()
 
-        slp, asp = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
+        slope, aspect = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
 
         # 1d binning
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'])
 
         # nmad goes up quite a bit with slope, we can expect a 10 m measurement error difference
         assert df.nmad.values[-1] - df.nmad.values[0] > 10
@@ -189,11 +189,11 @@ class TestBinning:
         def percentile_80(a):
             return np.nanpercentile(a, 80)
 
-        xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
+        xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
 
         # 2d binning
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
 
         # nd binning
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten(),asp.flatten()],list_var_names=['slope','elevation','aspect'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten(),aspect.flatten()],list_var_names=['slope','elevation','aspect'])
 

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -185,8 +185,8 @@ class TestBinning:
         # check length matches
         assert df.shape[0] == 10
         # check bin edges match the minimum and maximum of binning variable
-        assert np.nanmin(slope) == np.min(df.slope)
-        assert np.nanmax(slope) == np.max(df.slope)
+        assert np.nanmin(slope) == np.min(pd.IntervalIndex(df.slope).left)
+        assert np.nanmax(slope) == np.max(pd.IntervalIndex(df.slope).right)
 
         # 1d binning with 20 bins
         df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(), list_var=[slope.flatten()], list_var_names=['slope'],

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -180,7 +180,7 @@ class TestBinning:
         slope, aspect = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
 
         # 1d binning, by default will create 10 bins
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'])
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'])
 
         # check length matches
         assert df.shape[0] == 10
@@ -189,7 +189,7 @@ class TestBinning:
         assert np.nanmax(slope) == np.max(pd.IntervalIndex(df.slope).right)
 
         # 1d binning with 20 bins
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(), list_var=[slope.flatten()], list_var_names=['slope'],
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(), list_var=[slope.flatten()], list_var_names=['slope'],
                                            list_var_bins=[[20]])
         # check length matches
         assert df.shape[0] == 20
@@ -202,16 +202,16 @@ class TestBinning:
             return np.nanpercentile(a, 80)
 
         # check the function runs with custom functions
-        xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
+        xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
 
         # 2d binning
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
 
         # dataframe should contain two 1D binning of length 10 and one 2D binning of length 100
         assert df.shape[0] == (10 + 10 + 100)
 
         # nd binning
-        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten(),aspect.flatten()],list_var_names=['slope','elevation','aspect'])
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten(),aspect.flatten()],list_var_names=['slope','elevation','aspect'])
 
         # dataframe should contain three 1D binning of length 10 and three 2D binning of length 100 and one 2D binning of length 1000
         assert df.shape[0] == (1000 + 3 * 100 + 3 * 10)

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -204,10 +204,10 @@ class TestBinning:
         slp, asp = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
 
         # 1d binning
-        output = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'])
 
         # nmad goes up quite a bit with slope, we can expect a 10 m measurement error difference
-        assert output[0][0].nmad_slope.values[-1] - output[0][0].nmad_slope.values[0] > 10
+        assert df.nmad.values[-1] - df.nmad.values[0] > 10
 
         # try custom stat
         def percentile_80(a):
@@ -216,8 +216,8 @@ class TestBinning:
         xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten()],list_var_names=['slope'], statistics=['count',percentile_80])
 
         # 2d binning
-        output_2d = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
 
         # nd binning
-        output_3d = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten(),asp.flatten()],list_var_names=['slope','elevation','aspect'])
+        df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(),list_var=[slp.flatten(),ref.data.flatten(),asp.flatten()],list_var_names=['slope','elevation','aspect'])
 

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -185,8 +185,8 @@ class TestBinning:
         # check length matches
         assert df.shape[0] == 10
         # check bin edges match the minimum and maximum of binning variable
-        assert np.nanmin(slope) == np.min(df.bin_low_var1)
-        assert np.nanmax(slope) == np.max(df.bin_upp_var1)
+        assert np.nanmin(slope) == np.min(df.slope)
+        assert np.nanmax(slope) == np.max(df.slope)
 
         # 1d binning with 20 bins
         df = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(), list_var=[slope.flatten()], list_var_names=['slope'],

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -9,7 +9,7 @@ import os
 import random
 import warnings
 from functools import partial
-from typing import Callable, Union, Iterable, List, Optional, Sequence
+from typing import Callable, Union, Iterable, Optional, Sequence
 
 import itertools
 import matplotlib.pyplot as plt
@@ -26,8 +26,8 @@ with warnings.catch_warnings():
     import skgstat as skg
     from skgstat import models
 
-def nd_binning(values: np.ndarray, list_var: List[np.ndarray], list_var_names=List[str], list_var_bins: Optional[Union[int,List[Iterable]]] = None,
-                     statistics: list[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[List[Sequence]] = None) \
+def nd_binning(values: np.ndarray, list_var: list[np.ndarray], list_var_names=list[str], list_var_bins: Optional[Union[int,list[Iterable]]] = None,
+                     statistics: list[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[list[Sequence]] = None) \
         -> tuple[list[pd.DataFrame],list[pd.DataFrame],pd.DataFrame]:
     """
     N-dimensional binning of values according to one or several explanatory variables.

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -62,7 +62,7 @@ def nd_binning_scipy(dh: np.ndarray, list_var: List[np.ndarray], list_var_names=
         df_stats_1d['bin_low_var1'] = bedges_1d[:-1]
         df_stats_1d['bin_upp_var1'] = bedges_1d[1:]
         df_stats_1d['name_var1'] = list_var_names[i]
-        df_stats_1d['ndim'] = 1
+        df_stats_1d['nd'] = 1
 
         list_df_1d.append(df_stats_1d)
 
@@ -91,7 +91,7 @@ def nd_binning_scipy(dh: np.ndarray, list_var: List[np.ndarray], list_var_names=
             df_stats_2d['bin_low_var2'] = [b2 for b1 in bin_mid_var1 for b2 in bedges_var2[:-1]]
             df_stats_2d['bin_upp_var2'] = [b2 for b1 in bin_mid_var1 for b2 in bedges_var2[1:]]
             df_stats_2d['name_var2'] = var2_name
-            df_stats_2d['ndim'] = 2
+            df_stats_2d['nd'] = 2
 
             list_df_2d.append(df_stats_2d)
 
@@ -114,11 +114,11 @@ def nd_binning_scipy(dh: np.ndarray, list_var: List[np.ndarray], list_var_names=
         nd_bin_upp = np.meshgrid(*list_bin_upp)
 
         for i, var_name in enumerate(list_var_names):
-            df_stats_nd['bin_mid_var'+str(list_var_names.index(var_name))] = nd_bin_mid[i].flatten()
-            df_stats_nd['bin_low_var'+str(list_var_names.index(var_name))] = nd_bin_low[i].flatten()
-            df_stats_nd['bin_upp_var'+str(list_var_names.index(var_name))] = nd_bin_upp[i].flatten()
-            df_stats_nd['name_var'+str(list_var_names.index(var_name))] = var_name
-            df_stats_nd['ndim'] = len(list_var_names)
+            df_stats_nd['bin_mid_var'+str(list_var_names.index(var_name)+1)] = nd_bin_mid[i].flatten()
+            df_stats_nd['bin_low_var'+str(list_var_names.index(var_name)+1)] = nd_bin_low[i].flatten()
+            df_stats_nd['bin_upp_var'+str(list_var_names.index(var_name)+1)] = nd_bin_upp[i].flatten()
+            df_stats_nd['name_var'+str(list_var_names.index(var_name)+1)] = var_name
+            df_stats_nd['nd'] = len(list_var_names)
 
     # concatenate everything
     list_all_dfs = list_df_1d + list_df_2d + [df_stats_nd]

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -26,9 +26,9 @@ with warnings.catch_warnings():
     import skgstat as skg
     from skgstat import models
 
-def nd_binning(values: np.ndarray, list_var: list[np.ndarray], list_var_names=list[str], list_var_bins: Optional[Union[int,list[Iterable]]] = None,
-                     statistics: list[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[list[Sequence]] = None) \
-        -> tuple[list[pd.DataFrame],list[pd.DataFrame],pd.DataFrame]:
+def nd_binning(values: np.ndarray, list_var: Iterable[np.ndarray], list_var_names=Iterable[str], list_var_bins: Optional[Union[int,Iterable[Iterable]]] = None,
+                     statistics: Iterable[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[Iterable[Sequence]] = None) \
+        -> pd.DataFrame:
     """
     N-dimensional binning of values according to one or several explanatory variables.
     Values input is a (N,) array and variable input is a list of flattened arrays of similar dimensions (N,).

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -49,6 +49,11 @@ def nd_binning(values: np.ndarray, list_var: list[np.ndarray], list_var_names=li
         list_var_bins = (10,) * len(list_var_names)
     elif isinstance(list_var_bins,int):
         list_var_bins = (list_var_bins,) * len(list_var_names)
+
+    # flatten the arrays if this has not been done by the user
+    values = values.ravel()
+    list_var = [var.ravel() for var in list_var]
+
     statistics_name = [f if isinstance(f,str) else f.__name__ for f in statistics]
 
     # get binned statistics in 1d: a simple loop is sufficient


### PR DESCRIPTION
## Binning simultaneously in several (N) dimensions based on scipy
Scipy base function on which I rely: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.binned_statistic_dd.html#scipy.stats.binned_statistic_dd
After some searching, the pure pandas solutions seemed a bit hard to extend in N-dimensions: https://stackoverflow.com/questions/60340107/pandas-dataframe-bin-on-multiple-columns-get-statistics-on-another-column
Suggestions of other implementations are welcome. Originally, my own functions were quite simply based on multiple `for` loops, so lots of room for improvement here  :exploding_head: (those can actually run quite fast, especially when using numba).

## Base usage (see full example in test)
```python
from xdem.spatial_tools import nmad
list_df_1d, list_df_2d, list_df_nd = xdem.spstats.nd_binning_scipy(dh=diff.data.flatten(), 
list_var=[slp.flatten(),ref.data.flatten(),asp.flatten()],list_var_names=['slope','elevation','aspect'], statistics=['count',np.nanmedian,nmad])
```
Binning in several dimension simultaneously lowers the amount of samples that can be used for estimation, so it's also very valuable to have the statistics for each 1D and 2D combinations.
Here by default the binning values are subdivided in 10 bins between their min and max. So subdivided into 10 subsamples in 1D, 100 in 2D and 1000 in 3D.
`list_df_1d` contains all possible binnings in 1D, for example with slope:
```
list_df_1d[0]
Out[15]: 
   count_slope  nanmedian_slope  nmad_slope  binmid_slope
0     487886.0        -0.092560    2.540733      1.784413
1     301319.0        -0.404083    2.913965      5.353238
2     265642.0         0.124084    3.007007      8.922064
3     206016.0         0.677917    3.451950     12.490889
4      46273.0         0.749176    4.222139     16.059715
5       3977.0         0.047241    5.870970     19.628540
6        695.0         0.736572    7.450644     23.197366
7        171.0        -0.417175   13.560306     26.766191
8         36.0         0.144989   14.016108     30.335017
9          5.0       -20.540710   16.012605     33.903843`
```
Same for `list_df_2d` for combinations of 2D binning.
```
list_df_2d[0]
Out[16]: 
    count_slope-elevation  ...  binmid_elevation
0                227518.0  ...         58.760407
1                 76479.0  ...        160.176258
2                 65977.0  ...        261.592110
3                 38701.0  ...        363.007962
4                 27911.0  ...        464.423814
..                    ...  ...               ...
95                    3.0  ...        565.839666
96                    0.0  ...        667.255517
97                    1.0  ...        768.671369
98                    1.0  ...        870.087221
99                    0.0  ...        971.503073
[100 rows x 5 columns]
```

## Limitations
1/ Currently, I output the results in several lists, each contain a pd.DataFrame for an easier manipulation. This is because binning variables can have different bin lengths, so the dimension cannot necessarily be concatenated into one dataframe.
An approach to circumvent this issue would be to have basic names for the statistics `count`, `nmad`, `binmid` and then add another column with a string containing the variable name `var`. Then they could all be concatenated in the same object, even the ones in multiple dimensions (now that I write it, I think that's highly preferable! it's an easy change :smile: )

2/ Right now only the middle value of the bin is returned. I could add 2 columns (`bin_min`, `bin_max`) to ensure we have this information as well?

3/ I'm not sure how well the `scipy.binned_statistic_dd` approach scales with millions of pixels... but I think it would be counterproductive to create our own binning functions that could become deprecated rapidly. Better to base ourselves on an existing pandas/scipy implementation! And I'm not sure `pandas.cut` is satisfactory for this kind of implementation right now (or maybe I missed something!)