### PR TITLE
Fix tests with GeoUtils `data.setter` and `__array_interface__` update

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install pytest-cov coveralls
-        pytest -ra -n=auto --cov=xdem/
+        pytest -ra --cov=xdem/
 
     # We can skip the conversion step once this PR of pytest is merged: https://github.com/pytest-dev/pytest-cov/pull/536
     # and replace pytest argument by --cov-report=lcov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,12 +28,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Ensure environment variables are correctly set
-      run: |
-        export LC_ALL=C
-        export LC_CTYPE="C"
-        export LC_MESSAGES="C"
-
     # Set up the conda-forge environment with mamba
     - name: Set up Python ${{ matrix.python-version }} and dependencies
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Ensure environment variables are correctly set
+      run: |
+        export LC_ALL=C
+        export LC_CTYPE="C"
+        export LC_MESSAGES="C"
+
     # Set up the conda-forge environment with mamba
     - name: Set up Python ${{ matrix.python-version }} and dependencies
       uses: conda-incubator/setup-miniconda@v2

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio<=1.2.10
+  - rasterio>=1.3
   - scipy
   - tqdm
   - scikit-image

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio<=1.2.10
+  - rasterio
   - scipy
   - tqdm
   - scikit-image

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio>=1.3
+  - rasterio<=1.2.10
   - scipy
   - tqdm
   - scikit-image

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio<=1.2.10
+  - rasterio
   - scipy
   - tqdm
   - scikit-image

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio>=1.3
+  - rasterio<=1.2.10
   - scipy
   - tqdm
   - scikit-image

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - matplotlib
   - opencv
   - pyproj
-  - rasterio
+  - rasterio>=1.3
   - scipy
   - tqdm
   - scikit-image

--- a/examples/advanced/plot_heterosc_estimation_modelling.py
+++ b/examples/advanced/plot_heterosc_estimation_modelling.py
@@ -207,6 +207,6 @@ for s, c in [(0., 0.1), (50., 0.1), (0., 20.), (50., 20.)]:
 # %%
 # This function can be used to estimate the spatial distribution of the elevation error on the extent of our DEMs:
 maxc = np.maximum(np.abs(profc), np.abs(planc))
-errors = dh.copy(new_array= dh_err_fun((slope, maxc)))
+errors = dh.copy(new_array= dh_err_fun((slope.data, maxc.data)))
 
 errors.show(cmap='Reds', vmin=2, vmax=8, cb_title='Elevation error ($1\sigma$, m)')

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -514,8 +514,9 @@ class TestCoregClass:
 
         # Copy the TBA DEM and set a square portion to nodata
         tba = self.tba.copy()
-        tba.data[0, 450:500, 450:500] = -9999
-        tba.set_ndv(-9999)
+        mask = np.zeros(np.shape(tba.data), dtype=bool)
+        mask[0, 450: 500, 450: 500] = True
+        tba.set_mask(mask=mask)
 
         blockwise = xdem.coreg.BlockwiseCoreg(xdem.coreg.NuthKaab(), 8, warn_failures=False)
 
@@ -618,7 +619,7 @@ class TestCoregClass:
         ref_dem, tba_dem, transform, testing_step, result, text = combination
         # Create a small sample-DEM
         dem1 = xdem.DEM.from_array(
-            np.arange(25, dtype="int32").reshape(5, 5),
+            np.arange(25, dtype="float64").reshape(5, 5),
             transform=rio.transform.from_origin(0, 5, 1, 1),
             crs=4326,
             nodata=-9999

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -578,7 +578,7 @@ class TestCoregClass:
         # TODO - Fix coreg.apply?
         assert isinstance(dem2_r, xdem.DEM)
         assert isinstance(dem2_a, np.ma.masked_array)
-        assert gu.misc.array_equal(dem2_r.data.squeeze(), dem2_a, equal_nan=True)
+        assert np.ma.allequal(dem2_r.data.squeeze(), dem2_a)
 
         # If apply on a masked_array was given without a transform, it should fail.
         with pytest.raises(ValueError, match="'transform' must be given"):

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -391,7 +391,7 @@ class TestVariogram:
         # Ground sampling distance
         gsd = values.res[0]
         # Coords
-        nx, ny = np.shape(values)
+        nx, ny = values.shape
         x, y = np.meshgrid(np.arange(0, values.shape[0] * gsd, gsd), np.arange(0, values.shape[1] * gsd, gsd))
         coords = np.dstack((x.ravel(), y.ravel())).squeeze()
 
@@ -411,7 +411,7 @@ class TestVariogram:
         # Extent
         extent = (np.min(coords[:, 0]), np.max(coords[:, 0]), np.min(coords[:, 1]), np.max(coords[:, 1]))
         # Shape
-        shape = np.shape(values)
+        shape = values.shape
         # Random state
         rnd = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(42)))
 

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -440,7 +440,7 @@ class Coreg:
             raise NotImplementedError("Weights have not yet been implemented")
 
         # Validate that both inputs are valid array-like (or Raster) types.
-        if not all(isinstance(dem, (np.ndarray | gu.Raster)) for dem in (reference_dem, dem_to_be_aligned)):
+        if not all(isinstance(dem, (np.ndarray, gu.Raster)) for dem in (reference_dem, dem_to_be_aligned)):
             raise ValueError(
                 "Both DEMs need to be array-like (implement a numpy array interface)."
                 f"'reference_dem': {reference_dem}, 'dem_to_be_aligned': {dem_to_be_aligned}"

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -440,7 +440,7 @@ class Coreg:
             raise NotImplementedError("Weights have not yet been implemented")
 
         # Validate that both inputs are valid array-like (or Raster) types.
-        if not all(hasattr(dem, "__array_interface__") for dem in (reference_dem, dem_to_be_aligned)):
+        if not all(isinstance(dem, (np.ndarray | gu.Raster)) for dem in (reference_dem, dem_to_be_aligned)):
             raise ValueError(
                 "Both DEMs need to be array-like (implement a numpy array interface)."
                 f"'reference_dem': {reference_dem}, 'dem_to_be_aligned': {dem_to_be_aligned}"

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -579,6 +579,9 @@ class Coreg:
             else:
                 raise ValueError("Coreg method is non-rigid but has no implemented _apply_func")
 
+        # Ensure the dtype is OK
+        applied_dem = applied_dem.astype("float32")
+
         # Calculate final mask
         final_mask = ~np.isfinite(applied_dem)
 

--- a/xdem/demcollection.py
+++ b/xdem/demcollection.py
@@ -47,8 +47,7 @@ class DEMCollection:
 
         # Find the sort indices from the timestamps
         indices = np.argsort(self.timestamps.astype("int64"))
-        self.dems = np.empty(len(dems), dtype=object)
-        self.dems[:] = [dems[i] for i in indices]
+        self.dems = [dems[i] for i in indices]
         self.ddems: list[xdem.dDEM] = []
         # The reference index changes place when sorted
         if isinstance(reference_dem, (int, np.integer)):

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -49,7 +49,7 @@ def download_longyearbyen_examples(overwrite: bool = False):
                 os.remove(fn)
 
     # Static commit hash to be bumped every time it needs to be.
-    commit = "321f84d5a67666f45a196a31a2697e22bfaf3c59"
+    commit = "fd832bc2e366cf2ba8b543f7e43f90ee02384f4f"
     # The URL from which to download the repository
     url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
 
@@ -97,10 +97,6 @@ def process_coregistered_examples(overwrite: bool =False):
     to_be_aligned_raster = gu.georaster.Raster(FILEPATHS_DATA["longyearbyen_tba_dem"])
     glacier_mask = gu.geovector.Vector(FILEPATHS_DATA["longyearbyen_glacier_outlines"])
     inlier_mask = ~glacier_mask.create_mask(reference_raster)
-
-    # This is to avoid issues with floating point nodatas
-    reference_raster.set_nodata(-9999)
-    to_be_aligned_raster.set_nodata(-9999)
 
     nuth_kaab = xdem.coreg.NuthKaab()
     nuth_kaab.fit(reference_raster, to_be_aligned_raster,

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -98,6 +98,10 @@ def process_coregistered_examples(overwrite: bool =False):
     glacier_mask = gu.geovector.Vector(FILEPATHS_DATA["longyearbyen_glacier_outlines"])
     inlier_mask = ~glacier_mask.create_mask(reference_raster)
 
+    # This is to avoid issues with floating point nodatas
+    reference_raster.set_ndv(-9999)
+    to_be_aligned_raster.set_ndv(-9999)
+
     nuth_kaab = xdem.coreg.NuthKaab()
     nuth_kaab.fit(reference_raster, to_be_aligned_raster,
                   inlier_mask=inlier_mask)

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -99,8 +99,8 @@ def process_coregistered_examples(overwrite: bool =False):
     inlier_mask = ~glacier_mask.create_mask(reference_raster)
 
     # This is to avoid issues with floating point nodatas
-    reference_raster.set_ndv(-9999)
-    to_be_aligned_raster.set_ndv(-9999)
+    reference_raster.set_nodata(-9999)
+    to_be_aligned_raster.set_nodata(-9999)
 
     nuth_kaab = xdem.coreg.NuthKaab()
     nuth_kaab.fit(reference_raster, to_be_aligned_raster,

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -1012,7 +1012,7 @@ def get_terrain_attribute(
     output_attributes = [terrain_attributes[key].reshape(dem.shape) for key in attribute]
 
     if isinstance(dem, gu.Raster):
-        output_attributes = [gu.Raster.from_array(attr, transform=dem.transform, crs=dem.crs, nodata=None) for attr in output_attributes]
+        output_attributes = [gu.Raster.from_array(attr, transform=dem.transform, crs=dem.crs, nodata=-99999) for attr in output_attributes]
 
     return output_attributes if len(output_attributes) > 1 else output_attributes[0]
 


### PR DESCRIPTION
Updating a couple tests that used syntax only supported by the previous `__array_interface__` or raised `UserWarning` due to the new `data.setter` of `Raster`.
Will make CI pass once https://github.com/GlacioHack/geoutils/pull/302 is merged.