### PR TITLE
Fix erroneous masks for Coreg classes

### DIFF
--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -518,7 +518,13 @@ class TestCoregClass:
 
         # Validate that the zshift is not something crazy high and that no negative values exist in the data.
         assert np.nanmax(np.abs(zshift)) < 50
-        assert np.count_nonzero(aligned.data.filled(0) < -50) == 0
+        assert np.count_nonzero(aligned.data.compressed() < -50) == 0
+
+        # Check that coregistration improved the alignment
+        ddem_post = (aligned - self.ref).data.compressed()
+        ddem_pre = (tba - self.ref).data.compressed()
+        assert abs(np.nanmedian(ddem_pre)) > abs(np.nanmedian(ddem_post))
+        assert np.nanstd(ddem_pre) > np.nanstd(ddem_post)
 
 
     def test_coreg_raster_and_ndarray_args(_) -> None:

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -505,7 +505,20 @@ class TestCoregClass:
         # Statistics are only calculated on finite values, so all of these should be finite as well.
         assert np.all(np.isfinite(stats))
 
+        # Copy the TBA DEM and set a square portion to nodata
+        tba = self.tba.copy()
+        tba.data[0, 450:500, 450:500] = -9999
+        tba.set_ndv(-9999)
 
+        blockwise = xdem.coreg.BlockwiseCoreg(xdem.coreg.NuthKaab(), 8, warn_failures=False)
+
+        # Align the DEM and apply the blockwise to a zero-array (to get the zshift)
+        aligned = blockwise.fit(self.ref, tba).apply(tba)
+        zshift = blockwise.apply(np.zeros_like(tba.data), transform=tba.transform)
+
+        # Validate that the zshift is not something crazy high and that no negative values exist in the data.
+        assert np.nanmax(np.abs(zshift)) < 50
+        assert np.count_nonzero(aligned.data.filled(0) < -50) == 0
 
 
     def test_coreg_raster_and_ndarray_args(_) -> None:

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1472,7 +1472,7 @@ def apply_matrix(dem: np.ndarray, transform: rio.transform.Affine, matrix: np.nd
             mode="constant",
             cval=1,
             preserve_range=True
-        ) > 0.1  # Due to different interpolation approaches, everything above 0.25 is assumed to be 1 (True)
+        ) > 0.1  # Due to different interpolation approaches, everything above 0.1 is assumed to be 1 (True)
 
     if dilate_mask:
         tr_nan_mask = scipy.ndimage.morphology.binary_dilation(tr_nan_mask, iterations=resampling_order)

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -578,6 +578,7 @@ class Coreg:
 
         # The array to provide the functions will be an ndarray with NaNs for masked out areas.
         dem_array, dem_mask = xdem.spatial_tools.get_array_and_mask(dem)
+
         if np.all(dem_mask):
             raise ValueError("'dem' had only NaNs")
 
@@ -1391,19 +1392,17 @@ def apply_matrix(dem: np.ndarray, transform: rio.transform.Affine, matrix: np.nd
     if np.mean(np.abs(empty_matrix - matrix)) == 0.0:
         return demc + matrix[2, 3]
 
-    # Temporary. Should probably be removed.
-    #demc[demc == -9999] = np.nan
     nan_mask = xdem.spatial_tools.get_mask(dem)
     assert np.count_nonzero(~nan_mask) > 0, "Given DEM had all nans."
     # Create a filled version of the DEM. (skimage doesn't like nans)
-    filled_dem = np.where(~nan_mask, demc, np.median(demc[~nan_mask]))
+    filled_dem = np.where(~nan_mask, demc, np.nan)
 
     # Get the centre coordinates of the DEM pixels.
     x_coords, y_coords = _get_x_and_y_coords(demc.shape, transform)
 
     bounds, resolution = _transform_to_bounds_and_res(dem.shape, transform)
 
-    # If a centroid was not given, default to the bottom left corner.
+    # If a centroid was not given, default to the center of the DEM (at Z=0).
     if centroid is None:
         centroid = (np.mean([bounds.left, bounds.right]), np.mean([bounds.bottom, bounds.top]), 0.0)
     else:
@@ -1453,24 +1452,27 @@ def apply_matrix(dem: np.ndarray, transform: rio.transform.Affine, matrix: np.nd
     # Create a skimage-compatible array of the new index coordinates that the pixels shall have after warping.
     inds = np.vstack((y_inds.reshape((1,) + y_inds.shape), x_inds.reshape((1,) + x_inds.shape)))
 
-    # Warp the DEM
-    transformed_dem = skimage.transform.warp(
-        filled_dem,
-        inds,
-        order=resampling_order,
-        mode="constant",
-        cval=0,
-        preserve_range=True
-    )
-    # Warp the NaN mask, setting true to all values outside the new frame.
-    tr_nan_mask = skimage.transform.warp(
-        nan_mask.astype("uint8"),
-        inds,
-        order=resampling_order,
-        mode="constant",
-        cval=1,
-        preserve_range=True
-    ) > 0.25  # Due to different interpolation approaches, everything above 0.25 is assumed to be 1 (True)
+    with warnings.catch_warnings():
+        # An skimage warning that will hopefully be fixed soon. (2021-07-30)
+        warnings.filterwarnings("ignore", message="Passing `np.nan` to mean no clipping in np.clip")
+        # Warp the DEM
+        transformed_dem = skimage.transform.warp(
+            filled_dem,
+            inds,
+            order=resampling_order,
+            mode="constant",
+            cval=np.nan,
+            preserve_range=True
+        )
+        # Warp the NaN mask, setting true to all values outside the new frame.
+        tr_nan_mask = skimage.transform.warp(
+            nan_mask.astype("uint8"),
+            inds,
+            order=resampling_order,
+            mode="constant",
+            cval=1,
+            preserve_range=True
+        ) > 0.1  # Due to different interpolation approaches, everything above 0.25 is assumed to be 1 (True)
 
     if dilate_mask:
         tr_nan_mask = scipy.ndimage.morphology.binary_dilation(tr_nan_mask, iterations=resampling_order)
@@ -1870,7 +1872,8 @@ def warp_dem(
         source_coords: np.ndarray,
         destination_coords: np.ndarray,
         resampling: str = "cubic",
-        trim_border: bool = True
+        trim_border: bool = True,
+        dilate_mask: bool = True,
     ) -> np.ndarray:
     """
     Warp a DEM using a set of source-destination 2D or 3D coordinates.
@@ -1881,6 +1884,7 @@ def warp_dem(
     :param destination_coords: The destination 2D or 3D points. Must have the exact same shape as 'source_coords'
     :param resampling: The resampling order to use. Choices: ['nearest', 'linear', 'cubic'].
     :param trim_border: Remove values outside of the interpolation regime (True) or leave them unmodified (False).
+    :param dilate_mask: Dilate the nan mask to exclude edge pixels that could be wrong.
 
     :raises ValueError: If the inputs are poorly formatted.
     :raises AssertionError: For unexpected outputs.
@@ -1958,20 +1962,24 @@ def warp_dem(
             # An skimage warning that will hopefully be fixed soon. (2021-06-08)
             warnings.filterwarnings("ignore", message="Passing `np.nan` to mean no clipping in np.clip")
             warped = skimage.transform.warp(
-                image=np.where(dem_mask, -9999.12345, dem_arr),
+                image=np.where(dem_mask, np.nan, dem_arr),
                 inverse_map=np.moveaxis(new_indices, 2, 0),
                 output_shape=dem_arr.shape,
                 preserve_range=True,
                 order=order[resampling],
-                cval=-9999.12345
+                cval=np.nan
             )
             new_mask = skimage.transform.warp(
                 image=dem_mask,
                 inverse_map=np.moveaxis(new_indices, 2, 0),
                 output_shape=dem_arr.shape,
                 cval=False
-            ) == 1
-            warped[new_mask | (warped == -9999.12345)] = np.nan
+            ) > 0.25
+
+        if dilate_mask:
+            new_mask = scipy.ndimage.morphology.binary_dilation(new_mask, iterations=order[resampling]).astype(new_mask.dtype)
+
+        warped[new_mask] = np.nan
 
 
     # If the coordinates are 3D (N, 3), apply a Z correction as well.

--- a/xdem/spatial_tools.py
+++ b/xdem/spatial_tools.py
@@ -4,6 +4,7 @@ from typing import Callable, Union, Sized
 import warnings
 
 import geoutils as gu
+from geoutils.georaster import RasterType
 import numpy as np
 import rasterio as rio
 import rasterio.warp
@@ -27,7 +28,7 @@ def get_mask(array: Union[np.ndarray, np.ma.masked_array]) -> np.ndarray:
 
 
 def get_array_and_mask(
-        array: Union[np.ndarray, np.ma.masked_array],
+        array: np.ndarray | np.ma.masked_array | RasterType,
         check_shape: bool = True,
         copy: bool = True
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -42,6 +43,9 @@ def get_array_and_mask(
     :returns array_data, invalid_mask: a tuple of ndarrays. First is array with invalid pixels converted to NaN, \
     second is mask of invalid pixels (True if invalid).
     """
+    if isinstance(array, gu.Raster):
+        array = array.data
+
     if check_shape:
         if len(array.shape) > 2 and array.shape[0] > 1:
             raise ValueError(


### PR DESCRIPTION
Fixes #195 .

Changes:
- `warp_dem()` now has mask dilation by default.
- `get_array_and_mask()` takes and properly respects Rasters now (it was used with rasters before, but the mask was not respected).
- -9999 values in `warp_dem()` were replaced by np.nan
- Added a warning catcher in `apply_matrix()` (due to skimage + numpy deprecation warning)
- Improved test to validate that the above changes fixes the problem.

Something that is not tested automatically but was tested manually was the example by @adehecq in #195 in `examples/plot_blockwise_coreg.py`. As seen in the screenshot in #195, these fixes solve that problem.