### PR TITLE
Make xdem compatible for Binder

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,0 +1,1 @@
+libgl1-mesa-glx

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,15 +1,25 @@
-name: xdem-demo
+name: xdem-binder
 channels:
   - conda-forge
 dependencies:
-  - pip
   - python>=3.8
   - jupyter
-  - jupytext  # used to render example scripts as notebooks
+  - jupytext
+  - proj>=7.2
+  - fiona
+  - shapely
+  - numba
   - numpy
   - matplotlib
-  - geoutils
-  - xdem
-  # - pip:
-  #     - git+https://github.com/GlacioHack/geoutils.git
-  #     - git+https://github.com/GlacioHack/xdem.git
+  - opencv
+  - pyproj
+  - rasterio
+  - scipy
+  - tqdm
+  - scikit-image
+  - proj-data
+  - scikit-gstat>=0.6.8
+  - pytransform3d
+
+  - pip:
+      - git+https://github.com/GlacioHack/geoutils.git

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,8 +5,11 @@ dependencies:
   - pip
   - python>=3.8
   - jupyter
+  - jupytext  # used to render example scripts as notebooks
   - numpy
   - matplotlib
-  - pip:
-      - git+https://github.com/GlacioHack/geoutils.git
-      - git+https://github.com/GlacioHack/xdem.git
+  - geoutils
+  - xdem
+  # - pip:
+  #     - git+https://github.com/GlacioHack/geoutils.git
+  #     - git+https://github.com/GlacioHack/xdem.git

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,12 @@
+name: xdem-demo
+channels:
+  - conda-forge
+dependencies:
+  - pip
+  - python>=3.8
+  - jupyter
+  - numpy
+  - matplotlib
+  - pip:
+      - git+https://github.com/GlacioHack/geoutils.git
+      - git+https://github.com/GlacioHack/xdem.git

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pip install -e .


### PR DESCRIPTION
To address #296 

This PR:
- Adds a binder repository
- In this folder, adds a postbuild file to run command `pip install -e .` to install xdem
- install optional dependencies