### PR TITLE
Add scaling factor details to `nmad` function description

### DIFF
--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -33,7 +33,8 @@ def nmad(data: np.ndarray, nfact: float = 1.4826) -> float:
     """
     Calculate the normalized median absolute deviation (NMAD) of an array.
     Default scaling factor is 1.4826 to scale the median absolute deviation (MAD) to the dispersion of a normal
-    distribution (see e.g. http://dx.doi.org/10.1016/j.isprsjprs.2009.02.003)
+    distribution (see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation, and
+    e.g. http://dx.doi.org/10.1016/j.isprsjprs.2009.02.003)
 
     :param data: input data
     :param nfact: normalization factor for the data


### PR DESCRIPTION
Resolves #217
fyi, @erikmannerfelt: this was already described in the *Robust statistics* page of our documentation :wink: 