### PR TITLE
Fix BlockwiseCoreg.stats() KeyError and improved tests.

### DIFF
--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -497,6 +497,14 @@ class TestCoregClass:
         # This should not fail or trigger warnings as warn_failures is False
         blockwise.fit(reference_dem, dem_to_be_aligned)
 
+        stats = blockwise.stats()
+
+        # We expect holes in the blockwise coregistration, so there should not be 64 "successful" blocks.
+        assert stats.shape[0] < 64
+
+        # Statistics are only calculated on finite values, so all of these should be finite as well.
+        assert np.all(np.isfinite(stats))
+
 
 
 

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -705,6 +705,10 @@ class Coreg:
         # Calculate the DEM difference
         diff = ref_arr - aligned_dem
 
+        # Sometimes, the float minimum (for float32 = -3.4028235e+38) is returned. This and inf should be excluded.
+        if "float" in str(diff.dtype):
+            full_mask[(diff == np.finfo(diff.dtype).min) | np.isinf(diff)] = False
+
         # Return the difference values within the full inlier mask
         return diff[full_mask]
 
@@ -756,7 +760,6 @@ class Coreg:
                     f"Invalid 'error_type'{'s' if len(error_type) > 1 else ''}: "
                     f"'{error_type}'. Choices: {list(error_functions.keys())}"
                     ) from exception
-
 
         return errors if len(errors) > 1 else errors[0]
 
@@ -1774,6 +1777,8 @@ class BlockwiseCoreg(Coreg):
 
         statistics: list[dict[str, Any]] = []
         for i in range(points.shape[0]):
+            if i not in chunk_meta:
+                continue
             statistics.append(
                 {
                     "center_x": points[i, 0, 0],


### PR DESCRIPTION
Closes #189.

The blocks that were empty are now correctly skipped.

Also, I found that there were `inf`s in the stats! That is because the  `Coreg.residuals()` for some reason calculated an incorrect mask sometimes. I fixed that as well, so all of the statistics are finite.

These two issues are now fixed and correctly tested, so they should not reoccur.