### PR TITLE
Fix testing warnings and improve CI testing output

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,4 +56,4 @@ jobs:
         python -c "from xdem.examples import *; download_longyearbyen_examples(overwrite=False)"
     - name: Test with pytest
       run: |
-        pytest -rA -n=auto
+        pytest -ra -n=auto

--- a/docs/source/code/coregistration.py
+++ b/docs/source/code/coregistration.py
@@ -13,7 +13,7 @@ from xdem import coreg
 # Load a reference DEM from 2009
 reference_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
 # Load a moderately well aligned DEM from 1990
-dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(reference_dem)
+dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(reference_dem, silent=True)
 # Load glacier outlines from 1990. This will act as the unstable ground.
 glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -498,7 +498,7 @@ class TestCoregClass:
         dem1.data[0, 1, 1] = 100
 
         # Translate the DEM 1 "meter" right and add a bias
-        dem2 = dem1.reproject(dst_bounds=rio.coords.BoundingBox(1, 0, 6, 5))
+        dem2 = dem1.reproject(dst_bounds=rio.coords.BoundingBox(1, 0, 6, 5), silent=True)
         dem2 += 1
 
         # Create a biascorr for Rasters ("_r") and for arrays ("_a")
@@ -512,7 +512,7 @@ class TestCoregClass:
         )
         biascorr_a.fit(
             reference_dem=dem1.data,
-            dem_to_be_aligned=dem2.reproject(dem1).data,
+            dem_to_be_aligned=dem2.reproject(dem1, silent=True).data,
             transform=dem1.transform
         )
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -25,6 +25,7 @@ class TestDocs:
                 # Run everything except plt.show() calls.
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
+                    warnings.simplefilter("error")
                     try:
                         exec(infile.read().replace("plt.show()", "plt.close()"))
                     except Exception as exception:

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -27,8 +27,7 @@ class TestDocs:
                     # When running the code asynchronously, matplotlib complains a bit
                     ignored_warnings = [
                         "Starting a Matplotlib GUI outside of the main thread",
-                        "An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'MultiPolygon'",
-                        "attribute `__array_interface__` from an object of type 'Polygon'",
+                        "fetching the attribute.*Polygon",
                     ]
                     # This is a GeoPandas issue
                     warnings.simplefilter("error")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -24,7 +24,10 @@ class TestDocs:
             with open(filename) as infile:
                 # Run everything except plt.show() calls.
                 with warnings.catch_warnings():
+                    # When running the code asynchronously, matplotlib complains a bit
                     warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
+                    # This is a GeoPandas issue
+                    warnings.filterwarnings("ignore", message="A polygon does not itself provide the array interface")
                     warnings.simplefilter("error")
                     try:
                         exec(infile.read().replace("plt.show()", "plt.close()"))

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -27,7 +27,7 @@ class TestDocs:
                     # When running the code asynchronously, matplotlib complains a bit
                     warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
                     # This is a GeoPandas issue
-                    warnings.filterwarnings("ignore", message="A polygon does not itself provide the array interface")
+                    warnings.filterwarnings("ignore", message="attribute `__array_interface__` from an object of type 'Polygon'")
                     warnings.simplefilter("error")
                     try:
                         exec(infile.read().replace("plt.show()", "plt.close()"))

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -27,7 +27,7 @@ class TestDocs:
                     # When running the code asynchronously, matplotlib complains a bit
                     ignored_warnings = [
                         "Starting a Matplotlib GUI outside of the main thread",
-                        "fetching the attribute.*Polygon",
+                        ".*fetching the attribute.*Polygon.*",
                     ]
                     # This is a GeoPandas issue
                     warnings.simplefilter("error")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -25,10 +25,16 @@ class TestDocs:
                 # Run everything except plt.show() calls.
                 with warnings.catch_warnings():
                     # When running the code asynchronously, matplotlib complains a bit
-                    warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread")
+                    ignored_warnings = [
+                        "Starting a Matplotlib GUI outside of the main thread",
+                        "An exception was ignored while fetching the attribute `__array_interface__` from an object of type 'MultiPolygon'",
+                        "attribute `__array_interface__` from an object of type 'Polygon'",
+                    ]
                     # This is a GeoPandas issue
-                    warnings.filterwarnings("ignore", message="attribute `__array_interface__` from an object of type 'Polygon'")
                     warnings.simplefilter("error")
+
+                    for warning_text in ignored_warnings:
+                        warnings.filterwarnings("ignore", warning_text)
                     try:
                         exec(infile.read().replace("plt.show()", "plt.close()"))
                     except Exception as exception:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -13,7 +13,7 @@ class TestFilters:
 
     # Load example data.
     dem_2009 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_ref_dem"))
-    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009)
+    dem_1990 = gu.georaster.Raster(xdem.examples.get_path("longyearbyen_tba_dem")).reproject(dem_2009, silent=True)
 
     def test_gauss(self):
         """Test applying the various Gaussian filters on DEMs with/without NaNs"""

--- a/tests/test_spstats.py
+++ b/tests/test_spstats.py
@@ -173,6 +173,7 @@ class TestSubSampling:
 
     def test_ring_masking(self):
         """Test that the ring masking works as intended"""
+        warnings.simplefilter("error")
 
         # by default, the mask is only an outside circle (ring of size 0)
         ring1 = xdem.spstats.create_ring_mask((5,5))

--- a/xdem/spstats.py
+++ b/xdem/spstats.py
@@ -356,8 +356,10 @@ def create_ring_mask(shape: Union[int, Sequence[int]], center: Optional[list[flo
         center = (int(w / 2), int(h / 2))
         out_radius = min(center[0], center[1], w - center[0], h - center[1])
 
-    mask_inside = create_circular_mask((w,h),center=center,radius=in_radius)
-    mask_outside = create_circular_mask((w,h),center=center,radius=out_radius)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", "invalid value encountered in true_divide")
+        mask_inside = create_circular_mask((w,h),center=center,radius=in_radius)
+        mask_outside = create_circular_mask((w,h),center=center,radius=out_radius)
 
     mask_ring = np.logical_and(~mask_inside,mask_outside)
 
@@ -980,7 +982,9 @@ def patches_method(dh : np.ndarray, mask: np.ndarray[bool], gsd : float, area_si
         elif patch_shape == 'circular':
             center_x = np.floor(nx_sub*(i+1/2))
             center_y = np.floor(ny_sub*(j+1/2))
-            mask = create_circular_mask((nx, ny), center=(center_x, center_y), radius=rad)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "invalid value encountered in true_divide")
+                mask = create_circular_mask((nx, ny), center=(center_x, center_y), radius=rad)
             patch = dh[mask]
         else:
             raise ValueError('Patch method must be rectangular or circular.')


### PR DESCRIPTION
Similar to my recent https://github.com/GlacioHack/GeoUtils/pull/222.

- bec7d29: The pytest CI log doesn't show 171 PASSED lines anymore!
- de84d32: Hid divide by zero warnings in `xdem.spstats.create_ring_mask()`. @rhugonnet  is that okay?
- 22c2830: Replaced all instances of `Raster.reproject(...)` to `Raster.reproject(..., silent=True)` in tests.