### PR TITLE
Fix loading of processed examples in `examples.py`

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -16,7 +16,7 @@ The dataset keys and paths can be found from
 
 .. code-block:: python
 
-        xdem.examples.FILEPATHS_DATA
+        xdem.examples.available
 
 Load DEMs and calculate elevation difference
 ------------------------------------------------

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -122,7 +122,7 @@ class TestBinning:
         assert df.shape[0] == (4**3 + 3 * 4**2 + 3 * 4)
 
         # Save for later use
-        df.to_csv(os.path.join(examples.EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index=False)
+        df.to_csv(os.path.join(examples._EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index=False)
 
     def test_interp_nd_binning_artificial_data(self) -> None:
         """Check that the N-dimensional interpolation works correctly using artificial data"""
@@ -220,7 +220,7 @@ class TestBinning:
 
         # Read nd_binning output
         df = pd.read_csv(
-            os.path.join(examples.EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None
+            os.path.join(examples._EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None
         )
 
         # First, in 1D
@@ -334,7 +334,7 @@ class TestBinning:
         assert np.array_equal(errors_1_arr, errors_2_arr, equal_nan=True)
 
         # Save for use in TestVariogram
-        errors_1.save(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors_1.save(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Check that errors are raised with wrong input
         with pytest.raises(ValueError, match="The values must be a Raster or NumPy array, or a list of those."):
@@ -737,7 +737,7 @@ class TestVariogram:
         diff_on_stable.set_mask(self.mask)
 
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Standardize the differences
         zscores = diff_on_stable / errors
@@ -788,7 +788,7 @@ class TestVariogram:
         )
         # Save the modelled variogram for later used in TestNeffEstimation
         params_model_vgm_5.to_csv(
-            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False
+            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False
         )
 
         # Check that errors are raised with wrong input
@@ -1067,11 +1067,11 @@ class TestNeffEstimation:
         """Test that the spatial error propagation wrapper function runs properly"""
 
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Load the spatial correlation from TestVariogram
         params_variogram_model = pd.read_csv(
-            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None
+            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None
         )
 
         # Run the function with vector areas

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -9,24 +9,25 @@ import geoutils as gu
 
 import xdem
 
-EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples", "data"))
+_EXAMPLES_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "examples", "data"))
 # Absolute filepaths to the example files.
-FILEPATHS_DATA = {
-    "longyearbyen_ref_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "data", "DEM_2009_ref.tif"),
-    "longyearbyen_tba_dem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "data", "DEM_1990.tif"),
+_FILEPATHS_DATA = {
+    "longyearbyen_ref_dem": os.path.join(_EXAMPLES_DIRECTORY, "Longyearbyen", "data", "DEM_2009_ref.tif"),
+    "longyearbyen_tba_dem": os.path.join(_EXAMPLES_DIRECTORY, "Longyearbyen", "data", "DEM_1990.tif"),
     "longyearbyen_glacier_outlines": os.path.join(
-        EXAMPLES_DIRECTORY, "Longyearbyen", "data", "glacier_mask", "CryoClim_GAO_SJ_1990.shp"
+        _EXAMPLES_DIRECTORY, "Longyearbyen", "data", "glacier_mask", "CryoClim_GAO_SJ_1990.shp"
     ),
     "longyearbyen_glacier_outlines_2010": os.path.join(
-        EXAMPLES_DIRECTORY, "Longyearbyen", "data", "glacier_mask", "CryoClim_GAO_SJ_2010.shp"
+        _EXAMPLES_DIRECTORY, "Longyearbyen", "data", "glacier_mask", "CryoClim_GAO_SJ_2010.shp"
     ),
 }
 
-FILEPATHS_PROCESSED = {
-    "longyearbyen_ddem": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "processed", "dDEM_2009_minus_1990.tif"),
-    "longyearbyen_tba_dem_coreg": os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "processed", "DEM_1990_coreg.tif"),
+_FILEPATHS_PROCESSED = {
+    "longyearbyen_ddem": os.path.join(_EXAMPLES_DIRECTORY, "Longyearbyen", "processed", "dDEM_2009_minus_1990.tif"),
+    "longyearbyen_tba_dem_coreg": os.path.join(_EXAMPLES_DIRECTORY, "Longyearbyen", "processed", "DEM_1990_coreg.tif"),
 }
 
+available = list(_FILEPATHS_DATA.keys()) + list(_FILEPATHS_PROCESSED.keys())
 
 def download_longyearbyen_examples(overwrite: bool = False) -> None:
     """
@@ -34,13 +35,13 @@ def download_longyearbyen_examples(overwrite: bool = False) -> None:
 
     :param overwrite: Do not download the files again if they already exist.
     """
-    if not overwrite and all(map(os.path.isfile, list(FILEPATHS_DATA.values()))):
+    if not overwrite and all(map(os.path.isfile, list(_FILEPATHS_DATA.values()))):
         # print("Datasets exist")
         return
 
     # If we ask for overwrite, also remove the processed test data
     if overwrite:
-        for fn in list(FILEPATHS_PROCESSED.values()):
+        for fn in list(_FILEPATHS_PROCESSED.values()):
             if os.path.exists(fn):
                 os.remove(fn)
 
@@ -74,67 +75,67 @@ def download_longyearbyen_examples(overwrite: bool = False) -> None:
     )
 
     # Copy the data to the examples directory.
-    copy_tree(dir_name, os.path.join(EXAMPLES_DIRECTORY, "Longyearbyen", "data"))
+    copy_tree(dir_name, os.path.join(_EXAMPLES_DIRECTORY, "Longyearbyen", "data"))
 
 
-def process_coregistered_examples(overwrite: bool = False) -> None:
+def process_coregistered_examples(name: str, overwrite: bool = False) -> None:
     """
     Process the Longyearbyen example files into a dDEM (to avoid repeating this in many test/documentation steps).
 
+    :param name: Name of test data
     :param overwrite: Do not download the files again if they already exist.
     """
 
-    if not overwrite and all(map(os.path.isfile, list(FILEPATHS_PROCESSED.values()))):
-        # print("Processed data exists")
+    # If the file called already exists and overwrite is False, do nothing
+    if not overwrite and os.path.isfile(_FILEPATHS_PROCESSED[name]):
         return
 
+    # Check that data is downloaded before attempting processing
     download_longyearbyen_examples(overwrite=False)
 
-    # Run the coregistration if it hasn't been made yet.
-    reference_raster = gu.georaster.Raster(FILEPATHS_DATA["longyearbyen_ref_dem"])
-    to_be_aligned_raster = gu.georaster.Raster(FILEPATHS_DATA["longyearbyen_tba_dem"])
-    glacier_mask = gu.geovector.Vector(FILEPATHS_DATA["longyearbyen_glacier_outlines"])
-    inlier_mask = ~glacier_mask.create_mask(reference_raster)
+    # If the ddem file does not exist, create it
+    if not os.path.isfile(_FILEPATHS_PROCESSED["longyearbyen_ddem"]):
+        reference_raster = gu.georaster.Raster(_FILEPATHS_DATA["longyearbyen_ref_dem"])
+        to_be_aligned_raster = gu.georaster.Raster(_FILEPATHS_DATA["longyearbyen_tba_dem"])
+        glacier_mask = gu.geovector.Vector(_FILEPATHS_DATA["longyearbyen_glacier_outlines"])
+        inlier_mask = ~glacier_mask.create_mask(reference_raster)
 
-    nuth_kaab = xdem.coreg.NuthKaab()
-    nuth_kaab.fit(reference_raster, to_be_aligned_raster, inlier_mask=inlier_mask)
-    aligned_raster = nuth_kaab.apply(to_be_aligned_raster)
+        nuth_kaab = xdem.coreg.NuthKaab()
+        nuth_kaab.fit(reference_raster, to_be_aligned_raster, inlier_mask=inlier_mask)
+        aligned_raster = nuth_kaab.apply(to_be_aligned_raster)
 
-    diff = reference_raster - aligned_raster
+        diff = reference_raster - aligned_raster
 
-    # Save it so that future calls won't need to recreate the file
-    os.makedirs(os.path.dirname(FILEPATHS_PROCESSED["longyearbyen_ddem"]), exist_ok=True)
-    diff.save(FILEPATHS_PROCESSED["longyearbyen_ddem"])
+        # Save it so that future calls won't need to recreate the file
+        os.makedirs(os.path.dirname(_FILEPATHS_PROCESSED["longyearbyen_ddem"]), exist_ok=True)
+        diff.save(_FILEPATHS_PROCESSED["longyearbyen_ddem"])
 
+    # If the tba_dem_coreg file does not exist, create it
+    if not os.path.isfile(_FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"]):
 
-def _get_longyearbyen_tba_coreg_dem() -> str:
-    if not os.path.isfile(FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"]):
         dem_2009 = xdem.DEM(get_path("longyearbyen_ref_dem"), silent=True)
         ddem = xdem.DEM(get_path("longyearbyen_ddem"), silent=True)
 
-        (dem_2009 - ddem).save(FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"])
-
-    return FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"]
+        # Save it so that future calls won't need to recreate the file
+        (dem_2009 - ddem).save(_FILEPATHS_PROCESSED["longyearbyen_tba_dem_coreg"])
 
 
 def get_path(name: str) -> str:
     """
-    Get path of example data
-    :param name: Name of test data (listed in xdem/examples.py)
+    Get path of example data. List of available files can be found in "examples.available".
+    :param name: Name of test data
     :return:
     """
-    if name == "longyearbyen_tba_dem_coreg":
-        return _get_longyearbyen_tba_coreg_dem()
 
-    if name in list(FILEPATHS_DATA.keys()):
+    if name in list(_FILEPATHS_DATA.keys()):
         download_longyearbyen_examples()
-        return FILEPATHS_DATA[name]
-    elif name in list(FILEPATHS_PROCESSED.keys()):
-        process_coregistered_examples()
-        return FILEPATHS_PROCESSED[name]
+        return _FILEPATHS_DATA[name]
+    elif name in list(_FILEPATHS_PROCESSED.keys()):
+        process_coregistered_examples(name)
+        return _FILEPATHS_PROCESSED[name]
     else:
         raise ValueError(
             'Data name should be one of "'
-            + '" , "'.join(list(FILEPATHS_DATA.keys()) + list(FILEPATHS_PROCESSED.keys()))
+            + '" , "'.join(list(_FILEPATHS_DATA.keys()) + list(_FILEPATHS_PROCESSED.keys()))
             + '".'
         )

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -29,6 +29,7 @@ _FILEPATHS_PROCESSED = {
 
 available = list(_FILEPATHS_DATA.keys()) + list(_FILEPATHS_PROCESSED.keys())
 
+
 def download_longyearbyen_examples(overwrite: bool = False) -> None:
     """
     Fetch the Longyearbyen example files.


### PR DESCRIPTION
This PR fixes a bug in the function `process_coregistered_examples` of `examples.py` that made the `ddem` processing run every time the file was called with `xdem.example.get_path("longyearbyen_ddem")`. This should save us some time in testing and building documentation! :smile:
 
Additionally, it makes the variables `FILEPATHS_DATA` and `FILEPATHS_PROCESSED` not accessible to users (adding `_` in front), and create the `xdem.examples.available` variable that list keys of both dictionaries that can be called with `xdem.examples.get_path()`, for consistency with GeoUtils https://github.com/GlacioHack/geoutils/pull/284.