### PR TITLE
Add N-dimensional linear interpolation

### DIFF
--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -254,3 +254,96 @@ class TestBinning:
         # dataframe should contain three 1D binning of length 10 and three 2D binning of length 100 and one 2D binning of length 1000
         assert df.shape[0] == (1000 + 3 * 100 + 3 * 10)
 
+
+    def test_interp_nd_binning(self):
+
+        # check the function works with a classic input (see example
+        df = pd.DataFrame({"var1": [1, 1, 1, 2, 2, 2, 3, 3, 3], "var2": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+                                "statistic": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
+        arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((3,3))
+        fun = xdem.spstats.interp_nd_binning(df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None)
+
+        # check interpolation falls right on values for points (1, 1), (1, 2) etc...
+        for i in range(3):
+            for j in range(3):
+                x = df['var1'][3 * i + j]
+                y = df['var2'][3 * i + j]
+                stat = df['statistic'][3 * i + j]
+                assert fun((y, x)) == stat
+
+        # check bilinear interpolation inside the grid
+        points_in = [(1.5, 1.5), (1.5, 2.5), (2.5, 1.5), (2.5, 2.5)]
+        for point in points_in:
+            # the values are 1 off from Python indexes
+            x = point[0] - 1
+            y = point[1] - 1
+            # get four closest points on the grid
+            xlow = int(x - 0.5)
+            xupp = int(x + 0.5)
+            ylow = int(y - 0.5)
+            yupp = int(y + 0.5)
+            # check the bilinear interpolation matches the mean value of those 4 points (equivalent as its the middle)
+            assert fun((y + 1, x + 1)) == np.mean([arr[xlow, ylow], arr[xupp, ylow], arr[xupp, yupp], arr[xlow, yupp]])
+
+        # check bilinear extrapolation for points at 1 spacing outside from the input grid
+        points_out = [(0, i) for i in np.arange(1, 4)] + [(i, 0) for i in np.arange(1, 4)] \
+                     + [(4, i) for i in np.arange(1, 4)] + [(i, 4) for i in np.arange(4, 1)]
+        for point in points_out:
+            x = point[0] - 1
+            y = point[1] - 1
+            val_extra = fun((y + 1, x + 1))
+            # the difference between the points extrapolated outside should be linear with the grid edges,
+            # i.e. the same as the difference as the first points inside the grid along the same axis
+            if point[0] == 0:
+                diff_in = arr[x + 2, y] - arr[x + 1, y]
+                diff_out = arr[x + 1, y] - val_extra
+            elif point[0] == 4:
+                diff_in = arr[x - 2, y] - arr[x - 1, y]
+                diff_out = arr[x - 1, y] - val_extra
+            elif point[1] == 0:
+                diff_in = arr[x, y + 2] - arr[x, y + 1]
+                diff_out = arr[x, y + 1] - val_extra
+            # has to be y == 4
+            else:
+                diff_in = arr[x, y - 2] - arr[x, y - 1]
+                diff_out = arr[x, y - 1] - val_extra
+            assert diff_in == diff_out
+
+        # check if it works with nd_binning output
+        ref, diff, mask = load_ref_and_diff()
+        slope, aspect = xdem.coreg.calculate_slope_and_aspect(ref.data.squeeze())
+
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten(),aspect.flatten()],list_var_names=['slope','elevation','aspect'])
+
+        # in 1d
+        fun = xdem.spstats.interp_nd_binning(df, list_var_names='slope')
+
+        # check a value is returned inside the grid
+        assert np.isfinite(fun([15]))
+        # check the nmad increases with slope
+        assert fun([20]) > fun([0])
+        # check a value is returned outside the grid
+        assert all(np.isfinite(fun([-5,50])))
+
+        # in 2d
+        fun = xdem.spstats.interp_nd_binning(df, list_var_names=['slope','elevation'])
+
+        # check a value is returned inside the grid
+        assert np.isfinite(fun([15, 1000]))
+        # check the nmad increases with slope
+        assert fun([20, 1000]) > fun([0, 1000])
+        # check a value is returned outside the grid
+        assert all(np.isfinite(fun(([-5, 50],[-500,3000]))))
+
+        # in 3d, let's decrease the number of bins to get something with enough samples
+        df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten(),aspect.flatten()],list_var_names=['slope','elevation','aspect'], list_var_bins=3)
+        fun = xdem.spstats.interp_nd_binning(df, list_var_names=['slope','elevation','aspect'])
+
+        # check a value is returned inside the grid
+        assert np.isfinite(fun([15,1000, np.pi]))
+        # check the nmad increases with slope
+        assert fun([20, 1000, np.pi]) > fun([0, 1000, np.pi])
+        # check a value is returned outside the grid
+        assert all(np.isfinite(fun(([-5, 50],[-500,3000],[-2*np.pi,4*np.pi]))))
+
+

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -254,10 +254,9 @@ class TestBinning:
         # dataframe should contain three 1D binning of length 10 and three 2D binning of length 100 and one 2D binning of length 1000
         assert df.shape[0] == (1000 + 3 * 100 + 3 * 10)
 
-
     def test_interp_nd_binning(self):
 
-        # check the function works with a classic input (see example
+        # check the function works with a classic input (see example)
         df = pd.DataFrame({"var1": [1, 1, 1, 2, 2, 2, 3, 3, 3], "var2": [1, 2, 3, 1, 2, 3, 1, 2, 3],
                                 "statistic": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
         arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((3,3))

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -3,14 +3,13 @@ xdem.spstats provides tools to use spatial statistics for elevation change data
 """
 from __future__ import annotations
 
-import itertools
 import math as m
 import multiprocessing as mp
 import os
 import random
 import warnings
 from functools import partial
-from typing import Callable, Union, Iterable, Optional, Sequence
+from typing import Callable, Union, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -18,7 +17,6 @@ import pandas as pd
 from scipy import integrate
 from scipy.optimize import curve_fit
 from skimage.draw import disk
-from scipy.stats import binned_statistic, binned_statistic_2d, binned_statistic_dd
 from scipy.interpolate import RegularGridInterpolator, LinearNDInterpolator, griddata
 from xdem.spatial_tools import nmad
 
@@ -26,105 +24,6 @@ with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import skgstat as skg
     from skgstat import models
-
-def nd_binning(values: np.ndarray, list_var: Iterable[np.ndarray], list_var_names=Iterable[str], list_var_bins: Optional[Union[int,Iterable[Iterable]]] = None,
-                     statistics: Iterable[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[Iterable[Sequence]] = None) \
-        -> pd.DataFrame:
-    """
-    N-dimensional binning of values according to one or several explanatory variables.
-    Values input is a (N,) array and variable input is a list of flattened arrays of similar dimensions (N,).
-    For more details on the format of input variables, see documentation of scipy.stats.binned_statistic_dd.
-
-    :param values: values array (N,)
-    :param list_var: list (L) of explanatory variables array (N,)
-    :param list_var_names: list (L) of names of the explanatory variables
-    :param list_var_bins: count, or list (L) of counts or custom bin edges for the explanatory variables; defaults to 10 bins
-    :param statistics: list (X) of statistics to be computed; defaults to count, median and nmad
-    :param list_ranges: list (L) of minimum and maximum ranges to bin the explanatory variables; defaults to min/max of the data
-    :return: dataframe of binned values according to explanatory variables for all possibles combinations in 1d, 2d and nd
-    """
-
-    # we separate 1d, 2d and nd binning, because propagating statistics between different dimensional binning is not always feasible
-    # using scipy because it allows for several dimensional binning, while it's not straightforward in pandas
-    if list_var_bins is None:
-        list_var_bins = (10,) * len(list_var_names)
-    elif isinstance(list_var_bins,int):
-        list_var_bins = (list_var_bins,) * len(list_var_names)
-
-    # flatten the arrays if this has not been done by the user
-    values = values.ravel()
-    list_var = [var.ravel() for var in list_var]
-
-    statistics_name = [f if isinstance(f,str) else f.__name__ for f in statistics]
-
-    # get binned statistics in 1d: a simple loop is sufficient
-    list_df_1d = []
-    for i, var in enumerate(list_var):
-        df_stats_1d = pd.DataFrame()
-        # get statistics
-        for j, statistic in enumerate(statistics):
-            stats_binned_1d, bedges_1d = binned_statistic(var,values,statistic=statistic,bins=list_var_bins[i],range=list_ranges)[:2]
-            # save in a dataframe
-            df_stats_1d[statistics_name[j]] = stats_binned_1d
-        # we need to get the middle of the bins from the edges, to get the same dimension length
-        df_stats_1d[list_var_names[i]] = pd.IntervalIndex.from_breaks(bedges_1d,closed='left')
-        # report number of dimensions used
-        df_stats_1d['nd'] = 1
-
-        list_df_1d.append(df_stats_1d)
-
-    # get binned statistics in 2d: all possible 2d combinations
-    list_df_2d = []
-    if len(list_var)>1:
-        combs = list(itertools.combinations(list_var_names, 2))
-        for i, comb in enumerate(combs):
-            var1_name, var2_name = comb
-            # corresponding variables indexes
-            i1, i2 = list_var_names.index(var1_name), list_var_names.index(var2_name)
-            df_stats_2d = pd.DataFrame()
-            for j, statistic in enumerate(statistics):
-                stats_binned_2d, bedges_var1, bedges_var2 = binned_statistic_2d(list_var[i1],list_var[i2],values,statistic=statistic
-                                                             ,bins=[list_var_bins[i1],list_var_bins[i2]]
-                                                             ,range=list_ranges)[:3]
-                # get statistics
-                df_stats_2d[statistics_name[j]] = stats_binned_2d.flatten()
-            # derive interval indexes and convert bins into 2d indexes
-            ii1 = pd.IntervalIndex.from_breaks(bedges_var1,closed='left')
-            ii2 = pd.IntervalIndex.from_breaks(bedges_var2,closed='left')
-            df_stats_2d[var1_name] = [i1 for i1 in ii1 for i2 in ii2]
-            df_stats_2d[var2_name] = [i2 for i1 in ii1 for i2 in ii2]
-            # report number of dimensions used
-            df_stats_2d['nd'] = 2
-
-            list_df_2d.append(df_stats_2d)
-
-
-    # get binned statistics in nd, without redoing the same stats
-    df_stats_nd = pd.DataFrame()
-    if len(list_var)>2:
-        for j, statistic in enumerate(statistics):
-            stats_binned_2d, list_bedges = binned_statistic_dd(list_var,values,statistic=statistic,bins=list_var_bins,range=list_ranges)[0:2]
-            df_stats_nd[statistics_name[j]] = stats_binned_2d.flatten()
-        list_ii = []
-        # loop through the bin edges and create IntervalIndexes from them (to get both
-        for bedges in list_bedges:
-            list_ii.append(pd.IntervalIndex.from_breaks(bedges,closed='left'))
-
-        # create nd indexes in nd-array and flatten for each variable
-        iind = np.meshgrid(*list_ii)
-        for i, var_name in enumerate(list_var_names):
-            df_stats_nd[var_name] = iind[i].flatten()
-
-        # report number of dimensions used
-        df_stats_nd['nd'] = len(list_var_names)
-
-    # concatenate everything
-    list_all_dfs = list_df_1d + list_df_2d + [df_stats_nd]
-    df_concat = pd.concat(list_all_dfs)
-    # commenting for now: pd.MultiIndex can be hard to use
-    # df_concat = df_concat.set_index(list_var_names)
-
-    return df_concat
 
 def robust_interp_nd_binning(df: pd.DataFrame, var_names: list[str], statistic : Union[str, Callable, None] = nmad, min_count: Optional[int] = 100) -> Callable:
     """

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -25,7 +25,7 @@ with warnings.catch_warnings():
     import skgstat as skg
     from skgstat import models
 
-def interp_nd_binning(df: pd.DataFrame, list_var_names: Union[str,list[str]], statistic : Union[str, Callable[[np.ndarray],float], None] = nmad,
+def interp_nd_binning(df: pd.DataFrame, list_var_names: Union[str,list[str]], statistic : Union[str, Callable[[np.ndarray],float]] = nmad,
                       min_count: Optional[int] = 100) -> Callable[[tuple[np.ndarray, ...]], np.ndarray]:
     """
     Estimate an interpolant function for an N-dimensional binning. Preferably based on the output of nd_binning.
@@ -67,7 +67,7 @@ def interp_nd_binning(df: pd.DataFrame, list_var_names: Union[str,list[str]], st
     # if list of variable input is simply a string
     if isinstance(list_var_names,str):
         list_var_names = [list_var_names]
-        
+
     # check that the dataframe contains what we need
     for var in list_var_names:
         if var not in df.columns:

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -47,24 +47,28 @@ def interp_nd_binning(df: pd.DataFrame, list_var_names: Union[str,list[str]], st
     :return: N-dimensional interpolant function
 
     :examples
-    Using a dataframe created from scratch
+    # Using a dataframe created from scratch
     >>> df = pd.DataFrame({"var1": [1, 1, 1, 2, 2, 2, 3, 3, 3], "var2": [1, 2, 3, 1, 2, 3, 1, 2, 3], "statistic": [1, 2, 3, 4, 5, 6, 7, 8, 9]})
-        In 2 dimensions, the statistic array looks like this
-        array([
-            [1, 2, 3],
-            [4, 5, 6],
-            [7, 8, 9]
-            ])
+
+    # In 2 dimensions, the statistic array looks like this
+    # array([
+    #     [1, 2, 3],
+    #     [4, 5, 6],
+    #     [7, 8, 9]
+    #     ])
     >>> fun = interp_nd_binning(df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None)
-    Right on point.
+
+    # Right on point.
     >>> fun((2, 2))
-        array(5.)
-    Interpolated linearly inside the 2D frame.
+    array(5.)
+
+    # Interpolated linearly inside the 2D frame.
     >>> fun((1.5, 1.5))
-        array(3.)
-    Extrapolated linearly outside the 2D frame.
+    array(3.)
+
+    # Extrapolated linearly outside the 2D frame.
     >>> fun((-1, 1))
-        array(-5.)
+    array(-5.)
     """
     # if list of variable input is simply a string
     if isinstance(list_var_names,str):

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -3,25 +3,199 @@ xdem.spstats provides tools to use spatial statistics for elevation change data
 """
 from __future__ import annotations
 
+import itertools
 import math as m
 import multiprocessing as mp
 import os
 import random
 import warnings
 from functools import partial
-from typing import Callable, Union
+from typing import Callable, Union, Iterable, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from scipy import integrate
 from scipy.optimize import curve_fit
+from skimage.draw import disk
+from scipy.stats import binned_statistic, binned_statistic_2d, binned_statistic_dd
+from scipy.interpolate import RegularGridInterpolator, LinearNDInterpolator, griddata
+from xdem.spatial_tools import nmad
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import skgstat as skg
     from skgstat import models
 
+def nd_binning(values: np.ndarray, list_var: Iterable[np.ndarray], list_var_names=Iterable[str], list_var_bins: Optional[Union[int,Iterable[Iterable]]] = None,
+                     statistics: Iterable[Union[str, Callable, None]] = ['count', np.nanmedian ,nmad], list_ranges : Optional[Iterable[Sequence]] = None) \
+        -> pd.DataFrame:
+    """
+    N-dimensional binning of values according to one or several explanatory variables.
+    Values input is a (N,) array and variable input is a list of flattened arrays of similar dimensions (N,).
+    For more details on the format of input variables, see documentation of scipy.stats.binned_statistic_dd.
+
+    :param values: values array (N,)
+    :param list_var: list (L) of explanatory variables array (N,)
+    :param list_var_names: list (L) of names of the explanatory variables
+    :param list_var_bins: count, or list (L) of counts or custom bin edges for the explanatory variables; defaults to 10 bins
+    :param statistics: list (X) of statistics to be computed; defaults to count, median and nmad
+    :param list_ranges: list (L) of minimum and maximum ranges to bin the explanatory variables; defaults to min/max of the data
+    :return: dataframe of binned values according to explanatory variables for all possibles combinations in 1d, 2d and nd
+    """
+
+    # we separate 1d, 2d and nd binning, because propagating statistics between different dimensional binning is not always feasible
+    # using scipy because it allows for several dimensional binning, while it's not straightforward in pandas
+    if list_var_bins is None:
+        list_var_bins = (10,) * len(list_var_names)
+    elif isinstance(list_var_bins,int):
+        list_var_bins = (list_var_bins,) * len(list_var_names)
+
+    # flatten the arrays if this has not been done by the user
+    values = values.ravel()
+    list_var = [var.ravel() for var in list_var]
+
+    statistics_name = [f if isinstance(f,str) else f.__name__ for f in statistics]
+
+    # get binned statistics in 1d: a simple loop is sufficient
+    list_df_1d = []
+    for i, var in enumerate(list_var):
+        df_stats_1d = pd.DataFrame()
+        # get statistics
+        for j, statistic in enumerate(statistics):
+            stats_binned_1d, bedges_1d = binned_statistic(var,values,statistic=statistic,bins=list_var_bins[i],range=list_ranges)[:2]
+            # save in a dataframe
+            df_stats_1d[statistics_name[j]] = stats_binned_1d
+        # we need to get the middle of the bins from the edges, to get the same dimension length
+        df_stats_1d[list_var_names[i]] = pd.IntervalIndex.from_breaks(bedges_1d,closed='left')
+        # report number of dimensions used
+        df_stats_1d['nd'] = 1
+
+        list_df_1d.append(df_stats_1d)
+
+    # get binned statistics in 2d: all possible 2d combinations
+    list_df_2d = []
+    if len(list_var)>1:
+        combs = list(itertools.combinations(list_var_names, 2))
+        for i, comb in enumerate(combs):
+            var1_name, var2_name = comb
+            # corresponding variables indexes
+            i1, i2 = list_var_names.index(var1_name), list_var_names.index(var2_name)
+            df_stats_2d = pd.DataFrame()
+            for j, statistic in enumerate(statistics):
+                stats_binned_2d, bedges_var1, bedges_var2 = binned_statistic_2d(list_var[i1],list_var[i2],values,statistic=statistic
+                                                             ,bins=[list_var_bins[i1],list_var_bins[i2]]
+                                                             ,range=list_ranges)[:3]
+                # get statistics
+                df_stats_2d[statistics_name[j]] = stats_binned_2d.flatten()
+            # derive interval indexes and convert bins into 2d indexes
+            ii1 = pd.IntervalIndex.from_breaks(bedges_var1,closed='left')
+            ii2 = pd.IntervalIndex.from_breaks(bedges_var2,closed='left')
+            df_stats_2d[var1_name] = [i1 for i1 in ii1 for i2 in ii2]
+            df_stats_2d[var2_name] = [i2 for i1 in ii1 for i2 in ii2]
+            # report number of dimensions used
+            df_stats_2d['nd'] = 2
+
+            list_df_2d.append(df_stats_2d)
+
+
+    # get binned statistics in nd, without redoing the same stats
+    df_stats_nd = pd.DataFrame()
+    if len(list_var)>2:
+        for j, statistic in enumerate(statistics):
+            stats_binned_2d, list_bedges = binned_statistic_dd(list_var,values,statistic=statistic,bins=list_var_bins,range=list_ranges)[0:2]
+            df_stats_nd[statistics_name[j]] = stats_binned_2d.flatten()
+        list_ii = []
+        # loop through the bin edges and create IntervalIndexes from them (to get both
+        for bedges in list_bedges:
+            list_ii.append(pd.IntervalIndex.from_breaks(bedges,closed='left'))
+
+        # create nd indexes in nd-array and flatten for each variable
+        iind = np.meshgrid(*list_ii)
+        for i, var_name in enumerate(list_var_names):
+            df_stats_nd[var_name] = iind[i].flatten()
+
+        # report number of dimensions used
+        df_stats_nd['nd'] = len(list_var_names)
+
+    # concatenate everything
+    list_all_dfs = list_df_1d + list_df_2d + [df_stats_nd]
+    df_concat = pd.concat(list_all_dfs)
+    # commenting for now: pd.MultiIndex can be hard to use
+    # df_concat = df_concat.set_index(list_var_names)
+
+    return df_concat
+
+def robust_interp_nd_binning(df: pd.DataFrame, var_names: list[str], statistic : Union[str, Callable, None] = nmad, min_count: Optional[int] = 100) -> Callable:
+    """
+    Estimate an interpolated function for an N-dimensional binning.
+    Relies on scipy.ndimage.map_coordinates: see for more information on input arguments.
+
+    :param df: dataframe of binned values according to explanatory variables
+    :param var_names: list of variable names to use
+    :param statistic: statistic to use
+    :param min_count: filter binned values with a sample count of less than this minimum count
+    :return:
+    """
+
+    # check that the dataframe contains what we need
+    for var in var_names:
+        if var not in df.columns:
+            raise ValueError('Variable "'+var+'" does not exist in the provided dataframe.')
+    statistic_name = statistic if isinstance(statistic,str) else statistic.__name__
+    if statistic_name not in df.columns:
+        raise ValueError('Statistic "' + statistic_name + '" does not exist in the provided dataframe.')
+    if min_count is not None and 'count' not in df.columns:
+        raise ValueError('Statistic "count" is not in the provided dataframe, necessary to use the min_count argument.')
+    if df.empty:
+        raise ValueError('Dataframe is empty.')
+
+    # keep only the binning in the number of dimensions corresponding to the length of the variables
+    df_sub = df[df.nd == len(var_names)]
+    if df_sub.empty:
+        raise ValueError('Dataframe does not contain the number of binned dimensions' + str(len(var_names))+' corresponding to the list of variables.')
+
+    # compute the middle values instead of bin interval
+    for var in var_names:
+        df_sub[var] = pd.IntervalIndex(df_sub[var]).mid.values
+    # keep only rows where the binning data exists for those variables (meaning they were used)
+    df_sub = df_sub[np.logical_and.reduce([np.isfinite(df_sub[var].values) for var in var_names])]
+    if df_sub.empty:
+        raise ValueError('Dataframe does not contain a nd binning with the variables corresponding to the list of variables.')
+
+    # remove statistic values calculated with a sample count under the minimum count
+    if min_count is not None:
+        df_sub.loc[df_sub['count'] < min_count,statistic_name] = np.nan
+
+    # valid values
+    vals = df_sub[statistic_name].values
+    ind_valid = np.isfinite(vals)
+
+    # get a list of middle values for the binning coordinates, to define a nd grid
+    list_bmid = []
+    shape = []
+    for var in var_names:
+        bmid = sorted(np.unique(df_sub[var][ind_valid]))
+        list_bmid.append(bmid)
+        shape.append(len(bmid))
+
+    # griddata first to perform nearest interpolation with NaNs (irregular grid)
+    # valid values
+    vals = vals[ind_valid]
+    # coordinates of valid values
+    points_valid = tuple([df_sub[var].values[ind_valid] for var in var_names])
+    # grid coordinates
+    points_grid = tuple([df_sub[var].values for var in var_names])
+    vals_grid = griddata(points_valid, vals, points_grid, method='nearest')
+    vals_grid = vals_grid.reshape(tuple(shape))
+
+    # RegularGridInterpolator to perform linear interpolation/extrapolation on the grid
+    # (will extrapolate only outside of boundaries not filled with the nearest of griddata)
+
+    # get interpolant on the regular grid, with linear extrapolation at the sides (fill_value = None)
+    interp_fun = RegularGridInterpolator(tuple(list_bmid),vals_grid,method='linear',bounds_error=False,fill_value=None)
+
+    return interp_fun
 
 def get_empirical_variogram(dh: np.ndarray, coords: np.ndarray, **kwargs) -> pd.DataFrame:
     """

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -54,15 +54,15 @@ def interp_nd_binning(df: pd.DataFrame, list_var_names: Union[str,list[str]], st
             [7, 8, 9]
             ])
     >>> fun = interp_nd_binning(df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None)
+    Right on point.
     >>> fun((2, 2))
         array(5.)
-        Right on point.
+    Interpolated linearly inside the 2D frame.
     >>> fun((1.5, 1.5))
         array(3.)
-        Interpolated linearly inside the 2D frame.
+    Extrapolated linearly outside the 2D frame.
     >>> fun((-1, 1))
         array(-5.)
-        Extrapolated linearly outside the 2D frame.
     """
     # if list of variable input is simply a string
     if isinstance(list_var_names,str):


### PR DESCRIPTION
Return a N-D interpolant function for binned explanatory variables.
Very much like np.interp1d but in N-D.

## Example
```python
df = xdem.spstats.nd_binning(values=diff.data.flatten(),list_var=[slope.flatten(),ref.data.flatten()],list_var_names=['slope','elevation'])
fun = robust_interp_nd_binning(df, ['slope','elevation'], statistic = nmad)
```

And you get a function that can return an interpolated value for any point (slope, elevation):
```
fun((5,1000))
Out[100]: array(2.42234615)
```

```
fun((15,1000))
Out[107]: array(4.61452136)
```

Here the NMAD is **~2 m** at 5° slope, 1000 m elevation and **~4 m** 15° slope, 1000 m elevation.
If you run this on the arrays of the explanatory variables, you can get your error map directly:
```python
err_dh = fun((slope.data,elevation.data))
```
Here the elevation is just an example, in practice it doesn't explain any variability in elevation measurement error.

## What's behind it
Both `scipy.interpolate.griddata` i.e. `NearestNDInterpolator` (non-regular grids) and `scipy.interpolate.interpn` i.e. `RegularGridInterpolator` (regular grids).

**The first problem: NaNs**
Regular N-D grid interpolation does not support NaNs (even with nearest neighbour!). With irregular grids you can simply remove the NaNs and provide remaining coordinates.
**The second problem: extrapolation**
Regular N-D grid interpolation supports linear extrapolation, but irregular grids don't (see https://github.com/scipy/scipy/issues/6396)
**My solution:**
- First, I provide a N-D grid based on the N-D binning, cropping the potential NaNs on the edges to be sure a boundary is not completely filled by NaNs (especially relevant after the filtering with `min_count` to be sure each N-D bin has enough sampled to be statistically significant)
- Second, I run `griddata` with N-D **nearest** interpolation on the same grid as the input N-D binning, to fill the potential NaNs with N-D nearest extrapolation (we have to keep in mind that those values won't be used too much if they can't be sampled on the DEM anyway).
- Finally, I run `interpn` (the interpolant function `RegularGridInterpolator` to get a Callable directly), with N-D **linear interpolation** and **extrapolation**. This means that the values in between two bins will be N-D linearly interpolated properly, and values near the N-D edges that were not NaNs before will be linearly extrapolated if the function is called outside the binning grid.

## TODO
Tests
Plot in the documentation
An example in the gallery ;)