### PR TITLE
Make 'Coreg.fit' return 'self' for one-liner coregistration.

### DIFF
--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -484,6 +484,17 @@ class TestCoregClass:
         # Check that offsets were actually calculated.
         assert np.sum(np.abs(np.linalg.norm(stats[["x_off", "y_off", "z_off"]], axis=0))) > 0
 
+    def test_coreg_oneliner(_) -> None:
+        """Test that a DEM can be coregistered in one line by chaining calls."""
+        dem_arr = np.ones((5, 5), dtype="int32")
+        dem_arr2 = dem_arr + 1
+        transform = rio.transform.from_origin(0, 5, 1, 1)
+
+        dem_arr2_fixed = coreg.BiasCorr().fit(dem_arr, dem_arr2, transform=transform).apply(dem_arr2, transform=transform)
+
+        assert np.array_equal(dem_arr, dem_arr2_fixed)
+
+
 
 def test_apply_matrix():
     warnings.simplefilter("error")

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -446,13 +446,13 @@ class Coreg:
                 valid_matrix = pytransform3d.transformations.check_transform(matrix)
             self._meta["matrix"] = valid_matrix
 
-    def fit(self, reference_dem: Union[np.ndarray, np.ma.masked_array],
+    def fit(self: CoregType, reference_dem: Union[np.ndarray, np.ma.masked_array],
             dem_to_be_aligned: Union[np.ndarray, np.ma.masked_array],
             inlier_mask: Optional[np.ndarray] = None,
             transform: Optional[rio.transform.Affine] = None,
             weights: Optional[np.ndarray] = None,
             subsample: Union[float, int] = 1.0,
-            verbose: bool = False):
+            verbose: bool = False) -> CoregType:
         """
         Estimate the coregistration transform on the given DEMs.
 
@@ -510,6 +510,8 @@ class Coreg:
 
         # Flag that the fitting function has been called.
         self._fit_called = True
+
+        return self
 
     def apply(self, dem: Union[np.ndarray, np.ma.masked_array],
               transform: rio.transform.Affine) -> Union[np.ndarray, np.ma.masked_array]:


### PR DESCRIPTION
Solves #167.

I'm 97% sure I got the typing right. With the upcoming pre-commit PR, however, it can be validated better.