### PR TITLE
Fix issue with NaNs masks in Coreg methods

### DIFF
--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -280,7 +280,7 @@ class TestPatchesMethod:
 
         # Check the sampling is always fixed for a random state
         assert df['tile'].values[0] == '31_184'
-        assert df['nanmedian'].values[0] == pytest.approx(2.28, abs=0.01)
+        assert df['nanmedian'].values[0] == pytest.approx(2.3, abs=0.01)
 
         # Check that all counts respect the default minimum percentage of 80% valid pixels
         assert all(df['count'].values > 0.8*np.max(df['count'].values))


### PR DESCRIPTION
This is a fix to #237.
During coreg.apply, a resampling is needed. When NaNs exist in the input DEMs, the NaNs also propagate and must be handled carefully. Currently, such resampling is done at 3 different places, and NaNs are not always caught properly.
This PR tries to fix this issue.

I also fixed a small issue in BlockwiseCoreg. Errors during fitting were caught, but not during apply.