### PR TITLE
Fix import errors, add solution for TLS issue on older systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ conda install -c conda-forge --strict-channel-priority xdem
 ```
 The `--strict-channel-priority` flag seems essential for Windows installs to function correctly, and is recommended for UNIX-based systems as well.
 
+If running into the `sklearn` error `ImportError: dlopen: cannot load any more object with static TLS`, your system 
+needs to update its `glibc` (see details [here](https://github.com/scikit-learn/scikit-learn/issues/14485)).
+If you have no administrator right on the system, you can circumvent this issue by installing an environment with a
+ downgraded version of scikit-learn:
+```bash
+mamba create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy=1.19.*
+
+```
 
 ### Installing with pip
 **NOTE**: Setting up GDAL and PROJ may need some extra steps, depending on your operating system and configuration.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ conda install mamba -n base -c conda-forge`
 Once installed, the same commands can be run by simply replacing `conda` by `mamba`. More details available through the [mamba project](https://github.com/mamba-org/mamba).
 
 If running into the `sklearn` error `ImportError: dlopen: cannot load any more object with static TLS`, your system 
-needs to update its `glibc` (see details [here](https://github.com/scikit-learn/scikit-learn/issues/14485)).
+needs to update its `glibc` (see details [here](https://github.com/scikit-learn/scikit-learn/issues/14485#issuecomment-822678559)).
 If you have no administrator right on the system, you might be able to circumvent this issue by installing a working 
 environment with specific downgraded versions of `scikit-learn` and `numpy`:
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ needs to update its `glibc` (see details [here](https://github.com/scikit-learn/
 If you have no administrator right on the system, you might be able to circumvent this issue by installing a working 
 environment with specific downgraded versions of `scikit-learn` and `numpy`:
 ```bash
-conda create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy=1.19.*
+conda create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy==1.19.*
 ```
+On very old systems, if the above install results in segmentation faults, try setting more specifically:
+ `numpy==1.19.2=py37h54aff64_0` (worked with Debian 8.11, GLIBC 2.19)
 
 ### Installing with pip
 **NOTE**: Setting up GDAL and PROJ may need some extra steps, depending on your operating system and configuration.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `--strict-channel-priority` flag seems essential for Windows installs to fun
 Solving dependencies can take a long time with `conda`. To speed up this, consider installing `mamba`:
 
 ```bash
-conda install mamba -n base -c conda-forge`
+conda install mamba -n base -c conda-forge
 ```
 
 Once installed, the same commands can be run by simply replacing `conda` by `mamba`. More details available through the [mamba project](https://github.com/mamba-org/mamba).

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ environment with specific downgraded versions of `scikit-learn` and `numpy`:
 ```bash
 conda create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy==1.19.*
 ```
-On very old systems, if the above install results in segmentation faults, try setting more specifically:
- `numpy==1.19.2=py37h54aff64_0` (worked with Debian 8.11, GLIBC 2.19)
+On very old systems, if the above install results in segmentation faults, try setting more specifically 
+`numpy==1.19.2=py37h54aff64_0` (worked with Debian 8.11, GLIBC 2.19).
 
 ### Installing with pip
 **NOTE**: Setting up GDAL and PROJ may need some extra steps, depending on your operating system and configuration.

--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ conda install -c conda-forge --strict-channel-priority xdem
 ```
 The `--strict-channel-priority` flag seems essential for Windows installs to function correctly, and is recommended for UNIX-based systems as well.
 
+Solving dependencies can take a long time with `conda`. To speed up this, consider installing `mamba`:
+
+`conda install mamba -n base -c conda-forge`
+
+Once installed, the same commands can be run by simply replacing `conda` by `mamba`. More details available through the [mamba project](https://github.com/mamba-org/mamba).
+
 If running into the `sklearn` error `ImportError: dlopen: cannot load any more object with static TLS`, your system 
 needs to update its `glibc` (see details [here](https://github.com/scikit-learn/scikit-learn/issues/14485)).
-If you have no administrator right on the system, you can circumvent this issue by installing an environment with a
- downgraded version of scikit-learn:
+If you have no administrator right on the system, you might be able to circumvent this issue by installing a working 
+environment with specific downgraded versions of `scikit-learn` and `numpy`:
 ```bash
-mamba create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy=1.19.*
+conda create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy=1.19.*
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ The `--strict-channel-priority` flag seems essential for Windows installs to fun
 
 Solving dependencies can take a long time with `conda`. To speed up this, consider installing `mamba`:
 
-`conda install mamba -n base -c conda-forge`
+```bash
+conda install mamba -n base -c conda-forge`
+```
 
 Once installed, the same commands can be run by simply replacing `conda` by `mamba`. More details available through the [mamba project](https://github.com/mamba-org/mamba).
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ If you have no administrator right on the system, you might be able to circumven
 environment with specific downgraded versions of `scikit-learn` and `numpy`:
 ```bash
 conda create -n xdem-env -c conda-forge xdem scikit-learn==0.20.3 numpy=1.19.*
-
 ```
 
 ### Installing with pip

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -11,6 +11,11 @@ import warnings
 from enum import Enum
 from typing import Any, Callable, Optional, overload, Union, Sequence, TypeVar
 
+try:
+    import cv2
+    _has_cv2 = True
+except ImportError:
+    _has_cv2 = False
 import fiona
 import geoutils as gu
 from geoutils.georaster import RasterType
@@ -34,12 +39,6 @@ try:
     _has_rd = True
 except ImportError:
     _has_rd = False
-
-try:
-    import cv2
-    _has_cv2 = True
-except ImportError:
-    _has_cv2 = False
 
 try:
     from pytransform3d.transform_manager import TransformManager

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -917,8 +917,10 @@ class ICP(Coreg):
     def _fit_func(self, ref_dem: np.ndarray, tba_dem: np.ndarray, transform: Optional[rio.transform.Affine],
                   weights: Optional[np.ndarray], verbose: bool = False):
         """Estimate the rigid transform from tba_dem to ref_dem."""
+
         if weights is not None:
             warnings.warn("ICP was given weights, but does not support it.")
+
 
         bounds, resolution = _transform_to_bounds_and_res(ref_dem.shape, transform)
         points: dict[str, np.ndarray] = {}
@@ -1391,6 +1393,10 @@ def apply_matrix(dem: np.ndarray, transform: rio.transform.Affine, matrix: np.nd
     empty_matrix[2, 3] = matrix[2, 3]
     if np.mean(np.abs(empty_matrix - matrix)) == 0.0:
         return demc + matrix[2, 3]
+
+    # Opencv is required down from here
+    if not _has_cv2:
+        raise ValueError("Optional dependency needed. Install 'opencv'")
 
     nan_mask = xdem.spatial_tools.get_mask(dem)
     assert np.count_nonzero(~nan_mask) > 0, "Given DEM had all nans."

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -5,7 +5,12 @@ import functools
 import warnings
 from typing import Any, Callable
 
-import cv2
+try:
+    import cv2
+    _has_cv2 = True
+except ImportError:
+    _has_cv2 = False
+
 import numpy as np
 
 import xdem.version
@@ -28,6 +33,10 @@ def generate_random_field(shape: tuple[int, int], corr_size: int) -> np.ndarray:
 
     :returns: A numpy array of semi-random values from 0 to 1
     """
+
+    if not _has_cv2:
+        raise ValueError("Optional dependency needed. Install 'opencv'")
+
     field = cv2.resize(
         cv2.GaussianBlur(
             np.repeat(


### PR DESCRIPTION
Resolves #199

- Added a description of the solution to circumvent the `dlopen` issue in the **README**: based on https://github.com/scikit-learn/scikit-learn/issues/14485#issuecomment-761735034, with additional conditions for `numpy` to function properly
- Added loop for optional `cv2` imports that were missing in `coreg.py` and `misc.py`
- Moved `cv2` imports before xdem to avoid `opencv` TLS errors: https://github.com/tensorflow/models/issues/523
- Performed tests to check that `xdem` runs normally with environments solved by `conda`/`mamba`, all seems OK now.