### PR TITLE
Store ddem example to minimize test/doc computing times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ instance/
 docs/_build/
 docs/build/
 docs/source/api/
+docs/.buildinfo
+docs/.doctrees
 
 # PyBuilder
 target/
@@ -138,3 +140,4 @@ dmypy.json
 xdem/version.py
 
 examples/*/data/
+examples/*/processed

--- a/docs/source/code/comparison.py
+++ b/docs/source/code/comparison.py
@@ -13,12 +13,12 @@ import xdem
 xdem.examples.download_longyearbyen_examples(overwrite=False)
 
 # Load a reference DEM from 2009
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], datetime=datetime(2009, 8, 1))
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"], datetime=datetime(2009, 8, 1))
 # Load a DEM from 1990
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], datetime=datetime(1990, 8, 1))
+dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"], datetime=datetime(1990, 8, 1))
 # Load glacier outlines from 1990.
-glaciers_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
-glaciers_2010 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines_2010"])
+glaciers_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+glaciers_2010 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines_2010"])
 
 # Make a dictionary of glacier outlines where the key represents the associated date.
 outlines = {

--- a/docs/source/code/comparison.py
+++ b/docs/source/code/comparison.py
@@ -9,16 +9,14 @@ import numpy as np
 
 import xdem
 
-# Download the necessary data. This may take a few minutes.
-xdem.examples.download_longyearbyen_examples(overwrite=False)
 
 # Load a reference DEM from 2009
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"], datetime=datetime(2009, 8, 1))
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), datetime=datetime(2009, 8, 1))
 # Load a DEM from 1990
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"], datetime=datetime(1990, 8, 1))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"), datetime=datetime(1990, 8, 1))
 # Load glacier outlines from 1990.
-glaciers_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
-glaciers_2010 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines_2010"])
+glaciers_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
+glaciers_2010 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines_2010"))
 
 # Make a dictionary of glacier outlines where the key represents the associated date.
 outlines = {

--- a/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
@@ -7,9 +7,9 @@ import xdem
 
 xdem.examples.download_longyearbyen_examples(overwrite=False)
 
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
@@ -5,11 +5,9 @@ import numpy as np
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
@@ -7,9 +7,9 @@ import xdem
 
 xdem.examples.download_longyearbyen_examples(overwrite=False)
 
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
@@ -5,11 +5,9 @@ import numpy as np
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/comparison_plot_spatial_interpolation.py
+++ b/docs/source/code/comparison_plot_spatial_interpolation.py
@@ -7,9 +7,9 @@ import xdem
 
 xdem.examples.download_longyearbyen_examples(overwrite=False)
 
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/comparison_plot_spatial_interpolation.py
+++ b/docs/source/code/comparison_plot_spatial_interpolation.py
@@ -5,11 +5,9 @@ import numpy as np
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
     xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/docs/source/code/coregistration.py
+++ b/docs/source/code/coregistration.py
@@ -8,16 +8,14 @@ import numpy as np
 import xdem
 from xdem import coreg
 
-# Download the necessary data. This may take a few minutes.
-xdem.examples.download_longyearbyen_examples(overwrite=False)
 
 # Load the data using xdem and geoutils (could be with rasterio and geopandas instead)
 # Load a reference DEM from 2009
-reference_dem = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+reference_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
 # Load a moderately well aligned DEM from 1990
-dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(reference_dem, silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(reference_dem, silent=True)
 # Load glacier outlines from 1990. This will act as the unstable ground.
-glacier_outlines = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 # Prepare the inputs for coregistration.
 ref_data = reference_dem.data.squeeze()  # This is a numpy 2D array/masked_array

--- a/docs/source/code/coregistration.py
+++ b/docs/source/code/coregistration.py
@@ -13,11 +13,11 @@ xdem.examples.download_longyearbyen_examples(overwrite=False)
 
 # Load the data using xdem and geoutils (could be with rasterio and geopandas instead)
 # Load a reference DEM from 2009
-reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
+reference_dem = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
 # Load a moderately well aligned DEM from 1990
-dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(reference_dem, silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(reference_dem, silent=True)
 # Load glacier outlines from 1990. This will act as the unstable ground.
-glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+glacier_outlines = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
 # Prepare the inputs for coregistration.
 ref_data = reference_dem.data.squeeze()  # This is a numpy 2D array/masked_array

--- a/docs/source/code/coregistration_plot_nuth_kaab.py
+++ b/docs/source/code/coregistration_plot_nuth_kaab.py
@@ -7,9 +7,9 @@ import xdem
 
 xdem.examples.download_longyearbyen_examples(overwrite=False)
 
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 inlier_mask = ~outlines_1990.create_mask(dem_2009)
 
 nuth_kaab = xdem.coreg.NuthKaab()

--- a/docs/source/code/coregistration_plot_nuth_kaab.py
+++ b/docs/source/code/coregistration_plot_nuth_kaab.py
@@ -5,11 +5,9 @@ import numpy as np
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 inlier_mask = ~outlines_1990.create_mask(dem_2009)
 
 nuth_kaab = xdem.coreg.NuthKaab()

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -22,13 +22,11 @@ with warnings.catch_warnings():
 
 def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovector.Vector]:
     """Load example files to try coregistration methods with."""
-    examples.download_longyearbyen_examples(overwrite=False)
-    
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        reference_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-        to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-        glacier_mask = gu.geovector.Vector(examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+        reference_raster = gu.georaster.Raster(examples.get_path("longyearbyen_ref_dem"))
+        to_be_aligned_raster = gu.georaster.Raster(examples.get_path("longyearbyen_tba_dem"))
+        glacier_mask = gu.geovector.Vector(examples.get_path("longyearbyen_glacier_outlines"))
 
     return reference_raster, to_be_aligned_raster, glacier_mask
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -29,9 +29,9 @@ def load_examples() -> tuple[gu.georaster.Raster, gu.georaster.Raster, gu.geovec
     """Load example files to try coregistration methods with."""
     examples.download_longyearbyen_examples(overwrite=False)
 
-    reference_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
-    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_tba_dem"])
-    glacier_mask = gu.geovector.Vector(examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    reference_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+    glacier_mask = gu.geovector.Vector(examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
     return reference_raster, to_be_aligned_raster, glacier_mask
 
 

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -10,9 +10,9 @@ with warnings.catch_warnings():
 
 
 class TestdDEM:
-    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
     ddem = xdem.dDEM(
         xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -10,9 +10,9 @@ with warnings.catch_warnings():
 
 
 class TestdDEM:
-    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+    dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+    outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
     ddem = xdem.dDEM(
         xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -12,8 +12,6 @@ import pytest
 import xdem
 from xdem.dem import DEM
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
 DO_PLOT = False
 
 
@@ -23,7 +21,7 @@ class TestDEM:
         """
         Test that inputs work properly in DEM class init
         """
-        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.get_path("longyearbyen_ref_dem")
 
         # from filename
         dem = DEM(fn_img)
@@ -69,7 +67,7 @@ class TestDEM:
               - if r is copied, r.data changed, r2.data should be unchanged
               """
         # Open dataset, update data and make a copy
-        r = xdem.dem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+        r = xdem.dem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
         r.data += 5
         r2 = r.copy()
 
@@ -102,7 +100,7 @@ class TestDEM:
 
     def test_set_vref(self):
 
-        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.get_path("longyearbyen_ref_dem")
         img = DEM(fn_img)
 
         # check for WGS84
@@ -195,7 +193,7 @@ class TestDEM:
         assert np.logical_and.reduce((np.isfinite(z_out), np.less(z_out, z), np.less(np.abs(z_out-z), 100)))
 
         # checking that the function does not run without a reference set
-        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.get_path("longyearbyen_ref_dem")
         img = DEM(fn_img)
         with pytest.raises(ValueError):
             img.to_vref(vref_name='EGM96')

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -25,7 +25,7 @@ class TestDEM:
         """
         Test that inputs work properly in DEM class init
         """
-        fn_img = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
 
         # from filename
         dem = DEM(fn_img)
@@ -71,7 +71,7 @@ class TestDEM:
               - if r is copied, r.data changed, r2.data should be unchanged
               """
         # Open dataset, update data and make a copy
-        r = xdem.dem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
+        r = xdem.dem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
         r.data += 5
         r2 = r.copy()
 
@@ -104,7 +104,7 @@ class TestDEM:
 
     def test_set_vref(self):
 
-        fn_img = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
         img = DEM(fn_img)
 
         # check for WGS84
@@ -197,7 +197,7 @@ class TestDEM:
         assert np.logical_and.reduce((np.isfinite(z_out), np.less(z_out, z), np.less(np.abs(z_out-z), 100)))
 
         # checking that the function does not run without a reference set
-        fn_img = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
+        fn_img = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
         img = DEM(fn_img)
         with pytest.raises(ValueError):
             img.to_vref(vref_name='EGM96')

--- a/tests/test_demcollection.py
+++ b/tests/test_demcollection.py
@@ -7,14 +7,11 @@ import numpy as np
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-
 class TestDEMCollection:
-    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
-    outlines_2010 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines_2010"])
+    dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+    dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+    outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
+    outlines_2010 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines_2010"))
 
     def test_init(self):
 

--- a/tests/test_demcollection.py
+++ b/tests/test_demcollection.py
@@ -10,10 +10,10 @@ xdem.examples.download_longyearbyen_examples(overwrite=False)
 
 
 class TestDEMCollection:
-    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"])
-    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
-    outlines_2010 = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines_2010"])
+    dem_2009 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem_1990 = xdem.DEM(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+    outlines_1990 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    outlines_2010 = gu.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines_2010"])
 
     def test_init(self):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,15 +7,13 @@ import pytest
 import geoutils as gu
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
 
 class TestFilters:
     """Test cases for the filter functions."""
 
     # Load example data.
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
+    dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
 
     def test_gauss(self):
         """Test applying the various Gaussian filters on DEMs with/without NaNs"""

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -16,8 +16,8 @@ class TestFilters:
     """Test cases for the filter functions."""
 
     # Load example data.
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
+    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
 
     def test_gauss(self):
         """Test applying the various Gaussian filters on DEMs with/without NaNs"""

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -20,8 +20,8 @@ from xdem import examples
 def test_dem_subtraction():
     """Test that the DEM subtraction script gives reasonable numbers."""
     diff = xdem.spatial_tools.subtract_rasters(
-        examples.FILEPATHS_DATA["longyearbyen_ref_dem"],
-        examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+        examples.get_path("longyearbyen_ref_dem"),
+        examples.get_path("longyearbyen_tba_dem"))
 
     assert np.nanmean(np.abs(diff.data)) < 100
 
@@ -31,7 +31,7 @@ class TestMerging:
     Test cases for stacking and merging DEMs
     Split a DEM with some overlap, then stack/merge it, and validate bounds and shape.
     """
-    dem = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem = gu.georaster.Raster(examples.get_path("longyearbyen_ref_dem"))
 
     # Find the easting midpoint of the DEM
     x_midpoint = np.mean([dem.bounds.right, dem.bounds.left])
@@ -137,7 +137,7 @@ def test_hillshade():
         temp_dir.cleanup()
         return data
 
-    filepath = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
+    filepath = xdem.examples.get_path("longyearbyen_ref_dem")
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         dem = xdem.DEM(filepath)

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -21,8 +21,8 @@ from xdem import examples
 def test_dem_subtraction():
     """Test that the DEM subtraction script gives reasonable numbers."""
     diff = xdem.spatial_tools.subtract_rasters(
-        examples.FILEPATHS["longyearbyen_ref_dem"],
-        examples.FILEPATHS["longyearbyen_tba_dem"])
+        examples.FILEPATHS_DATA["longyearbyen_ref_dem"],
+        examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
 
     assert np.nanmean(np.abs(diff.data)) < 100
 
@@ -32,7 +32,7 @@ class TestMerging:
     Test cases for stacking and merging DEMs
     Split a DEM with some overlap, then stack/merge it, and validate bounds and shape.
     """
-    dem = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
+    dem = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
 
     # Find the easting midpoint of the DEM
     x_midpoint = np.mean([dem.bounds.right, dem.bounds.left])
@@ -140,7 +140,7 @@ def test_hillshade():
         temp_dir.cleanup()
         return data
 
-    filepath = xdem.examples.FILEPATHS["longyearbyen_ref_dem"]
+    filepath = xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"]
     dem = xdem.DEM(filepath)
 
     xdem_hillshade = xdem.spatial_tools.hillshade(dem.data, resolution=dem.res)

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -20,14 +20,11 @@ PLOT = False
 
 def load_ref_and_diff() -> tuple[gu.georaster.Raster, gu.georaster.Raster, np.ndarray]:
     """Load example files to try coregistration methods with."""
-    examples.download_longyearbyen_examples(overwrite=False)
 
-    reference_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
-    glacier_mask = gu.geovector.Vector(examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    reference_raster = gu.georaster.Raster(examples.get_path("longyearbyen_ref_dem"))
+    glacier_mask = gu.geovector.Vector(examples.get_path("longyearbyen_glacier_outlines"))
 
-    examples.process_coregistered_example(overwrite=False)
-    ddem = gu.georaster.Raster(examples.FILEPATHS_PROCESSED['longyearbyen_ddem'])
+    ddem = gu.georaster.Raster(examples.get_path('longyearbyen_ddem'))
     mask = glacier_mask.create_mask(ddem)
 
     return reference_raster, ddem, mask

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -21,29 +21,19 @@ with warnings.catch_warnings():
 
 PLOT = False
 
-
 def load_diff() -> tuple[gu.georaster.Raster, np.ndarray]:
     """Load example files to try coregistration methods with."""
     examples.download_longyearbyen_examples(overwrite=False)
 
-    reference_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_ref_dem"])
-    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS["longyearbyen_tba_dem"])
-    glacier_mask = gu.geovector.Vector(examples.FILEPATHS["longyearbyen_glacier_outlines"])
-    inlier_mask = ~glacier_mask.create_mask(reference_raster)
+    reference_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    to_be_aligned_raster = gu.georaster.Raster(examples.FILEPATHS_DATA["longyearbyen_tba_dem"])
+    glacier_mask = gu.geovector.Vector(examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
-    metadata = {}
-    # aligned_raster, _ = xdem.coreg.coregister(reference_raster, to_be_aligned_raster, method="amaury", mask=glacier_mask,
-    #                                          metadata=metadata)
-    nuth_kaab = xdem.coreg.NuthKaab()
-    nuth_kaab.fit(reference_raster.data, to_be_aligned_raster.data,
-                  inlier_mask=inlier_mask, transform=reference_raster.transform)
-    aligned_raster = nuth_kaab.apply(to_be_aligned_raster.data, transform=reference_raster.transform)
+    examples.process_coregistered_example(overwrite=False)
+    ddem = gu.georaster.Raster(examples.FILEPATHS_PROCESSED['longyearbyen_ddem'])
+    mask = glacier_mask.create_mask(ddem)
 
-    diff = gu.Raster.from_array((reference_raster.data - aligned_raster),
-                                transform=reference_raster.transform, crs=reference_raster.crs)
-    mask = glacier_mask.create_mask(diff)
-
-    return diff, mask
+    return ddem, mask
 
 
 class TestVariogram:

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -172,9 +172,9 @@ class TestLocalHypsometric:
 
 
 class TestNormHypsometric:
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
-    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
+    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
 
     glacier_index_map = outlines.rasterize(dem_2009)
     ddem = dem_2009.data - dem_1990.data

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -9,16 +9,13 @@ import pytest
 
 import xdem
 
-xdem.examples.download_longyearbyen_examples(overwrite=False)
-
-
 class TestLocalHypsometric:
     """Test cases for the local hypsometric method."""
 
     # Load example data.
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
-    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
+    outlines = gu.geovector.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
     all_outlines = outlines.copy()
     
     # Filter to only look at the Scott Turnerbreen glacier
@@ -172,9 +169,9 @@ class TestLocalHypsometric:
 
 
 class TestNormHypsometric:
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
-    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
+    outlines = gu.geovector.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
     glacier_index_map = outlines.rasterize(dem_2009)
     ddem = dem_2009.data - dem_1990.data

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -11,9 +11,9 @@ class TestLocalHypsometric:
     """Test cases for the local hypsometric method."""
 
     # Load example data.
-    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_ref_dem"])
-    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
-    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+    dem_2009 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_ref_dem"])
+    dem_1990 = gu.georaster.Raster(xdem.examples.FILEPATHS_DATA["longyearbyen_tba_dem"]).reproject(dem_2009, silent=True)
+    outlines = gu.geovector.Vector(xdem.examples.FILEPATHS_DATA["longyearbyen_glacier_outlines"])
     # Filter to only look at the Scott Turnerbreen glacier
     outlines.ds = outlines.ds.loc[outlines.ds["NAME"] == "Scott Turnerbreen"]
     # Create a mask where glacier areas are True

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -34,7 +34,7 @@ def download_longyearbyen_examples(overwrite: bool = False):
     :param overwrite: Do not download the files again if they already exist.
     """
     if not overwrite and all(map(os.path.isfile, list(FILEPATHS_DATA.values()))):
-        print("Datasets exist")
+        # print("Datasets exist")
         return
 
     # Static commit hash to be bumped every time it needs to be.
@@ -68,7 +68,7 @@ def download_longyearbyen_examples(overwrite: bool = False):
     # Copy the data to the examples directory.
     copy_tree(dir_name, os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen","data"))
 
-def process_coregistered_example(overwrite=False):
+def process_coregistered_examples(overwrite: bool =False):
     """
        Process the Longyearbyen example files into a dDEM (to avoid repeating this in many test/documentation steps).
 
@@ -90,7 +90,7 @@ def process_coregistered_example(overwrite=False):
                 raise
 
     if not overwrite and all(map(os.path.isfile, list(FILEPATHS_PROCESSED.values()))):
-        print("Processed data exists")
+        # print("Processed data exists")
         return
 
     download_longyearbyen_examples(overwrite=False)
@@ -112,3 +112,19 @@ def process_coregistered_example(overwrite=False):
     # Save it so that future calls won't need to recreate the file
     mkdir_p(os.path.dirname(FILEPATHS_PROCESSED['longyearbyen_ddem']))
     diff.save(FILEPATHS_PROCESSED['longyearbyen_ddem'])
+
+def get_path(name: str) -> str:
+    """
+    Get path of example data
+    :param name: Name of test data (listed in xdem/examples.py)
+    :return:
+    """
+    if name in list(FILEPATHS_DATA.keys()):
+        download_longyearbyen_examples()
+        return FILEPATHS_DATA[name]
+    elif name in list(FILEPATHS_PROCESSED.keys()):
+        process_coregistered_examples()
+        return FILEPATHS_PROCESSED[name]
+    else:
+        raise ValueError('Data name should be one of "'+'" , "'.join(list(FILEPATHS_DATA.keys())+list(FILEPATHS_PROCESSED.keys()))+'".')
+

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -1,4 +1,5 @@
 """Utility functions to download and find example data."""
+import errno
 import os
 import shutil
 import tarfile
@@ -6,20 +7,24 @@ import tempfile
 import urllib.request
 from distutils.dir_util import copy_tree
 
-EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "../", "examples/"))
+import geoutils as gu
+import xdem
+
+EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples"))
 # Absolute filepaths to the example files.
-FILEPATHS = {
-    "longyearbyen_ref_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen/data/DEM_2009_ref.tif"),
-    "longyearbyen_tba_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen/data/DEM_1990.tif"),
+FILEPATHS_DATA = {
+    "longyearbyen_ref_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen","data","DEM_2009_ref.tif"),
+    "longyearbyen_tba_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen","data","DEM_1990.tif"),
     "longyearbyen_glacier_outlines": os.path.join(
         EXAMPLES_DIRECTORY,
-        "Longyearbyen/data/glacier_mask/CryoClim_GAO_SJ_1990.shp"
+        "Longyearbyen","data","glacier_mask","CryoClim_GAO_SJ_1990.shp"
     ),
     "longyearbyen_glacier_outlines_2010": os.path.join(
         EXAMPLES_DIRECTORY,
-        "Longyearbyen/data/glacier_mask/CryoClim_GAO_SJ_2010.shp"
-    )
-}
+        "Longyearbyen","data","glacier_mask","CryoClim_GAO_SJ_2010.shp"
+    )}
+
+FILEPATHS_PROCESSED = {"longyearbyen_ddem": os.path.join(EXAMPLES_DIRECTORY,"Longyearbyen","processed","dDEM_2009_minus_1990.tif")}
 
 
 def download_longyearbyen_examples(overwrite: bool = False):
@@ -28,7 +33,7 @@ def download_longyearbyen_examples(overwrite: bool = False):
 
     :param overwrite: Do not download the files again if they already exist.
     """
-    if not overwrite and all(map(os.path.isfile, list(FILEPATHS.values()))):
+    if not overwrite and all(map(os.path.isfile, list(FILEPATHS_DATA.values()))):
         print("Datasets exist")
         return
 
@@ -57,8 +62,53 @@ def download_longyearbyen_examples(overwrite: bool = False):
     dir_name = os.path.join(
         temp_dir.name,
         [dirname for dirname in os.listdir(temp_dir.name) if os.path.isdir(os.path.join(temp_dir.name, dirname))][0],
-        "data/Longyearbyen"
+        "data","Longyearbyen"
     )
 
     # Copy the data to the examples directory.
-    copy_tree(dir_name, os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen/data"))
+    copy_tree(dir_name, os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen","data"))
+
+def process_coregistered_example(overwrite=False):
+    """
+       Process the Longyearbyen example files into a dDEM (to avoid repeating this in many test/documentation steps).
+
+       :param overwrite: Do not download the files again if they already exist.
+       """
+
+    def mkdir_p(out_dir):
+        """
+        Add bash mkdir -p functionality to os.makedirs.
+
+        :param out_dir: directory to create.
+        """
+        try:
+            os.makedirs(out_dir)
+        except OSError as exc:  # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(out_dir):
+                pass
+            else:
+                raise
+
+    if not overwrite and all(map(os.path.isfile, list(FILEPATHS_PROCESSED.values()))):
+        print("Processed data exists")
+        return
+
+    download_longyearbyen_examples(overwrite=False)
+
+    # Run the coregistration if it hasn't been made yet.
+    reference_raster = gu.georaster.Raster(FILEPATHS_DATA["longyearbyen_ref_dem"])
+    to_be_aligned_raster = gu.georaster.Raster(FILEPATHS_DATA["longyearbyen_tba_dem"])
+    glacier_mask = gu.geovector.Vector(FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+    inlier_mask = ~glacier_mask.create_mask(reference_raster)
+
+    nuth_kaab = xdem.coreg.NuthKaab()
+    nuth_kaab.fit(reference_raster.data, to_be_aligned_raster.data,
+                  inlier_mask=inlier_mask, transform=reference_raster.transform)
+    aligned_raster = nuth_kaab.apply(to_be_aligned_raster.data, transform=reference_raster.transform)
+
+    diff = gu.Raster.from_array((reference_raster.data - aligned_raster),
+                                transform=reference_raster.transform, crs=reference_raster.crs)
+
+    # Save it so that future calls won't need to recreate the file
+    mkdir_p(os.path.dirname(FILEPATHS_PROCESSED['longyearbyen_ddem']))
+    diff.save(FILEPATHS_PROCESSED['longyearbyen_ddem'])


### PR DESCRIPTION
### Update examples.py

Added `process_coregistered_example` to `xdem/examples.py` that works similarly as `download_longyearbyen_examples`.
To differentiate the two when loading data from `examples`, I have renamed `FILEPATHS` into `FILEPATHS_DATA` and added a `FILEPATHS_PROCESSED`.

Now one can load the dDEM example through: `examples.FILEPATHS_PROCESSED['longyearbyen_ddem']`. I have refactored previous usages of `FILEPATHS` into `FILEPATHS_DATA`.

@erikmannerfelt I see most of your test cases for volume/ddem and plot scripts in the documentation simply use the difference between the non-aligned Longyearbyen rasters (rather than doing a N&K like I did in spatial_stats). Should we change those to using the dDEM data now that it is available, or keep them as is?