### PR TITLE
Force geoutils to 0.0.7

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -33,5 +33,6 @@ dependencies:
   - sphinx-gallery
 
   - pip:
-    - git+https://github.com/GlacioHack/GeoUtils.git
+    - geoutils==0.0.7
+#    - git+https://github.com/GlacioHack/GeoUtils.git
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -33,6 +33,6 @@ dependencies:
   - sphinx-gallery
 
   - pip:
-    - geoutils==0.0.7
+    - geoutils==0.0.8
 #    - git+https://github.com/GlacioHack/GeoUtils.git
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,2 +1,0 @@
-Examples gallery
-================


### PR DESCRIPTION
To avoid all hell breaking loose from https://github.com/GlacioHack/GeoUtils/pull/265, but also for long-term stability with releases.

Resolves #268 