### PR TITLE
Fix issue in volume.calculate_hypsometry_area when ddem_bins contain NaNs

### DIFF
--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -231,10 +231,14 @@ def calculate_hypsometry_area(ddem_bins: Union[pd.Series, pd.DataFrame], ref_dem
 
     if isinstance(ddem_bins, pd.DataFrame):
         ddem_bins = ddem_bins["value"]
-    assert not np.any(np.isnan(ddem_bins.values)), "The dDEM bins cannot contain NaNs. Remove or fill them first."
-    # Generate a continuous elevation vs. dDEM function
-    ddem_func = scipy.interpolate.interp1d(ddem_bins.index.mid, ddem_bins.values,
-                                           kind="linear", fill_value="extrapolate")
+
+    if timeframe in ["mean", "nonreference"]:
+        assert not np.any(np.isnan(ddem_bins.values)), "The dDEM bins cannot contain NaNs. Remove or fill them first."
+
+        # Generate a continuous elevation vs. dDEM function
+        ddem_func = scipy.interpolate.interp1d(ddem_bins.index.mid, ddem_bins.values,
+                                               kind="linear", fill_value="extrapolate")
+
     # Generate average elevations by subtracting half of the dDEM's values to the reference DEM
     if timeframe == "mean":
         elevations = ref_dem - (ddem_func(ref_dem.data) / 2)

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -232,6 +232,7 @@ def calculate_hypsometry_area(ddem_bins: Union[pd.Series, pd.DataFrame], ref_dem
     if isinstance(ddem_bins, pd.DataFrame):
         ddem_bins = ddem_bins["value"]
 
+    # For timeframe "mean" or "nonreference", check that ddem_bins values can be interpolated at any altitude
     if timeframe in ["mean", "nonreference"]:
         assert not np.any(np.isnan(ddem_bins.values)), "The dDEM bins cannot contain NaNs. Remove or fill them first."
 


### PR DESCRIPTION
`volume.calculate_hypsometry_area` raises an `AssertionError` when `ddem_bins` contains gaps/NaNs. This should not be the case when `timeframe` is set to "reference", as the ddem_bins values are not used.
Fixed this.