### PR TITLE
Allow `Raster`s as arguments -> return types for terrain attributes

### DIFF
--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -177,7 +177,8 @@ class TestTerrainAttribute:
 
         assert slope != aspect
 
-        assert type(slope) == type(self.dem) == type(aspect)
+        assert type(slope) == type(aspect)
+        assert all(isinstance(r, gu.Raster) for r in (aspect, slope, self.dem))
 
         assert slope.transform == self.dem.transform == aspect.transform
         assert slope.crs == self.dem.crs == aspect.crs

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -171,6 +171,17 @@ class TestTerrainAttribute:
         slope_lowres = xdem.terrain.get_terrain_attribute(self.dem.data, "slope", resolution=self.dem.res[0] * 2)
         assert np.mean(slope) > np.mean(slope_lowres)
 
+    def test_raster_argument(self):
+
+        slope, aspect = xdem.terrain.get_terrain_attribute(self.dem, attribute=["slope", "aspect"])
+
+        assert slope != aspect
+
+        assert type(slope) == type(self.dem) == type(aspect)
+
+        assert slope.transform == self.dem.transform == aspect.transform
+        assert slope.crs == self.dem.crs == aspect.crs
+
 
 def test_get_quadric_coefficients() -> None:
     """Test the outputs and exceptions of the get_quadric_coefficients() function."""

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -1,7 +1,6 @@
 """DEM class and functions."""
 import os
 import pyproj
-from typing import Union
 import warnings
 from geoutils.georaster import Raster
 from geoutils.satimg import SatelliteImage

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -241,5 +241,3 @@ class DEM(SatelliteImage):
         # update raster
         self._update(metadata=meta,imgdata=zz)
 
-
-DEMLike = Union[DEM, Raster, SatelliteImage]

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -1,6 +1,7 @@
 """DEM class and functions."""
 import os
 import pyproj
+from typing import Union
 import warnings
 from geoutils.georaster import Raster
 from geoutils.satimg import SatelliteImage
@@ -239,3 +240,6 @@ class DEM(SatelliteImage):
 
         # update raster
         self._update(metadata=meta,imgdata=zz)
+
+
+DEMLike = Union[DEM, Raster, SatelliteImage]

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -240,4 +240,3 @@ class DEM(SatelliteImage):
 
         # update raster
         self._update(metadata=meta,imgdata=zz)
-

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -8,8 +8,8 @@ import numba
 import numpy as np
 
 import xdem.spatial_tools
-from xdem.dem import DEMLike
 import geoutils as gu
+from geoutils.georaster import RasterType
 
 
 @numba.njit(parallel=True)
@@ -225,7 +225,7 @@ def get_terrain_attribute(
 
 @overload
 def get_terrain_attribute(
-    dem: DEMLike,
+    dem: RasterType,
     attribute: str,
     resolution: tuple[float, float] | float | None,
     degrees: bool,
@@ -234,12 +234,12 @@ def get_terrain_attribute(
     hillshade_z_factor: float,
     fill_method: str,
     edge_method: str
-) -> DEMLike:
+) -> RasterType:
     ...
 
 @overload
 def get_terrain_attribute(
-    dem: DEMLike,
+    dem: RasterType,
     attribute: list[str],
     resolution: tuple[float, float] | float | None,
     degrees: bool,
@@ -248,12 +248,12 @@ def get_terrain_attribute(
     hillshade_z_factor: float,
     fill_method: str,
     edge_method: str
-) -> list[DEMLike]:
+) -> list[RasterType]:
     ...
 
 
 def get_terrain_attribute(
-    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    dem: np.ndarray | np.ma.masked_array | RasterType,
     attribute: str | list[str],
     resolution: tuple[float, float] | float | None = None,
     degrees: bool = True,
@@ -262,7 +262,7 @@ def get_terrain_attribute(
     hillshade_z_factor: float = 1.0,
     fill_method: str = "median",
     edge_method: str = "nearest",
-) -> np.ndarray | list[np.ndarray] | DEMLike | list[DEMLike]:
+) -> np.ndarray | list[np.ndarray] | RasterType | list[RasterType]:
     """
     Derive one or multiple terrain attributes from a DEM.
 
@@ -461,10 +461,10 @@ def get_terrain_attribute(
 
 @overload
 def slope(
-    dem: DEMLike,
+    dem: RasterType,
     resolution: float | tuple[float, float] | None,
     degrees: bool
-) -> DEMLike: ...
+) -> RasterType: ...
 
 @overload
 def slope(
@@ -474,8 +474,8 @@ def slope(
 ) -> np.ndarray: ...
 
 def slope(
-    dem: np.ndarray | np.ma.masked_array | DEMLike, resolution: float | tuple[float, float] | None = None, degrees: bool = True
-) -> np.ndarray | DEMLike:
+    dem: np.ndarray | np.ma.masked_array | RasterType, resolution: float | tuple[float, float] | None = None, degrees: bool = True
+) -> np.ndarray | RasterType:
     """
     Generate a slope map for a DEM.
 
@@ -486,12 +486,6 @@ def slope(
     :returns: A slope map of the same shape as 'dem' in degrees or radians.
     """
     return get_terrain_attribute(dem, attribute="slope", resolution=resolution, degrees=degrees)
-
-@overload
-def slope(
-    aspect: DEMLike,
-    degrees: bool
-) -> DEMLike: ...
 
 @overload
 def aspect(
@@ -532,12 +526,12 @@ def aspect(dem: np.ndarray | np.ma.masked_array, degrees: bool = True) -> np.nda
 
 @overload
 def hillshade(
-    dem: DEMLike,
+    dem: RasterType,
     resolution: float | tuple[float, float],
     azimuth: float,
     altitude: float,
     z_factor: float,
-) -> DEMLike: ...
+) -> RasterType: ...
 
 @overload
 def hillshade(
@@ -554,7 +548,7 @@ def hillshade(
     azimuth: float = 315.0,
     altitude: float = 45.0,
     z_factor: float = 1.0,
-) -> np.ndarray | DEMLike:
+) -> np.ndarray | RasterType:
     """
     Generate a hillshade from the given DEM.
 
@@ -580,9 +574,9 @@ def hillshade(
 
 @overload
 def curvature(
-    dem: DEMLike,
+    dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> DEMLike: ...
+) -> RasterType: ...
 
 @overload
 def curvature(
@@ -591,9 +585,9 @@ def curvature(
 ) -> np.ndarray: ...
 
 def curvature(
-    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | DEMLike:
+) -> np.ndarray | RasterType:
     """
     Get the terrain curvature (second derivative of elevation).
 
@@ -626,9 +620,9 @@ def curvature(
 
 @overload
 def planform_curvature(
-    dem: DEMLike,
+    dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> DEMLike: ...
+) -> RasterType: ...
 
 @overload
 def planform_curvature(
@@ -637,9 +631,9 @@ def planform_curvature(
 ) -> np.ndarray: ...
 
 def planform_curvature(
-    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | DEMLike:
+) -> np.ndarray | RasterType:
     """
     Get the terrain curvature perpendicular to the direction of the slope.
 
@@ -655,9 +649,9 @@ def planform_curvature(
 
 @overload
 def profile_curvature(
-    dem: DEMLike,
+    dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> DEMLike: ...
+) -> RasterType: ...
 
 @overload
 def profile_curvature(
@@ -666,9 +660,9 @@ def profile_curvature(
 ) -> np.ndarray: ...
 
 def profile_curvature(
-    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | DEMLike:
+) -> np.ndarray | RasterType:
     """
     Get the terrain curvature parallel to the direction of the slope.
 

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import xdem.spatial_tools
 import geoutils as gu
-from geoutils.georaster import RasterType
+from geoutils.georaster import RasterType, Raster
 
 
 @numba.njit(parallel=True)
@@ -234,7 +234,7 @@ def get_terrain_attribute(
     hillshade_z_factor: float,
     fill_method: str,
     edge_method: str
-) -> RasterType:
+) -> Raster:
     ...
 
 @overload
@@ -248,7 +248,7 @@ def get_terrain_attribute(
     hillshade_z_factor: float,
     fill_method: str,
     edge_method: str
-) -> list[RasterType]:
+) -> list[Raster]:
     ...
 
 
@@ -262,7 +262,7 @@ def get_terrain_attribute(
     hillshade_z_factor: float = 1.0,
     fill_method: str = "median",
     edge_method: str = "nearest",
-) -> np.ndarray | list[np.ndarray] | RasterType | list[RasterType]:
+) -> np.ndarray | list[np.ndarray] | Raster | list[Raster]:
     """
     Derive one or multiple terrain attributes from a DEM.
 
@@ -455,7 +455,7 @@ def get_terrain_attribute(
     output_attributes = [terrain_attributes[key].reshape(dem.shape) for key in attribute]
 
     if isinstance(dem, gu.Raster):
-        output_attributes = [dem.from_array(attr, transform=dem.transform, crs=dem.crs, nodata=None) for attr in output_attributes]
+        output_attributes = [gu.Raster.from_array(attr, transform=dem.transform, crs=dem.crs, nodata=None) for attr in output_attributes]
 
     return output_attributes if len(output_attributes) > 1 else output_attributes[0]
 
@@ -464,7 +464,7 @@ def slope(
     dem: RasterType,
     resolution: float | tuple[float, float] | None,
     degrees: bool
-) -> RasterType: ...
+) -> Raster: ...
 
 @overload
 def slope(
@@ -475,7 +475,7 @@ def slope(
 
 def slope(
     dem: np.ndarray | np.ma.masked_array | RasterType, resolution: float | tuple[float, float] | None = None, degrees: bool = True
-) -> np.ndarray | RasterType:
+) -> np.ndarray | Raster:
     """
     Generate a slope map for a DEM.
 
@@ -493,7 +493,13 @@ def aspect(
     degrees: bool
 ) -> np.ndarray: ...
 
-def aspect(dem: np.ndarray | np.ma.masked_array, degrees: bool = True) -> np.ndarray:
+@overload
+def aspect(
+    dem: RasterType,
+    degrees: bool
+) -> Raster: ...
+
+def aspect(dem: np.ndarray | np.ma.masked_array | RasterType, degrees: bool = True) -> np.ndarray | Raster:
     """
     Calculate the aspect of each cell in a DEM.
 
@@ -531,7 +537,7 @@ def hillshade(
     azimuth: float,
     altitude: float,
     z_factor: float,
-) -> RasterType: ...
+) -> Raster: ...
 
 @overload
 def hillshade(
@@ -548,7 +554,7 @@ def hillshade(
     azimuth: float = 315.0,
     altitude: float = 45.0,
     z_factor: float = 1.0,
-) -> np.ndarray | RasterType:
+) -> np.ndarray | Raster:
     """
     Generate a hillshade from the given DEM.
 
@@ -576,7 +582,7 @@ def hillshade(
 def curvature(
     dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> RasterType: ...
+) -> Raster: ...
 
 @overload
 def curvature(
@@ -587,7 +593,7 @@ def curvature(
 def curvature(
     dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | RasterType:
+) -> np.ndarray | Raster:
     """
     Get the terrain curvature (second derivative of elevation).
 
@@ -622,7 +628,7 @@ def curvature(
 def planform_curvature(
     dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> RasterType: ...
+) -> Raster: ...
 
 @overload
 def planform_curvature(
@@ -633,7 +639,7 @@ def planform_curvature(
 def planform_curvature(
     dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | RasterType:
+) -> np.ndarray | Raster:
     """
     Get the terrain curvature perpendicular to the direction of the slope.
 
@@ -651,7 +657,7 @@ def planform_curvature(
 def profile_curvature(
     dem: RasterType,
     resolution: float | tuple[float, float] | None,
-) -> RasterType: ...
+) -> Raster: ...
 
 @overload
 def profile_curvature(
@@ -662,7 +668,7 @@ def profile_curvature(
 def profile_curvature(
     dem: np.ndarray | np.ma.masked_array | RasterType,
     resolution: float | tuple[float, float] | None = None,
-) -> np.ndarray | RasterType:
+) -> np.ndarray | Raster:
     """
     Get the terrain curvature parallel to the direction of the slope.
 

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -459,10 +459,23 @@ def get_terrain_attribute(
 
     return output_attributes if len(output_attributes) > 1 else output_attributes[0]
 
+@overload
+def slope(
+    dem: DEMLike,
+    resolution: float | tuple[float, float] | None,
+    degrees: bool
+) -> DEMLike: ...
+
+@overload
+def slope(
+    dem: np.ndarray | np.ma.masked_array,
+    resolution: float | tuple[float, float] | None,
+    degrees: bool
+) -> np.ndarray: ...
 
 def slope(
-    dem: np.ndarray | np.ma.masked_array, resolution: float | tuple[float, float], degrees: bool = True
-) -> np.ndarray:
+    dem: np.ndarray | np.ma.masked_array | DEMLike, resolution: float | tuple[float, float] | None = None, degrees: bool = True
+) -> np.ndarray | DEMLike:
     """
     Generate a slope map for a DEM.
 
@@ -474,6 +487,17 @@ def slope(
     """
     return get_terrain_attribute(dem, attribute="slope", resolution=resolution, degrees=degrees)
 
+@overload
+def slope(
+    aspect: DEMLike,
+    degrees: bool
+) -> DEMLike: ...
+
+@overload
+def aspect(
+    dem: np.ndarray | np.ma.masked_array,
+    degrees: bool
+) -> np.ndarray: ...
 
 def aspect(dem: np.ndarray | np.ma.masked_array, degrees: bool = True) -> np.ndarray:
     """
@@ -506,14 +530,31 @@ def aspect(dem: np.ndarray | np.ma.masked_array, degrees: bool = True) -> np.nda
     """
     return get_terrain_attribute(dem, attribute="aspect", resolution=1.0, degrees=degrees)
 
+@overload
+def hillshade(
+    dem: DEMLike,
+    resolution: float | tuple[float, float],
+    azimuth: float,
+    altitude: float,
+    z_factor: float,
+) -> DEMLike: ...
 
+@overload
 def hillshade(
     dem: np.ndarray | np.ma.masked_array,
     resolution: float | tuple[float, float],
+    azimuth: float,
+    altitude: float,
+    z_factor: float,
+) -> np.ndarray: ...
+
+def hillshade(
+    dem: np.ndarray | np.ma.masked_array,
+    resolution: float | tuple[float, float] | None = None,
     azimuth: float = 315.0,
     altitude: float = 45.0,
     z_factor: float = 1.0,
-) -> np.ndarray:
+) -> np.ndarray | DEMLike:
     """
     Generate a hillshade from the given DEM.
 
@@ -537,11 +578,22 @@ def hillshade(
         hillshade_z_factor=z_factor,
     )
 
+@overload
+def curvature(
+    dem: DEMLike,
+    resolution: float | tuple[float, float] | None,
+) -> DEMLike: ...
 
+@overload
 def curvature(
     dem: np.ndarray | np.ma.masked_array,
-    resolution: float | tuple[float, float],
-) -> np.ndarray:
+    resolution: float | tuple[float, float] | None,
+) -> np.ndarray: ...
+
+def curvature(
+    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    resolution: float | tuple[float, float] | None = None,
+) -> np.ndarray | DEMLike:
     """
     Get the terrain curvature (second derivative of elevation).
 
@@ -572,10 +624,22 @@ def curvature(
     return get_terrain_attribute(dem=dem, attribute="curvature", resolution=resolution)
 
 
+@overload
+def planform_curvature(
+    dem: DEMLike,
+    resolution: float | tuple[float, float] | None,
+) -> DEMLike: ...
+
+@overload
 def planform_curvature(
     dem: np.ndarray | np.ma.masked_array,
-    resolution: float | tuple[float, float],
-) -> np.ndarray:
+    resolution: float | tuple[float, float] | None,
+) -> np.ndarray: ...
+
+def planform_curvature(
+    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    resolution: float | tuple[float, float] | None = None,
+) -> np.ndarray | DEMLike:
     """
     Get the terrain curvature perpendicular to the direction of the slope.
 
@@ -589,10 +653,22 @@ def planform_curvature(
     return get_terrain_attribute(dem=dem, attribute="planform_curvature", resolution=resolution)
 
 
+@overload
+def profile_curvature(
+    dem: DEMLike,
+    resolution: float | tuple[float, float] | None,
+) -> DEMLike: ...
+
+@overload
 def profile_curvature(
     dem: np.ndarray | np.ma.masked_array,
-    resolution: float | tuple[float, float],
-) -> np.ndarray:
+    resolution: float | tuple[float, float] | None,
+) -> np.ndarray: ...
+
+def profile_curvature(
+    dem: np.ndarray | np.ma.masked_array | DEMLike,
+    resolution: float | tuple[float, float] | None = None,
+) -> np.ndarray | DEMLike:
     """
     Get the terrain curvature parallel to the direction of the slope.
 


### PR DESCRIPTION
Tackles #178 

Now, this works:
```python
import xdem

dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))

slope = xdem.terrain.slope(dem)  # This is a Raster since a RasterType was given as an argument.

slope.save(...)

```