### PR TITLE
Unforce `openh264` version

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy
   - matplotlib
   - opencv
-  - openh264=2.3.0
+  - openh264
   - pyproj
   - rasterio>=1.3
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - numpy
   - matplotlib
   - opencv
-  - openh264=2.3.0
+  - openh264
   - pyproj
   - rasterio>=1.3
   - scipy


### PR DESCRIPTION
It's been a couple weeks, hopefully they should have pushed a fix on the `2.3` version update for the imports to work correctly.

Resolves #317