### PR TITLE
Fix gap bug in `xdem.volume.norm_regional_hypsometric_interpolation`

### DIFF
--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -283,6 +283,8 @@ class TestNormHypsometric:
         )
         assert not np.array_equal(filled_ddem, idealized_ddem)
 
+        # Check that all glacier-values are finite
+        assert np.count_nonzero(np.isnan(idealized_ddem)[self.glacier_index_map > 0]) == 0
         # Validate that the un-idealized dDEM has a higher gradient variance (more ups and downs)
         filled_gradient = np.linalg.norm(np.gradient(filled_ddem), axis=0)
         ideal_gradient = np.linalg.norm(np.gradient(idealized_ddem), axis=0)

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -14,7 +14,7 @@ class TestLocalHypsometric:
 
     # Load example data.
     dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
-    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009)
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
     outlines = gu.geovector.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
     all_outlines = outlines.copy()
 
@@ -170,7 +170,7 @@ class TestLocalHypsometric:
 
 class TestNormHypsometric:
     dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
-    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009)
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
     outlines = gu.geovector.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
     glacier_index_map = outlines.rasterize(dem_2009)

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -733,7 +733,7 @@ def norm_regional_hypsometric_interpolation(voided_ddem: Union[np.ndarray, np.ma
             )[0]
 
         # Create a linear model from the elevations and the scaled regional signal.
-        model = scipy.interpolate.interp1d(signal.index.mid, np.poly1d(coeffs)(signal.values), bounds_error=False)
+        model = scipy.interpolate.interp1d(signal.index.mid, np.poly1d(coeffs)(signal.values), bounds_error=False, fill_value="extrapolate")
 
         # Find which values to fill using the model (all nans within the glacier extent)
         if not idealized_ddem:

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -682,8 +682,8 @@ def norm_regional_hypsometric_interpolation(voided_ddem: Union[np.ndarray, np.ma
         # Scale the signal elevation midpoints to the glacier elevation range.
         midpoints = signal.index.mid
         midpoints *= elev_max - elev_min
+        midpoints += elev_min
         step = midpoints[1] - midpoints[0]
-        midpoints += elev_min + step / 2
         # Create an interval structure from the midpoints and the step size.
         signal.index = pd.IntervalIndex.from_arrays(left=midpoints - step / 2, right=midpoints + step / 2)
 

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -682,8 +682,8 @@ def norm_regional_hypsometric_interpolation(voided_ddem: Union[np.ndarray, np.ma
         # Scale the signal elevation midpoints to the glacier elevation range.
         midpoints = signal.index.mid
         midpoints *= elev_max - elev_min
-        midpoints += elev_min
         step = midpoints[1] - midpoints[0]
+        midpoints += elev_min + step / 2
         # Create an interval structure from the midpoints and the step size.
         signal.index = pd.IntervalIndex.from_arrays(left=midpoints - step / 2, right=midpoints + step / 2)
 


### PR DESCRIPTION
The lowermost half bin of the glacier was not filled because of the midpoint-centered approach; Only the midpoints of the bins were evaluated, so the lower half of the lowermost bin was out of the interpolation range!

Adding `scipy.interpolate.interp1d(..., fill_value="extrapolate")` fixes this issue, so the lower half of the lowermost bin correctly uses the model for the lowermost bin, without introducing NaNs.

I've also added a test for nans to make sure this won't happen again.