### PR TITLE
Add example gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 xdem/version.py
 
 examples/*/data/
+auto_examples/
+gen_modules/

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - sphinxcontrib-programoutput
   - flake8
   - sphinx-autodoc-typehints
+  - sphinx-gallery

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ git+https://github.com/GlacioHack/GeoUtils.git
 scikit-gstat
 flake8
 opencv-contrib-python
+sphinx-gallery

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,11 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+clean:
+	rm -r "$(BUILDDIR)"
+	rm -r "$(SOURCEDIR)/auto_examples"
+	rm -r "$(SOURCEDIR)/gen_modules"
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/source/_templates/module.rst
+++ b/docs/source/_templates/module.rst
@@ -1,0 +1,58 @@
+{{ fullname }}
+{{ underline }}
+
+.. automodule:: {{ fullname }}
+
+   .. contents:: Contents 
+      :local:
+
+   {% block functions %}
+   {% if functions %}
+
+   Functions
+   ---------
+
+   {% for item in functions %}
+
+   .. autofunction:: {{ item }}
+
+   .. _sphx_glr_backref_{{fullname}}.{{item}}:
+
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
+
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+
+   Classes
+   -------
+
+   {% for item in classes %}
+   .. autoclass:: {{ item }}
+      :members:
+
+   .. _sphx_glr_backref_{{fullname}}.{{item}}:
+
+   .. minigallery:: {{fullname}}.{{item}}
+       :add-heading:
+
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+
+   Exceptions
+   ----------
+
+   .. autosummary::
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/source/_templates/module.rst
+++ b/docs/source/_templates/module.rst
@@ -10,9 +10,12 @@
    {% if functions %}
 
    Functions
-   ---------
+   =========
 
    {% for item in functions %}
+
+   {{item}}
+   {{ "-" * (item | length) }}
 
    .. autofunction:: {{ item }}
 
@@ -29,10 +32,16 @@
    {% if classes %}
 
    Classes
-   -------
+   =======
 
    {% for item in classes %}
+
+   {{item}}
+   {{ "-" * (item | length) }}
+
    .. autoclass:: {{ item }}
+      :show-inheritance:
+      :special-members: __init__
       :members:
 
    .. _sphx_glr_backref_{{fullname}}.{{item}}:
@@ -48,7 +57,7 @@
    {% if exceptions %}
 
    Exceptions
-   ----------
+   ==========
 
    .. autosummary::
    {% for item in exceptions %}

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,27 @@
+.. _api:
+
+API Reference
+=============
+
+Full information about xdem's functionality is provided on this page.
+
+.. currentmodule:: xdem
+
+.. automodule:: xdem
+        :no-members:
+        :no-inherited-members:
+
+:py:mod:`xdem`:
+
+.. autosummary::
+        :toctree: gen_modules/
+        :template: module.rst
+
+        coreg
+        ddem
+        dem
+        demcollection
+        filters
+        spatial_tools
+        spstats
+        volume

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,21 +7,54 @@ Full information about xdem's functionality is provided on this page.
 
 .. currentmodule:: xdem
 
-.. automodule:: xdem
-        :no-members:
-        :no-inherited-members:
-
-:py:mod:`xdem`:
-
 .. autosummary::
         :toctree: gen_modules/
         :template: module.rst
 
         coreg
-        ddem
         dem
-        demcollection
         filters
         spatial_tools
         spstats
         volume
+
+.. automodule:: xdem
+
+   .. contents:: Contents 
+      :local:
+        
+   DEM
+   ---
+   .. autoclass:: DEM
+        :show-inheritance:
+        :special-members: __init__
+        :members:
+
+   .. _sphx_glr_backref_xdem.DEM:
+
+   .. minigallery:: xdem.DEM
+        :add-heading:
+        
+   DEMCollection
+   -------------
+   .. autoclass:: DEMCollection
+        :show-inheritance:
+        :special-members: __init__
+        :members:
+
+   .. _sphx_glr_backref_xdem.DEMCollection:
+
+   .. minigallery:: xdem.DEMCollection
+        :add-heading:
+
+   dDEM
+   ----
+   .. autoclass:: dDEM
+        :show-inheritance:
+        :special-members: __init__
+        :members:
+
+   .. _sphx_glr_backref_xdem.dDEM:
+
+   .. minigallery:: xdem.dDEM
+        :add-heading:

--- a/docs/source/code/comparison.py
+++ b/docs/source/code/comparison.py
@@ -70,21 +70,3 @@ ddem.interpolate(method="local_hypsometric", reference_elevation=dem_2009, mask=
 # SUBSECTION: Regional hypsometric interpolation
 
 ddem.interpolate(method="regional_hypsometric", reference_elevation=dem_2009, mask=glaciers_1990)
-
-###################################
-# SECTION: The DEMCollection object
-###################################
-
-dems = xdem.DEMCollection(
-    [dem_1990, dem_2009, dem_2060],
-    outlines=outlines,
-    reference_dem=dem_2009
-)
-
-# TEXT HERE
-
-dems.subtract_dems()
-dems.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")
-
-# Create an object that can be printed in the documentation.
-scott_series = dems.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")

--- a/docs/source/code/comparison_print_cumulative_dh.py
+++ b/docs/source/code/comparison_print_cumulative_dh.py
@@ -2,10 +2,24 @@
 import contextlib
 import io
 import sys
+import xdem
 
 sys.path.insert(0, "code/")  # The base directory is source/, so to find comparison.py, it has to be source/code/
 
 with contextlib.redirect_stdout(io.StringIO()):  # Import the script without printing anything.
     import comparison
 
-print(comparison.scott_series)
+
+dems = xdem.DEMCollection(
+    [comparison.dem_1990, comparison.dem_2009, comparison.dem_2060],
+    outlines=comparison.outlines,
+    reference_dem=comparison.dem_2009
+)
+
+dems.subtract_dems()
+dems.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")
+
+# Create an object that can be printed in the documentation.
+scott_series = dems.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")
+
+print(scott_series)

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -10,11 +10,11 @@ DEM subtraction and volume change
 Example data in this chapter are loaded as follows:
 
 .. literalinclude:: code/comparison.py
-        :lines: 5-33
+        :lines: 5-32
 
 
 Subtracting rasters
-^^^^^^^^^^^^^^^^^^^
+-------------------
 Calculating the difference of DEMs (dDEMs) is theoretically simple, but can in practice often be time consuming.
 In ``xdem``, the aim is to minimize or completely remove potential pitfalls in this analysis.
 
@@ -22,13 +22,13 @@ Let's assume we have two perfectly aligned DEMs, with the same shape, extent, re
 Calculating a dDEM would then be as simple as:
 
 .. literalinclude:: code/comparison.py
-        :lines: 39-43
+        :lines: 37-41
 
 But in practice, our two DEMs are most often not perfectly aligned, which is why we might need a helper function for this:
 :func:`xdem.spatial_tools.subtract_rasters`
 
 .. literalinclude:: code/comparison.py
-        :lines: 47
+        :lines: 45
         
 
 So what does this magical function do?
@@ -40,7 +40,7 @@ Most often, ``xdem`` works with Masked Arrays, where the mask signifies cells to
 The ``subtract_rasters()`` function makes sure that the outgoing mask is the union of the two ingoing masks.
 
 dDEM interpolation
-^^^^^^^^^^^^^^^^^^
+------------------
 There are many approaches to interpolate a dDEM.
 A good comparison study for glaciers is McNabb et al., (`2019 <https://doi.org/10.5194/tc-13-895-2019>`_).
 So far, ``xdem`` has three types of interpolation:
@@ -52,22 +52,22 @@ So far, ``xdem`` has three types of interpolation:
 Let's first create a :class:`xdem.ddem.dDEM` object to experiment on:
 
 .. literalinclude:: code/comparison.py
-        :lines: 53-62
+        :lines: 51-60
 
 
 Linear spatial interpolation
-****************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Linear spatial interpolation (also often called bilinear interpolation) of dDEMs is arguably the simplest approach: voids are filled by a an average of the surrounding pixels values, weighted by their distance to the void pixel.
 
 
 .. literalinclude:: code/comparison.py
-        :lines: 66
+        :lines: 64
 
 .. plot:: code/comparison_plot_spatial_interpolation.py
         
 
 Local hypsometric interpolation
-*******************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 This approach assumes that there is a relationship between the elevation and the elevation change in the dDEM, which is often the case for glaciers.
 Elevation change gradients in late 1900s and 2000s on glaciers often have the signature of large melt in the lower parts, while the upper parts might be less negative, or even positive.
 This relationship is strongly correlated for a specific glacier, and weakly correlated on regional scales (see `Regional hypsometric interpolation`_).
@@ -77,7 +77,7 @@ Then, voids are interpolated by replacing them with what "should be there" at th
 
 
 .. literalinclude:: code/comparison.py
-        :lines: 70
+        :lines: 68
 
 .. plot:: code/comparison_plot_local_hypsometric_interpolation.py
         
@@ -86,14 +86,14 @@ Then, voids are interpolated by replacing them with what "should be there" at th
 
 
 Regional hypsometric interpolation
-**********************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Similarly to `Local hypsometric interpolation`_, the elevation change is assumed to be largely elevation-dependent.
 With the regional approach (often also called "global"), elevation change gradients are estimated for all glaciers in an entire region, instead of estimating one by one.
 This is advantageous in respect to areas where voids are frequent, as not even a single dDEM value has to exist on a glacier in order to reconstruct it.
 Of course, the accuracy of such an averaging is much lower than if the local hypsometric approach is used (assuming it is possible).
 
 .. literalinclude:: code/comparison.py
-        :lines: 74
+        :lines: 72
 
 .. plot:: code/comparison_plot_regional_hypsometric_interpolation.py
         
@@ -101,27 +101,14 @@ Of course, the accuracy of such an averaging is much lower than if the local hyp
 *Caption: The regional elevation dependent elevation change in central Svalbard from 1990--2009. The width of the bars indicate the standard devation of the bin. The light blue background bars show the area distribution with elevation.*
 
 The DEMCollection object
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 Keeping track of multiple DEMs can be difficult when many different extents, resolutions and CRSs are involved, and :class:`xdem.demcollection.DEMCollection` is ``xdem``'s answer to make this simple.
 We need metadata on the timing of these products.
 The DEMs can be provided with the ``datetime=`` argument upon instantiation, or the attribute could be set later.
-Multiple outlines are provided as a dictionary in the shape of ``{datetime: outline}``:
+Multiple outlines are provided as a dictionary in the shape of ``{datetime: outline}``.
 
 
-In the examples, we have three DEMs and glacier outlines with known dates, so we can create a collection from them:
-
-
-.. literalinclude:: code/comparison.py
-        :lines: 80-84
-
-Now, we can easily calculate the elevation or volume change between the DEMs, for example on the glacier Scott Turnerbreen:
-
-.. literalinclude:: code/comparison.py
-        :lines: 88-89
-
-which will return a Pandas Series:
-
-.. program-output:: $PYTHON code/comparison_print_cumulative_dh.py 
-        :shell:
+.. minigallery:: xdem.DEMCollection
+        :add-heading:
 
 `See here for the outline filtering syntax <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html>`_.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,12 @@ extensions = [
 
 #autosummary_generate = True
 
+intersphinx_mapping = {
+    "geoutils": ("https://geoutils.readthedocs.io/en/latest", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
+}
+
 sphinx_gallery_conf = {
      "examples_dirs": os.path.join(os.path.dirname(__file__), "../", "../", "examples"),   # path to your example scripts
      "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
@@ -69,15 +75,6 @@ sphinx_gallery_conf = {
 # Add any paths that contain templates here, relative to this directory.
 templates_path = [os.path.join(os.path.dirname(__file__), '_templates')]
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-#exclude_patterns = [
-#    "_templates"
-#]
-#exclude_patterns = [
-#    "api/modules.rst"  # This is not really needed, but is created automatically by autodoc
-#]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -92,23 +89,6 @@ html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']  # Commented out as we have no custom static data
 
 
-'''
-def run_apidoc(_):
-    """
-    Make sure readthedocs finds the module.
-
-    Maybe this is not needed?
-    """
-    from sphinx.ext.apidoc import main
-    import os
-    import sys
-    sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-    cur_dir = os.path.abspath(os.path.dirname(__file__))
-    module = os.path.join(cur_dir, "../../", "xdem")
-    output_path = os.path.join(cur_dir, 'gen_modules/')
-    main(['-e', '-o', output_path, module, os.path.join(module, "version.py"), "--force"])
-
-
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
-'''
+exclude_patterns = [
+    "_templates"
+]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,6 +55,7 @@ extensions = [
 
 intersphinx_mapping = {
     "geoutils": ("https://geoutils.readthedocs.io/en/latest", None),
+    "rasterio": ("https://rasterio.readthedocs.io/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
 }
@@ -69,7 +70,7 @@ sphinx_gallery_conf = {
     },
      # directory where function/class granular galleries are stored
     "backreferences_dir"  : "gen_modules/backreferences",
-    "doc_module": ("xdem", "geoutils")
+    "doc_module": ("xdem", "geoutils")  # I honestly don't know what this is.
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,10 @@ import os
 import sys
 
 # Allow conf.py to find the xdem module
-sys.path.insert(0, os.path.abspath("../xdem/'"))
+sys.path.append(os.path.abspath("../.."))
+sys.path.append(os.path.abspath("../../xdem/"))
+sys.path.append(os.path.abspath(".."))
+
 import xdem.version
 
 # -- Project information -----------------------------------------------------
@@ -43,20 +46,38 @@ extensions = [
     "sphinx.ext.autosummary",  # Create API doc summary texts from the docstrings.
     "sphinx.ext.inheritance_diagram",  # For class inheritance diagrams (see coregistration.rst).
     "sphinx_autodoc_typehints",  # Include type hints in the API documentation.
-    "sphinxcontrib.programoutput"
+    "sphinxcontrib.programoutput",
+    "sphinx_gallery.gen_gallery",  # Examples gallery
+    "sphinx.ext.intersphinx",
 ]
 
-autosummary_generate = True
+#autosummary_generate = True
+
+sphinx_gallery_conf = {
+     "examples_dirs": os.path.join(os.path.dirname(__file__), "../", "../", "examples"),   # path to your example scripts
+     "gallery_dirs": "auto_examples",  # path to where to save gallery generated output
+     "inspect_global_variables": True,  # Make links to the class/function definitions.
+     "reference_url": {
+         # The module you locally document uses None
+        "xdem": None,
+    },
+     # directory where function/class granular galleries are stored
+    "backreferences_dir"  : "gen_modules/backreferences",
+    "doc_module": ("xdem", "geoutils")
+}
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = [os.path.join(os.path.dirname(__file__), '_templates')]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = [
-    "api/modules.rst"  # This is not really needed, but is created automatically by autodoc
-]
+#exclude_patterns = [
+#    "_templates"
+#]
+#exclude_patterns = [
+#    "api/modules.rst"  # This is not really needed, but is created automatically by autodoc
+#]
 
 # -- Options for HTML output -------------------------------------------------
 
@@ -71,6 +92,7 @@ html_theme = 'sphinx_rtd_theme'
 # html_static_path = ['_static']  # Commented out as we have no custom static data
 
 
+'''
 def run_apidoc(_):
     """
     Make sure readthedocs finds the module.
@@ -83,9 +105,10 @@ def run_apidoc(_):
     sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
     cur_dir = os.path.abspath(os.path.dirname(__file__))
     module = os.path.join(cur_dir, "../../", "xdem")
-    output_path = os.path.join(cur_dir, 'api/')
+    output_path = os.path.join(cur_dir, 'gen_modules/')
     main(['-e', '-o', output_path, module, os.path.join(module, "version.py"), "--force"])
 
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+'''

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -51,6 +51,8 @@ Nuth and Kääb (2011)
 ^^^^^^^^^^^^^^^^^^^^
 :class:`xdem.coreg.NuthKaab`
 
+.. _coregistration_nuthkaab:
+
 - **Performs:** translation and bias corrections.
 - **Supports weights** (soon)
 - **Recommended for:** Noisy data with low rotational differences.
@@ -79,6 +81,10 @@ Example
 
 .. literalinclude:: code/coregistration.py
         :lines: 33-38
+
+
+.. minigallery:: xdem.coreg.NuthKaab
+        :add-heading:
 
 Deramping
 ^^^^^^^^^

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -7,7 +7,7 @@ DEM Coregistration
    :local:
 
 Introduction
-^^^^^^^^^^^^
+------------
 
 Coregistration of a DEM is performed when it needs to be compared to a reference, but the DEM does not align with the reference perfectly.
 There are many reasons for why this might be, for example: poor georeferencing, unknown coordinate system transforms or vertical datums, and instrument- or processing-induced distortion.
@@ -30,7 +30,7 @@ Examples are given using data close to Longyearbyen on Svalbard. These can be lo
         :lines: 5-27
 
 The Coreg object
-^^^^^^^^^^^^^^^^^^^^
+----------------
 :class:`xdem.coreg.Coreg`
 
 Each of the coregistration approaches in ``xdem`` inherit their interface from the ``Coreg`` class.
@@ -51,7 +51,7 @@ First, ``.fit()`` is called to estimate the transform, and then this transform c
 
 
 Nuth and Kääb (2011)
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 :class:`xdem.coreg.NuthKaab`
 
 - **Performs:** translation and bias corrections.
@@ -71,24 +71,24 @@ The loop is stopped either when the maximum iteration limit is reached, or when 
 *Caption: Demonstration of the Nuth and Kääb (2011) approach from Svalbard. Note that large improvements are seen, but nonlinear offsets still exist. The NMAD is calculated from the off-glacier surfaces.*
 
 Limitations
-***********
+^^^^^^^^^^^
 The Nuth and Kääb (2011) coregistration approach does not take rotation into account.
 Rotational corrections are often needed on for example satellite derived DEMs, so a complementary tool is required for a perfect fit.
 1st or higher degree `Deramping`_ can be used for small rotational corrections.
 For large rotations, the Nuth and Kääb (2011) approach will not work properly, and `ICP`_ is recommended instead.
 
 Example
-*******
+^^^^^^^
 
 .. literalinclude:: code/coregistration.py
-        :lines: 33-38
+        :lines: 31-36
 
 
 .. minigallery:: xdem.coreg.NuthKaab
         :add-heading:
 
 Deramping
-^^^^^^^^^
+---------
 :class:`xdem.coreg.Deramp`
 
 - **Performs:** Bias, linear or nonlinear height corrections.
@@ -100,21 +100,21 @@ This may be useful for correcting small rotations in the dataset, or nonlinear e
 Applying a "0 degree deramping" is equivalent to a simple bias correction, and is recommended for e.g. vertical datum corrections.
 
 Limitations
-***********
+^^^^^^^^^^^
 Deramping does not account for horizontal (X/Y) shifts, and should most often be used in conjunction with other methods.
 
 1st order deramping is not perfectly equivalent to a rotational correction: Values are simply corrected in the vertical direction, and therefore includes a horizontal scaling factor, if it would be expressed as a transformation matrix.
 For large rotational corrections, `ICP`_ is recommended.
 
 Example
-*******
+^^^^^^^
 
 .. literalinclude:: code/coregistration.py
-        :lines: 44-50
+        :lines: 42-48
 
 
 Bias correction
-^^^^^^^^^^^^^^^
+---------------
 :class:`xdem.coreg.BiasCorr`
 
 - **Performs:** (Weighted) bias correction using the mean, median or anything else
@@ -126,16 +126,16 @@ This function is more customizable, for example allowing changing of the bias al
 It should also be faster, since it is a single function call.
 
 Limitations
-***********
+^^^^^^^^^^^
 Only performs vertical corrections, so it should be combined with another approach.
 
 Example
-*******
+^^^^^^^
 .. literalinclude:: code/coregistration.py
-        :lines: 56-66
+        :lines: 54-64
 
 ICP
-^^^
+---
 :class:`xdem.coreg.ICP`
 
 - **Performs:** Rigid transform correction (translation + rotation).
@@ -152,7 +152,7 @@ The opencv implementation of ICP includes outlier removal, since extreme outlier
 This may improve results on noisy data significantly, but care should still be taken, as the risk of landing in `local minima <https://en.wikipedia.org/wiki/Maxima_and_minima>`_ increases.
 
 Limitations
-***********
+^^^^^^^^^^^
 ICP often works poorly on noisy data.
 The outlier removal functionality of the opencv implementation is a step in the right direction, but it still does not compete with other coregistration approaches when the relative rotation is small.
 In cases of high rotation, ICP is the only approach that can account for this properly, but results may need refinement, for example with the `Nuth and Kääb (2011)`_ approach.
@@ -160,19 +160,22 @@ In cases of high rotation, ICP is the only approach that can account for this pr
 Due to the repeated nearest neighbour calculations, ICP is often the slowest coregistration approach out of the alternatives.
 
 Example
-*******
+^^^^^^^
 .. literalinclude:: code/coregistration.py
-        :lines: 72-78
+        :lines: 70-76
+
+.. minigallery:: xdem.coreg.ICP
+        :add-heading:
 
 The CoregPipeline object
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 :class:`xdem.coreg.CoregPipeline`
 
 Often, more than one coregistration approach is necessary to obtain the best results.
 For example, ICP works poorly with large initial biases, so a ``CoregPipeline`` can be constructed to perform both sequentially:
 
 .. literalinclude:: code/coregistration.py
-        :lines: 84-89
+        :lines: 82-87
 
 The ``CoregPipeline`` object exposes the same interface as the ``Coreg`` object.
 The results of a pipeline can be used in other programs by exporting the combined transformation matrix:
@@ -181,11 +184,15 @@ The results of a pipeline can be used in other programs by exporting the combine
 
         pipeline.to_matrix()
 
-
 This class is heavily inspired by the `Pipeline <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html#sklearn-pipeline-pipeline>`_ and `make_pipeline() <https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.make_pipeline.html#sklearn.pipeline.make_pipeline>`_ functionalities in ``scikit-learn``.
 
+
+.. minigallery:: xdem.coreg.CoregPipeline
+        :add-heading:
+
+
 Suggested pipelines
-*******************
+^^^^^^^^^^^^^^^^^^^
 
 For sub-pixel accuracy, the `Nuth and Kääb (2011)`_ approach should almost always be used.
 The approach does not account for rotations in the dataset, however, so a combination is often necessary.

--- a/docs/source/coregistration.rst
+++ b/docs/source/coregistration.rst
@@ -47,17 +47,18 @@ First, ``.fit()`` is called to estimate the transform, and then this transform c
 .. inheritance-diagram:: xdem.coreg
         :top-classes: xdem.coreg.Coreg
 
+.. _coregistration_nuthkaab:
+
+
 Nuth and Kääb (2011)
 ^^^^^^^^^^^^^^^^^^^^
 :class:`xdem.coreg.NuthKaab`
-
-.. _coregistration_nuthkaab:
 
 - **Performs:** translation and bias corrections.
 - **Supports weights** (soon)
 - **Recommended for:** Noisy data with low rotational differences.
 
-The Nuth and Kääb (`2011 <https:https://doi.org/10.5194/tc-5-271-2011>`_) coregistration approach is named after the paper that first implemented it.
+The Nuth and Kääb (`2011 <https://doi.org/10.5194/tc-5-271-2011>`_) coregistration approach is named after the paper that first implemented it.
 It estimates translation and bias corrections iteratively by solving a cosine equation to model the direction at which the DEM is most likely offset.
 First, the DEMs are compared to get a dDEM, and slope/aspect maps are created from the reference DEM.
 Together, these three products contain the information about in which direction the offset is.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,8 @@ Simple usage
    coregistration
    comparison
    spatial_stats
-   api/xdem.rst
+   auto_examples/index.rst
+   api.rst
 
 Indices and tables
 ==================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ Simple usage
         dem1 = xdem.DEM("path/to/first_dem.tif")
         dem2 = xdem.DEM("path/to/second_dem.tif")
 
-        difference = xdem.spatial_tools.subtract_rasters(dem1, dem2)
+        difference = dem1 - dem2
 
 
 
@@ -27,7 +27,6 @@ Simple usage
    :maxdepth: 2
    :caption: Contents:
 
-   tutorials
    coregistration
    comparison
    spatial_stats

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,5 +1,0 @@
-Tutorials
-=========
-
-
-Here there will be tutorials.

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,2 @@
+Examples gallery
+================

--- a/examples/plot_blockwise_coreg.py
+++ b/examples/plot_blockwise_coreg.py
@@ -1,0 +1,104 @@
+"""
+Blockwise coregistration
+========================
+
+Often, biases are spatially variable, and a "global" shift may not be enough to coregister a DEM properly.
+In the :ref:`sphx_glr_auto_examples_plot_nuth_kaab.py` example, we saw that the method improved the alignment significantly, but there were still possibly nonlinear artefacts in the result.
+Clearly, nonlinear coregistration approaches are needed.
+One solution is :class:`xdem.coreg.BlockwiseCoreg`, a helper to run any ``Coreg`` class over an arbitrarily small grid, and then "puppet warp" the DEM to fit the reference best.
+
+The ``BlockwiseCoreg`` class runs in five steps:
+
+1. Generate a subdivision grid to divide the DEM in N blocks.
+2. Run the requested coregistration approach in each block.
+3. Extract each result as a source and destination X/Y/Z point.
+4. Interpolate the X/Y/Z point-shifts into three shift-rasters.
+5. Warp the DEM to apply the X/Y/Z shifts.
+
+"""
+import matplotlib.pyplot as plt
+import geoutils as gu
+import numpy as np
+import xdem
+
+# %%
+# **Example files**
+
+xdem.examples.download_longyearbyen_examples()
+
+reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
+glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+
+# Create a stable ground mask (not glacierized) to mark "inlier data"
+inlier_mask = ~glacier_outlines.create_mask(reference_dem)
+
+plt_extent = [
+    reference_dem.bounds.left,
+    reference_dem.bounds.right,
+    reference_dem.bounds.bottom,
+    reference_dem.bounds.top,
+]
+
+# %%
+# The DEM to be aligned (a 1990 photogrammetry-derived DEM) has some vertical and horizontal biases that we want to avoid, as well as possible nonlinear distortions.
+# The product is a mosaic of multiple DEMs, so "seams" may exist in the data.
+# These can be visualized by plotting a change map:
+
+diff_before = (reference_dem - dem_to_be_aligned).data
+
+plt.figure(figsize=(8, 5))
+plt.imshow(diff_before.squeeze(), cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+plt.colorbar()
+plt.show()
+
+# %%
+# Horizontal and vertical shifts can be estimated using :class:`xdem.coreg.NuthKaab`.
+# Let's prepare a coregistration class that calculates 64 offsets, evenly spread over the DEM.
+
+blockwise = xdem.coreg.BlockwiseCoreg(xdem.coreg.NuthKaab(), subdivision=64)
+
+
+# %%
+# The grid that will be used can be visualized with a helper function.
+# Coregistration will be performed in each block separately.
+
+plt.title("Subdivision grid")
+plt.imshow(blockwise.subdivide_array(dem_to_be_aligned.shape), cmap="gist_ncar")
+plt.show()
+
+# %%
+# Coregistration is performed with the ``.fit()`` method.
+# This runs in multiple threads by default, so more CPU cores are preferable here.
+
+blockwise.fit(reference_dem.data, dem_to_be_aligned.data, transform=reference_dem.transform, inlier_mask=inlier_mask)
+
+aligned_dem_data = blockwise.apply(dem_to_be_aligned.data, transform=dem_to_be_aligned.transform)
+
+# %%
+# The estimated shifts can be visualized by applying the coregistration to a completely flat surface.
+# This shows the estimated shifts that would be applied in elevation; additional horizontal shifts will also be applied if the method supports it.
+# The :func:`xdem.coreg.BlockwiseCoreg.stats` method can be used to annotate each block with its associated Z shift.
+
+z_correction = blockwise.apply(np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform)
+plt.title("Vertical correction")
+plt.imshow(z_correction, cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+for _, row in blockwise.stats().iterrows():
+    plt.annotate(round(row["z_off"], 1), (row["center_x"], row["center_y"]), ha
+="center")
+
+# %%
+# Then, the new difference can be plotted to validate that it improved.
+
+diff_after = reference_dem.data - aligned_dem_data
+
+plt.figure(figsize=(8, 5))
+plt.imshow(diff_after.squeeze(), cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+plt.colorbar()
+plt.show()
+
+# %%
+# We can compare the :ref:`spatial_stats_nmad` to validate numerically that there was an improvment:
+
+print(f"Error before: {xdem.spatial_tools.nmad(diff_before):.2f} m")
+print(f"Error after: {xdem.spatial_tools.nmad(diff_after):.2f} m")

--- a/examples/plot_blockwise_coreg.py
+++ b/examples/plot_blockwise_coreg.py
@@ -27,9 +27,9 @@ import xdem
 
 xdem.examples.download_longyearbyen_examples()
 
-reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
-dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
-glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+reference_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"), silent=True)
+glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 # Create a stable ground mask (not glacierized) to mark "inlier data"
 inlier_mask = ~glacier_outlines.create_mask(reference_dem)

--- a/examples/plot_blockwise_coreg.py
+++ b/examples/plot_blockwise_coreg.py
@@ -16,6 +16,7 @@ The ``BlockwiseCoreg`` class runs in five steps:
 5. Warp the DEM to apply the X/Y/Z shifts.
 
 """
+# sphinx_gallery_thumbnail_number = 2
 import matplotlib.pyplot as plt
 import geoutils as gu
 import numpy as np

--- a/examples/plot_dem_subtraction.py
+++ b/examples/plot_dem_subtraction.py
@@ -1,0 +1,60 @@
+"""
+DEM subtraction
+===============
+
+Subtracting one DEM with another should be easy!
+This is why ``xdem`` (with functionality from `geoutils <https://geoutils.readthedocs.io>`_) allows directly using the ``-`` or ``+`` operators on :class:`xdem.DEM` objects.
+
+Before DEMs can be compared, they need to be reprojected/resampled/cropped to fit the same grid.
+The :func:`xdem.DEM.reproject` method takes care of this.
+
+"""
+import matplotlib.pyplot as plt
+import xdem
+
+
+# %%
+
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), silent=True)
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem_coreg"), silent=True)
+
+# %%
+# We can print the information about the DEMs for a "sanity check"
+
+print(dem_2009)
+print(dem_1990)
+
+# %%
+# In this particular case, the two DEMs are already on the same grid (they have the same bounds, resolution and coordinate system).
+# If they don't, we need to reproject one DEM to fit the other.
+# :func:`xdem.DEM.reproject` is a multi-purpose method that ensures a fit each time:
+
+_ = dem_1990.reproject(dem_2009)
+
+# %%
+# Oops!
+# ``xdem`` just warned us that ``dem_1990`` did not need reprojection, but we asked it to anyway.
+# To hide this prompt, add ``.reproject(..., silent=True)``.
+# By default, :func:`xdem.DEM.reproject` uses "nearest neighbour" resampling (assuming resampling is needed).
+# This approach is great for speed, but it may often be erroneous when resampling.
+# Other more accurate methods are "bilinear", "cubic_spline" and others.
+# See `geoutils.Raster.reproject() <https://geoutils.readthedocs.io/en/latest/api.html#geoutils.georaster.Raster.reproject>`_ and `rasterio.enums.Resampling <https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html#rasterio.enums.Resampling>`_ for more information about reprojection.
+#
+# Now, we are ready to generate the dDEM:
+
+ddem = dem_2009 - dem_1990
+
+print(ddem)
+
+# %%
+# It is a new :class:`xdem.DEM` instance, loaded in memory.
+# Let's visualize it:
+
+plt.figure(figsize=(8, 5))
+plt.imshow(ddem.data.squeeze(), cmap="coolwarm_r", vmin=-20, vmax=20)
+
+plt.show()
+
+# %%
+# ... and that's it!
+# For missing values, ``xdem`` provides a number of interpolation methods which are shown in the other examples.

--- a/examples/plot_demcollection.py
+++ b/examples/plot_demcollection.py
@@ -49,7 +49,7 @@ dem_2060.datetime = datetime(2060, 8, 1)
 # 2. Two glacier outline timestamps from 1990 and 2009
 #
 
-demcollection = xdem.DEMCollection(dems=[dem_1990, dem_2009, dem_2060], outlines=outlines, reference_dem=dem_2009)
+demcollection = xdem.DEMCollection(dems=[dem_1990, dem_2009, dem_2060], outlines=outlines, reference_dem=1)
 
 
 # %%

--- a/examples/plot_demcollection.py
+++ b/examples/plot_demcollection.py
@@ -1,0 +1,111 @@
+"""
+Working with a collection of DEMs
+=================================
+
+Oftentimes, more than two timestamps (DEMs) are analyzed simultaneously.
+One single dDEM only captures one interval, so multiple dDEMs have to be created.
+In addition, if multiple masking polygons exist (e.g. glacier outlines from multiple years), these should be accounted for properly.
+The :class:`xdem.DEMCollection` is a tool to properly work with multiple timestamps at the same time, and makes calculations of elevation/volume change over multiple years easy.
+"""
+
+from datetime import datetime
+
+import geoutils as gu
+import matplotlib.pyplot as plt
+
+import xdem
+
+# %%
+# **Example data**.
+#
+# We can load the DEMs as usual, but with the addition that the ``datetime`` argument should be filled.
+# Since multiple DEMs are in question, the "time dimension" is what keeps them apart.
+
+dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), datetime=datetime(2009, 8, 1), silent=True)
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"), datetime=datetime(1990, 8, 1), silent=True)
+
+
+# %%
+# For glacier research (any many other fields), only a subset of the DEMs are usually interesting.
+# These parts can be delineated with masks or polygons.
+# Here, we have glacier outlines from 1990 and 2009.
+outlines = {
+    datetime(1990, 8, 1): gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines")),
+    datetime(2009, 8, 1): gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines_2010")),
+}
+
+# %%
+# To experiment with a longer time-series, we can also fake a 2060 DEM, by simply exaggerating the 1990-2009 change.
+
+# Fake a 2060 DEM by assuming twice the change from 1990-2009 between 2009 and 2060
+dem_2060 = dem_2009 + (dem_2009 - dem_1990).data * 3
+dem_2060.datetime = datetime(2060, 8, 1)
+
+
+# %%
+# Now, all data are ready to be collected in an :class:`xdem.DEMCollection` object.
+# What we have are:
+# 1. Three DEMs from 1990, 2009, and 2060 (the last is artificial)
+# 2. Two glacier outline timestamps from 1990 and 2009
+#
+
+demcollection = xdem.DEMCollection(dems=[dem_1990, dem_2009, dem_2060], outlines=outlines, reference_dem=dem_2009)
+
+
+# %%
+# We can generate :class:`xdem.dDEM` objects using :func:`xdem.DEMCollection.subtract_dems`.
+# In this case, it will generate three dDEMs:
+#
+# * 1990-2009
+# * 2009-2009  (to maintain the ``dems`` and ``ddems`` list length and order)
+# * 2060-2009 (note the inverted order; negative change will be positive)
+
+_ = demcollection.subtract_dems()
+
+# %%
+# These are saved internally, but are also returned as a list.
+#
+# An elevation or volume change series can automatically be generated from the ``DEMCollection``.
+# In this case, we should specify *which* glacier we want the change for, as a regional value may not always be required.
+# We can look at the glacier called "Scott Turnerbreen", specified in the "NAME" column of the outline data.
+# `See here for the outline filtering syntax <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html>`_.
+
+demcollection.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")
+
+# %%
+# And there we have a cumulative dH series of the glacier Scott Turnerbreen on Svalbard!
+# The dDEMs can be visualized to give further context.
+
+extent = [
+    demcollection.dems[0].bounds.left,
+    demcollection.dems[0].bounds.right,
+    demcollection.dems[0].bounds.bottom,
+    demcollection.dems[0].bounds.top,
+]
+
+scott_extent = [
+        518600, 
+        523800,
+        8666600,
+        8672300
+]
+
+plt.figure(figsize=(8, 5))
+
+for i in range(2):
+    plt.subplot(1, 2, i + 1)
+
+    if i == 0:
+        title = "1990 - 2009"
+        ddem_2060 = demcollection.ddems[0].data.squeeze()
+    else:
+        title = "2009 - 2060"
+        # The 2009 - 2060 DEM is inverted since the reference year is 2009
+        ddem_2060 = -demcollection.ddems[2].data.squeeze()
+
+    plt.imshow(ddem_2060, cmap="coolwarm_r", vmin=-50, vmax=50, extent=extent)
+    plt.xlim(scott_extent[:2])
+    plt.ylim(scott_extent[2:])
+
+plt.show()
+

--- a/examples/plot_icp_coregistration.py
+++ b/examples/plot_icp_coregistration.py
@@ -1,0 +1,102 @@
+"""
+Iterative Closest Point (ICP) coregistration.
+=============================================
+Some DEMs may for one or more reason be erroneously rotated in the X, Y or Z directions.
+Established coregistration approaches like :ref:`coregistration_nuthkaab` work great for X, Y and Z *translations*, but rotation is not accounted for at all.
+
+ICP is one method that takes both rotation and translation into account.
+It is however not as good as :ref:`coregistration_nuthkaab` when it comes to sub-pixel accuracy.
+Fortunately, ``xdem`` provides the best of two worlds by allowing a combination of the two.
+"""
+# sphinx_gallery_thumbnail_number = 2
+import matplotlib.pyplot as plt
+import numpy as np
+
+import xdem
+
+# %%
+# Let's load a DEM and crop it to a single mountain on Svalbard, called Battfjellet.
+# Its aspects vary in every direction, and is therefore a good candidate for coregistration exercises.
+dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), silent=True)
+
+subset_extent = [523000, 8660000, 529000, 8665000]
+dem.crop(subset_extent)
+
+# %%
+# Let's plot a hillshade of the mountain for context.
+plt_extent = [subset_extent[0], subset_extent[2], subset_extent[1], subset_extent[3]]
+
+plt.imshow(xdem.spatial_tools.hillshade(dem.data, resolution=dem.res), cmap="Greys_r", extent=plt_extent)
+plt.show()
+
+# %%
+# To try the effects of rotation, we can artificially rotate the DEM using a transformation matrix.
+# Here, a rotation of just one degree is attempted.
+# But keep in mind: the window is 6 km wide; 1 degree of rotation at the center equals to a 52 m vertical difference at the edges!
+
+rotation = np.deg2rad(1)
+rotation_matrix = np.array(
+    [
+        [np.cos(rotation), 0, np.sin(rotation), 0],
+        [0, 1, 0, 0],
+        [-np.sin(rotation), 0, np.cos(rotation), 0],
+        [0, 0, 0, 1],
+    ]
+)
+
+# This will apply the matrix along the center of the DEM
+rotated_dem = xdem.coreg.apply_matrix(dem.data.squeeze(), transform=dem.transform, matrix=rotation_matrix)
+
+
+# %%
+# We can plot the difference between the original and rotated DEM.
+# It is now artificially tilting from east down to the west.
+diff_before = dem.data - rotated_dem
+plt.imshow(diff_before.squeeze(), cmap="coolwarm_r", vmin=-20, vmax=20, extent=plt_extent)
+
+plt.show()
+
+# %%
+# As previously mentioned, ``NuthKaab`` works well on sub-pixel scale but does not handle rotation.
+# ``ICP`` works with rotation but lacks the sub-pixel accuracy.
+# Luckily, these can be combined!
+# Any :class:`xdem.coreg.Coreg` subclass can be added with another, making a :class:`xdem.coreg.CoregPipeline`.
+# With a pipeline, each step is run sequentially, potentially leading to a better result.
+# Let's try all three approaches: ``ICP``, ``NuthKaab`` and ``ICP + NuthKaab``.
+
+approaches = [
+    (xdem.coreg.ICP(), "ICP"),
+    (xdem.coreg.NuthKaab(), "NuthKaab"),
+    (xdem.coreg.ICP() + xdem.coreg.NuthKaab(), "ICP + NuthKaab"),
+]
+
+
+plt.figure(figsize=(6, 12))
+
+for i, (approach, name) in enumerate(approaches):
+    approach.fit(
+        reference_dem=dem.data,
+        dem_to_be_aligned=rotated_dem,
+        transform=dem.transform,
+    )
+
+    corrected_dem_data = approach.apply(dem=rotated_dem, transform=dem.transform)
+
+    diff = dem.data - corrected_dem_data
+
+    plt.subplot(3, 1, i + 1)
+    plt.title(name)
+    plt.imshow(diff.squeeze(), cmap="coolwarm_r", vmin=-20, vmax=20, extent=plt_extent)
+
+plt.tight_layout()
+plt.show()
+
+
+# %%
+# The results show what we expected:
+#
+# * ``ICP`` alone handled the rotational offset, but left a horizontal offset as it is not sub-pixel accurate (in this case, the resolution is 20x20m).
+# * ``NuthKaab`` barely helped at all, since the offset is purely rotational.
+# * ``ICP + NuthKaab`` first handled the rotation, then fit the reference with sub-pixel accuracy.
+#
+# The last result is an almost identical raster that was offset but then corrected back to its original position!

--- a/examples/plot_norm_regional_hypso.py
+++ b/examples/plot_norm_regional_hypso.py
@@ -2,7 +2,28 @@
 Normalized regional hypsometric interpolation
 =============================================
 
+There are many ways of interpolating gaps in a dDEM.
+In the case of glaciers, one very useful fact is that elevation change is generally varies with elevation.
+This means that if valid pixels exist in a certain elevation bin, their values can be used to fill other pixels in the same approximate elevation.
+Filling gaps by elevation is the main basis of "hypsometric interpolation approaches", of which there are many variations of.
 
+One problem with simple hypsometric approaches is that they may not work glaciers with different elevation ranges and scales.
+Let's say we have two glaciers: one gigantic reaching from 0-1000 m, and one small from 900-1100 m.
+Usually in the 2000s, glaciers thin rapidly at the bottom, while they may be neutral or only thin slightly in the top.
+If we extrapolate the hypsometric signal of the gigantic glacier to use on the small one, it may seem like the smaller glacier has almost no change whatsoever.
+This may be right, or it may be catastrophically wrong!
+
+Normalized regional hypsometric interpolation solves the scale and elevation range problems in one go. It:
+
+    1. Calculates a regional signal using the weighted average of each glacier's normalized signal:
+
+        a. The glacier's elevation range is scaled from 0-1 to be elevation-independent.
+        b. The glaciers elevation change is scaled from 0-1 to be magnitude-independent.
+        c. A weight is assigned by the amount of valid pixels (well-covered large glaciers gain a higher weight)
+
+    2. Re-scales that signal to fit each glacier once determined.
+
+The consequence is a much more accurate interpolation approach that can be used in a multitude of glacierized settings.
 
 """
 # sphinx_gallery_thumbnail_number = 2

--- a/examples/plot_norm_regional_hypso.py
+++ b/examples/plot_norm_regional_hypso.py
@@ -1,0 +1,106 @@
+"""
+Normalized regional hypsometric interpolation
+=============================================
+
+
+
+"""
+# sphinx_gallery_thumbnail_number = 2
+import matplotlib.pyplot as plt
+
+import numpy as np
+import xdem
+import xdem.misc
+import geoutils as gu
+
+# %%
+# **Example files**
+
+xdem.examples.download_longyearbyen_examples()
+
+dem_2009 = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
+dem_1990_non_coreg = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
+glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+
+# Rasterize the glacier outlines to create an index map.
+# Stable ground is 0, the first glacier is 1, the second is 2, etc.
+glacier_index_map = glacier_outlines.rasterize(dem_2009)
+
+# Coregister the DEM. TODO: This should be fetched from @rhugonnet's new function.
+coreg = xdem.coreg.NuthKaab()
+coreg.fit(dem_2009.data, dem_1990_non_coreg.data, transform=dem_1990_non_coreg.transform, inlier_mask=glacier_index_map == 0)
+
+dem_1990_data = coreg.apply(dem_1990_non_coreg.data, transform=dem_1990_non_coreg.transform)
+
+plt_extent = [
+    dem_2009.bounds.left,
+    dem_2009.bounds.right,
+    dem_2009.bounds.bottom,
+    dem_2009.bounds.top,
+]
+
+
+# %%
+# To test the method, we can generate a semi-random mask to assign nans to glacierized areas.
+# Let's remove 30% of the data.
+np.random.seed(42)
+random_nans = (xdem.misc.generate_random_field(dem_1990_data.shape, corr_size=5) > 0.7) & (glacier_index_map > 0)
+
+plt.imshow(random_nans)
+plt.show()
+
+# %%
+# The normalized hypsometric signal shows the tendency for elevation change as a function of elevation.
+# The magnitude may vary between glaciers, but the shape is generally similar.
+# Normalizing by both elevation and elevation change, and then re-scaling the signal to every glacier, ensures that it is as accurate as possible.
+# **NOTE**: The hypsometric signal does not need to be generated separately; it will be created by :func:`xdem.volume.norm_regional_hypsometric_interpolation`.
+# Generating it first, however, allows us to visualize and validate it.
+
+ddem = dem_2009.data - dem_1990_data
+ddem_voided = np.where(random_nans, np.nan, ddem)
+
+signal = xdem.volume.get_regional_hypsometric_signal(
+    ddem=ddem_voided,
+    ref_dem=dem_2009.data,
+    glacier_index_map=glacier_index_map,
+)
+
+plt.fill_between(signal.index.mid, signal["sigma-1-lower"], signal["sigma-1-upper"], label="Spread (+- 1 sigma)")
+plt.plot(signal.index.mid, signal["w_mean"], color="black", label="Weighted mean")
+plt.ylabel("Normalized elevation change")
+plt.xlabel("Normalized elevation")
+plt.legend()
+plt.show()
+
+# %%
+# The signal can now be used (or simply estimated again if not provided) to interpolate the DEM.
+
+ddem_filled = xdem.volume.norm_regional_hypsometric_interpolation(
+    voided_ddem=ddem_voided,
+    ref_dem=dem_2009.data,
+    glacier_index_map=glacier_index_map,
+    regional_signal=signal
+)
+
+
+plt.figure(figsize=(8, 5))
+plt.imshow(ddem_filled, cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+plt.colorbar()
+plt.show()
+
+
+# %%
+# We can plot the difference between the actual and the interpolated values, to validate the method.
+
+difference = (ddem_filled - ddem).squeeze()[random_nans].filled(np.nan)
+median = np.nanmedian(difference)
+nmad = xdem.spatial_tools.nmad(difference)
+
+plt.title(f"Median: {median:.2f} m, NMAD: {nmad:.2f} m")
+plt.hist(difference, bins=np.linspace(-15, 15, 100))
+plt.show()
+
+# %%
+# As we see, the median is close to zero, while the :ref:`spatial_stats_nmad` varies slightly more.
+# This is expected, as the regional signal is good for multiple glaciers at once, but it cannot account for difficult local topography and meteorological conditions.
+# It is therefore highly recommended for large regions; just don't zoom in too close!

--- a/examples/plot_norm_regional_hypso.py
+++ b/examples/plot_norm_regional_hypso.py
@@ -40,7 +40,7 @@ import geoutils as gu
 xdem.examples.download_longyearbyen_examples()
 
 dem_2009 = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), silent=True)
-dem_1990 = dem_2009 - xdem.DEM(xdem.examples.get_path("longyearbyen_ddem"))
+dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem_coreg"), silent=True)
 
 glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 

--- a/examples/plot_nuth_kaab.py
+++ b/examples/plot_nuth_kaab.py
@@ -14,12 +14,9 @@ import xdem
 
 # %%
 # **Example files**
-
-xdem.examples.download_longyearbyen_examples()
-
-reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
-dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
-glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+reference_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"), silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"), silent=True)
+glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 # Create a stable ground mask (not glacierized) to mark "inlier data"
 inlier_mask = ~glacier_outlines.create_mask(reference_dem)

--- a/examples/plot_nuth_kaab.py
+++ b/examples/plot_nuth_kaab.py
@@ -68,3 +68,8 @@ plt.show()
 
 print(f"Error before: {xdem.spatial_tools.nmad(diff_before):.2f} m")
 print(f"Error after: {xdem.spatial_tools.nmad(diff_after):.2f} m")
+
+# %%
+# In the plot above, one may notice a positive (blue) tendency toward the east.
+# The 1990 DEM is a mosaic, and likely has a "seam" near there.
+# :ref:`sphx_glr_auto_examples_plot_blockwise_coreg.py` tackles this issue, using a nonlinear coregistration approach.

--- a/examples/plot_nuth_kaab.py
+++ b/examples/plot_nuth_kaab.py
@@ -1,0 +1,68 @@
+"""
+Nuth & Kääb (2011) coregistration
+=================================
+
+Nuth and Kääb (`2011 <https:https://doi.org/10.5194/tc-5-271-2011>`_) coregistration allows for horizontal and vertical shifts to be estimated and corrected for.
+In ``xdem``, this approach is implemented through the :class:`xdem.coreg.NuthKaab` class.
+
+For more information about the approach, see :ref:`coregistration_nuthkaab`.
+"""
+import geoutils as gu
+import matplotlib.pyplot as plt
+
+import xdem
+
+# %%
+# **Example files**
+
+reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
+dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
+glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])
+
+# Create a stable ground mask (not glacierized) to mark "inlier data"
+inlier_mask = ~glacier_outlines.create_mask(reference_dem)
+
+plt_extent = [
+    reference_dem.bounds.left,
+    reference_dem.bounds.right,
+    reference_dem.bounds.bottom,
+    reference_dem.bounds.top,
+]
+
+# %%
+# The DEM to be aligned (a 1990 photogrammetry-derived DEM) has some vertical and horizontal biases that we want to avoid.
+# These can be visualized by plotting a change map:
+
+diff_before = (reference_dem - dem_to_be_aligned).data
+
+plt.figure(figsize=(8, 5))
+plt.imshow(diff_before.squeeze(), cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+plt.colorbar()
+plt.show()
+
+
+# %%
+# Horizontal and vertical shifts can be estimated using :class:`xdem.coreg.NuthKaab`.
+# First, the shifts are estimated, and then they can be applied to the data:
+
+nuth_kaab = xdem.coreg.NuthKaab()
+
+nuth_kaab.fit(reference_dem.data, dem_to_be_aligned.data, inlier_mask, transform=reference_dem.transform)
+
+aligned_dem_data = nuth_kaab.apply(dem_to_be_aligned.data, transform=dem_to_be_aligned.transform)
+
+# %%
+# Then, the new difference can be plotted to validate that it improved.
+
+diff_after = reference_dem.data - aligned_dem_data
+
+plt.figure(figsize=(8, 5))
+plt.imshow(diff_after.squeeze(), cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
+plt.colorbar()
+plt.show()
+
+# %%
+# We can compare the :ref:`spatial_stats_nmad` to validate numerically that there was an improvment:
+
+print(f"Error before: {xdem.spatial_tools.nmad(diff_before):.2f} m")
+print(f"Error after: {xdem.spatial_tools.nmad(diff_after):.2f} m")

--- a/examples/plot_nuth_kaab.py
+++ b/examples/plot_nuth_kaab.py
@@ -15,6 +15,8 @@ import xdem
 # %%
 # **Example files**
 
+xdem.examples.download_longyearbyen_examples()
+
 reference_dem = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_ref_dem"], silent=True)
 dem_to_be_aligned = xdem.DEM(xdem.examples.FILEPATHS["longyearbyen_tba_dem"], silent=True)
 glacier_outlines = gu.Vector(xdem.examples.FILEPATHS["longyearbyen_glacier_outlines"])

--- a/xdem/__init__.py
+++ b/xdem/__init__.py
@@ -1,3 +1,4 @@
+"""xdem"""
 from . import coreg, dem, examples, spatial_tools, spstats, volume, filters
 from .ddem import dDEM
 from .dem import DEM

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -537,8 +537,13 @@ class Coreg:
         except NotImplementedError:
             if self.is_affine:  # This only works on it's affine, however.
                 # Apply the matrix around the centroid (if defined, otherwise just from the center).
-                applied_dem = apply_matrix(dem_array, transform=transform,
-                                           matrix=self.to_matrix(), centroid=self._meta.get("centroid"))
+                applied_dem = apply_matrix(
+                    dem_array,
+                    transform=transform,
+                    matrix=self.to_matrix(),
+                    centroid=self._meta.get("centroid"),
+                    dilate_mask=True
+                )
             else:
                 raise ValueError("Coreg method is non-rigid but has no implemented _apply_func")
 
@@ -1400,7 +1405,7 @@ def apply_matrix(dem: np.ndarray, transform: rio.transform.Affine, matrix: np.nd
         mode="constant",
         cval=1,
         preserve_range=True
-    ) > 0.5  # Due to different interpolation approaches, everything above 0.5 is assumed to be 1 (True)
+    ) > 0.25  # Due to different interpolation approaches, everything above 0.25 is assumed to be 1 (True)
 
     if dilate_mask:
         tr_nan_mask = scipy.ndimage.morphology.binary_dilation(tr_nan_mask, iterations=resampling_order)

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -24,7 +24,10 @@ FILEPATHS_DATA = {
         "Longyearbyen","data","glacier_mask","CryoClim_GAO_SJ_2010.shp"
     )}
 
-FILEPATHS_PROCESSED = {"longyearbyen_ddem": os.path.join(EXAMPLES_DIRECTORY,"Longyearbyen","processed","dDEM_2009_minus_1990.tif")}
+FILEPATHS_PROCESSED = {
+    "longyearbyen_ddem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen","processed","dDEM_2009_minus_1990.tif"),
+    "longyearbyen_tba_dem_coreg": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "processed", "DEM_1990_coreg.tif")
+}
 
 
 def download_longyearbyen_examples(overwrite: bool = False):
@@ -113,12 +116,27 @@ def process_coregistered_examples(overwrite: bool =False):
     mkdir_p(os.path.dirname(FILEPATHS_PROCESSED['longyearbyen_ddem']))
     diff.save(FILEPATHS_PROCESSED['longyearbyen_ddem'])
 
+
+def _get_longyearbyen_tba_coreg_dem() -> str:
+    if not os.path.isfile(FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"]):
+        dem_2009 = xdem.DEM(get_path("longyearbyen_ref_dem"), silent=True)
+        ddem = xdem.DEM(get_path("longyearbyen_ddem"), silent=True)
+
+        (dem_2009 - ddem).save(FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"])
+
+    return FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"]
+
+
+
 def get_path(name: str) -> str:
     """
     Get path of example data
     :param name: Name of test data (listed in xdem/examples.py)
     :return:
     """
+    if name == "longyearbyen_tba_dem_coreg":
+        return _get_longyearbyen_tba_coreg_dem()
+
     if name in list(FILEPATHS_DATA.keys()):
         download_longyearbyen_examples()
         return FILEPATHS_DATA[name]


### PR DESCRIPTION
The example gallery seems to be working!

Now, an example in the `examples/` directory will show up in the `Example gallery`, and will link to the API if a function from xdem is used. It will also link to the documentation of `geoutils`, `numpy` and `matplotlib` (more can be added).

There are only two weird things:

- Things defined in the `__init__` does not really work (at least now; I'm sure it's fixable). Therefore, `xdem.DEM` refers to `gu.Raster` (since it can't find the definition of `xdem.DEM`). EDIT: This is now fixed!
- Each example has to be prepended with `plot_` in order to actually execute. This is according to https://github.com/sphinx-gallery/sphinx-gallery, and might be possible to circumvent. Still, I think it's a nice way to know which functions will run and which will only render as notebook-like code.

Here's the documentation!
https://xdem-erikm.readthedocs.io/en/example-gallery/index.html