### PR TITLE
Deprecate `subtract_rasters`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ This is an implementation of the [Nuth and Kääb (2011)](https://doi.org/10.519
 ```python
 import xdem
 
-first_dem = "path/to/first.tif"
-second_dem = "path/to/second.tif"
+first_dem = xdem.DEM("path/to/first.tif")
+second_dem = xdem.DEM("path/to/second.tif")
 
-difference = xdem.spatial_tools.subtract_rasters(first_dem, second_dem)
+difference = first_dem - second_dem
 
 difference.save("path/to/difference.tif")
 ```

--- a/docs/source/code/comparison.py
+++ b/docs/source/code/comparison.py
@@ -42,14 +42,14 @@ ddem_raster = xdem.DEM.from_array(ddem_data, dem1.transform, dem2.crs)
 
 # TEXT HERE
 
-ddem_raster = xdem.spatial_tools.subtract_rasters(dem1, dem2)
+ddem_raster = dem1 - dem2
 
 #############################
 # SECTION: dDEM interpolation
 #############################
 
 ddem = xdem.dDEM(
-    raster=xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990),
+    raster=dem_2009 - dem_1990,
     start_time=dem_1990.datetime,
     end_time=dem_2009.datetime
 )

--- a/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_local_hypsometric_interpolation.py
@@ -10,7 +10,7 @@ dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
 outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
-    xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),
+    dem_2009 - dem_1990,
     start_time=np.datetime64("1990-08-01"),
     end_time=np.datetime64("2009-08-01")
 )

--- a/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
+++ b/docs/source/code/comparison_plot_regional_hypsometric_interpolation.py
@@ -10,7 +10,7 @@ dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
 outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
-    xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),
+    dem_2009 - dem_1990,
     start_time=np.datetime64("1990-08-01"),
     end_time=np.datetime64("2009-08-01")
 )

--- a/docs/source/code/comparison_plot_spatial_interpolation.py
+++ b/docs/source/code/comparison_plot_spatial_interpolation.py
@@ -10,7 +10,7 @@ dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
 outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
 ddem = xdem.dDEM(
-    xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),
+    dem_2009 - dem_1990,
     start_time=np.datetime64("1990-08-01"),
     end_time=np.datetime64("2009-08-01")
 )

--- a/docs/source/comparison.rst
+++ b/docs/source/comparison.rst
@@ -13,32 +13,6 @@ Example data in this chapter are loaded as follows:
         :lines: 5-32
 
 
-Subtracting rasters
--------------------
-Calculating the difference of DEMs (dDEMs) is theoretically simple, but can in practice often be time consuming.
-In ``xdem``, the aim is to minimize or completely remove potential pitfalls in this analysis.
-
-Let's assume we have two perfectly aligned DEMs, with the same shape, extent, resolution and coordinate referencesystem (CRS) as each other.
-Calculating a dDEM would then be as simple as:
-
-.. literalinclude:: code/comparison.py
-        :lines: 37-41
-
-But in practice, our two DEMs are most often not perfectly aligned, which is why we might need a helper function for this:
-:func:`xdem.spatial_tools.subtract_rasters`
-
-.. literalinclude:: code/comparison.py
-        :lines: 45
-        
-
-So what does this magical function do?
-First, the nonreference; ``dem2``, will be reprojected to fit the shape, extent, resolution and CRS of ``dem1``.
-This behaviour can be switched by changing the default ``reference="first"`` to ``reference="second"``.
-Cubic spline interpolation is used by default to resample the data, which is sometimes slow, but provides the most accurate resampling results.
-This can be changed with the ``resampling_method=`` keyword, for example to ``"bilinear"`` or ``"nearest"`` (`see the rasterio docs for the full suite of options <https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html#rasterio.enums.Resampling>`_).
-Most often, ``xdem`` works with Masked Arrays, where the mask signifies cells to exclude (presumably areas of no data).
-The ``subtract_rasters()`` function makes sure that the outgoing mask is the union of the two ingoing masks.
-
 dDEM interpolation
 ------------------
 There are many approaches to interpolate a dDEM.

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -15,7 +15,7 @@ class TestdDEM:
     outlines_1990 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 
     ddem = xdem.dDEM(
-        xdem.spatial_tools.subtract_rasters(dem_2009, dem_1990, resampling_method="nearest"),
+        dem_2009 - dem_1990,
         start_time=np.datetime64("1990-08-01"),
         end_time=np.datetime64("2009-08-01")
     )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,64 @@
+"""Test the xdem.misc functions."""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+import xdem
+import xdem.misc
+
+
+@pytest.mark.parametrize("deprecation_increment", [-1, 0, 1, None])
+@pytest.mark.parametrize("details", [None, "It was completely useless!", "dunnowhy"])
+def test_deprecate(deprecation_increment: int | None, details: str | None) -> None:
+    """
+    Test the deprecation warnings/errors.
+
+    If the version is larger than the current, it should warn.
+    If the version is smaller or equal, it should raise an error.
+
+    :param deprecation_increment: The version number relative to the current version.
+    """
+    warnings.simplefilter("error")
+
+    current_version = xdem.version.version
+
+    # Set the deprecation_version to be the current version plus the increment (e.g. 0.0.5 + 1 -> 0.0.6)
+    deprecation_version = (
+        current_version[:-1] + str(int(current_version.rsplit(".", 1)[1]) + deprecation_increment)
+        if deprecation_increment is not None
+        else None
+    )
+
+    @xdem.misc.deprecate(deprecation_version, details=details)
+    def useless_func() -> int:
+        return 1
+
+    should_warn = deprecation_version is None or deprecation_version > current_version
+
+    text = (
+        "Call to deprecated function 'useless_func'."
+        if should_warn
+        else f"Function 'useless_func' was deprecated in {deprecation_version}."
+    )
+
+    if details is not None:
+        text += " " + details.strip().capitalize()
+
+        if not any(text.endswith(c) for c in ".!?"):
+            text += "."
+
+    
+    if should_warn and deprecation_version is not None:
+        text += f" This functionality will be removed in version {deprecation_version}."
+    elif not should_warn:
+        text += f" Current version: {current_version}."
+
+
+    if should_warn:
+        with pytest.warns(DeprecationWarning, match=text):
+            useless_func()
+    else:
+        with pytest.raises(ValueError, match=text):
+            useless_func()

--- a/tests/test_spatial_tools.py
+++ b/tests/test_spatial_tools.py
@@ -19,9 +19,11 @@ from xdem import examples
 
 def test_dem_subtraction():
     """Test that the DEM subtraction script gives reasonable numbers."""
-    diff = xdem.spatial_tools.subtract_rasters(
-        examples.get_path("longyearbyen_ref_dem"),
-        examples.get_path("longyearbyen_tba_dem"))
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        diff = xdem.spatial_tools.subtract_rasters(
+            examples.get_path("longyearbyen_ref_dem"),
+            examples.get_path("longyearbyen_tba_dem"))
 
     assert np.nanmean(np.abs(diff.data)) < 100
 

--- a/xdem/demcollection.py
+++ b/xdem/demcollection.py
@@ -100,12 +100,7 @@ class DEMCollection:
                 )
             else:
                 ddem = xdem.dDEM(
-                    raster=xdem.spatial_tools.subtract_rasters(
-                        self.reference_dem,
-                        dem,
-                        reference="first",
-                        resampling_method=resampling_method
-                    ),
+                    self.reference_dem - dem.reproject(resampling=resampling_method, silent=True),
                     start_time=min(self.reference_timestamp, self.timestamps[i]),
                     end_time=max(self.reference_timestamp, self.timestamps[i]),
                     error=None

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -79,7 +79,11 @@ def deprecate(removal_version: str | None = None, details: str | None = None):
 
             # Add the details explanation if it was given, and make sure the sentence is ended.
             if details is not None:
-                text += " " + details.strip().capitalize()
+                details_frm = details.strip()
+                if details_frm[0].islower():
+                    details_frm = details_frm[0].upper() + details_frm[1:]
+
+                text += " " + details_frm
 
                 if not any(text.endswith(c) for c in ".!?"):
                     text += "."

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -1,8 +1,15 @@
 """Small functions for testing, examples, and other miscellaneous uses."""
 from __future__ import annotations
 
+import functools
+import warnings
+from typing import Any, Callable
+
 import cv2
 import numpy as np
+
+import xdem.version
+
 
 def generate_random_field(shape: tuple[int, int], corr_size: int) -> np.ndarray:
     """
@@ -23,12 +30,67 @@ def generate_random_field(shape: tuple[int, int], corr_size: int) -> np.ndarray:
     """
     field = cv2.resize(
         cv2.GaussianBlur(
-            np.repeat(np.repeat(
-                np.random.randint(0, 255, (shape[0]//corr_size,
-                                           shape[1]//corr_size), dtype='uint8'),
-                corr_size, axis=0), corr_size, axis=1),
-            ksize=(2*corr_size + 1, 2*corr_size + 1),
-            sigmaX=corr_size) / 255,
-        dsize=(shape[1], shape[0])
+            np.repeat(
+                np.repeat(
+                    np.random.randint(0, 255, (shape[0] // corr_size, shape[1] // corr_size), dtype="uint8"),
+                    corr_size,
+                    axis=0,
+                ),
+                corr_size,
+                axis=1,
+            ),
+            ksize=(2 * corr_size + 1, 2 * corr_size + 1),
+            sigmaX=corr_size,
+        )
+        / 255,
+        dsize=(shape[1], shape[0]),
     )
     return field
+
+
+def deprecate(removal_version: str | None = None, details: str | None = None):
+    """
+    Trigger a DeprecationWarning for the decorated function.
+
+    :param func: The function to be deprecated.
+    :param removal_version: Optional. The version at which this will be removed. 
+                            If this version is reached, a ValueError is raised.
+    :param details: Optional. A description for why the function was deprecated.
+
+    :triggers DeprecationWarning: For any call to the function.
+
+    :raises ValueError: If 'removal_version' was given and the current version is equal or higher.
+
+    :returns: The decorator to decorate the function.
+    """
+    def deprecator_func(func):
+
+        @functools.wraps(func)
+        def new_func(*args, **kwargs):
+            warning_text = f"Call to deprecated function '{func.__name__}'."
+            if details is not None:
+                formatted_details = " " + details.strip().capitalize()
+                if not any(formatted_details.endswith(c) for c in ".!?"):
+                    formatted_details += "."
+                warning_text += formatted_details
+            else:
+                formatted_details = ""
+            if removal_version is not None:
+                warning_text = warning_text.strip()
+                if not any(warning_text.endswith(c) for c in ".!?"):
+                    warning_text += "."
+                warning_text += f" This functionality will be removed in version {removal_version}."
+
+                if xdem.version.version >= removal_version:
+                    raise ValueError(
+                        f"Function '{func.__name__}' was deprecated in {removal_version}."
+                        + formatted_details + 
+                        f" Current version: {xdem.version.version}."
+                    )
+            warnings.warn(warning_text, category=DeprecationWarning, stacklevel=2)
+
+            return func(*args, **kwargs)
+
+        return new_func
+
+    return deprecator_func

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -118,7 +118,7 @@ def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
         removal_version="0.0.6",
         details=(
             "This function is redundant after the '-' operator for rasters was introduced."
-            "Use 'dem1 - dem2.reproject(dem1, resampling_method='cubic_spline')' instead."
+            " Use 'dem1 - dem2.reproject(dem1, resampling_method='cubic_spline')' instead."
         )
 )
 def subtract_rasters(first_raster: Union[str, gu.georaster.Raster], second_raster: Union[str, gu.georaster.Raster],

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -11,6 +11,8 @@ from tqdm import tqdm
 import numba
 import skimage.transform
 
+from xdem.misc import deprecate
+
 
 def get_mask(array: Union[np.ndarray, np.ma.masked_array]) -> np.ndarray:
     """
@@ -112,6 +114,13 @@ def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
     return resampling_method
 
 
+@deprecate(
+        removal_version="0.0.5",
+        details=(
+            "This function is redundant after the '-' operator for rasters was introduced."
+            "Use 'dem1 - dem2.reproject(dem1, resampling_method='cubic_spline')' instead."
+        )
+)
 def subtract_rasters(first_raster: Union[str, gu.georaster.Raster], second_raster: Union[str, gu.georaster.Raster],
                      reference: str = "first",
                      resampling_method: Union[str, rio.warp.Resampling] = "cubic_spline") -> gu.georaster.Raster:

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -115,7 +115,7 @@ def resampling_method_from_str(method_str: str) -> rio.warp.Resampling:
 
 
 @deprecate(
-        removal_version="0.0.5",
+        removal_version="0.0.6",
         details=(
             "This function is redundant after the '-' operator for rasters was introduced."
             "Use 'dem1 - dem2.reproject(dem1, resampling_method='cubic_spline')' instead."


### PR DESCRIPTION
Closes #163.

All uses of `xdem.spatial_tools.subtract_rasters()` are now gone.

I've added a `xdem.misc.deprecate()` function with associated tests. It triggers a deprecation warning up to the version where it is supposed to be removed, whereby it will raise a ValueError. This means that if the repo is still using the deprecated function by then, it won't pass CI!

