### PR TITLE
Exclude empty blocks in BlockwiseCoreg and handle warnings.

### DIFF
--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -485,6 +485,21 @@ class TestCoregClass:
         # Check that offsets were actually calculated.
         assert np.sum(np.abs(np.linalg.norm(stats[["x_off", "y_off", "z_off"]], axis=0))) > 0
 
+
+    def test_blockwise_coreg_large_gaps(self):
+        """Test BlockwiseCoreg when large gaps are encountered, e.g. around the frame of a rotated DEM."""
+        warnings.simplefilter("error")
+        reference_dem = self.ref.reproject(dst_crs='EPSG:3413', dst_res=self.ref.res, resampling='bilinear')
+        dem_to_be_aligned = self.tba.reproject(dst_ref=reference_dem, resampling='bilinear')
+
+        blockwise = xdem.coreg.BlockwiseCoreg(xdem.coreg.NuthKaab(), 64, warn_failures=False)
+
+        # This should not fail or trigger warnings as warn_failures is False
+        blockwise.fit(reference_dem, dem_to_be_aligned)
+
+
+
+
     def test_coreg_raster_and_ndarray_args(_) -> None:
 
         # Create a small sample-DEM


### PR DESCRIPTION
Closes #185.

Completely empty blocks are now skipped, and are not considered for the success percentage.

Also, a few warnings may occur before coreg approaches fail, so these are now caught and are by default not shown. For debug purposes, it can be shown by enabling the `warn_failures` attribute to `True` (can also be set as an argument to the `__init__()` method), whereby each failure and warning will be shown as warnings.

