### PR TITLE
Fix xDEM with a new GeoUtils release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
 
         # Sort imports using isort
         - repo: https://github.com/PyCQA/isort
-          rev: 5.10.1
+          rev: 5.12.0
           hooks:
                   - id: isort
                     args: ["--profile", "black"]

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -37,5 +37,5 @@ dependencies:
   - richdem
 
   - pip:
-    - git+https://github.com/GlacioHack/GeoUtils.git
-    # - geoutils==0.0.9
+    # - git+https://github.com/GlacioHack/GeoUtils.git
+    - geoutils==0.0.10

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -37,4 +37,5 @@ dependencies:
   - richdem
 
   - pip:
-    - geoutils==0.0.9
+    - git+https://github.com/GlacioHack/GeoUtils.git
+    # - geoutils==0.0.9

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ scipy
 rasterio
 pyproj
 tqdm
-git+https://github.com/GlacioHack/geoutils.git
+geoutils
 scikit-gstat
 flake8
 opencv-contrib-python

--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - pip
 
   - pip:
-    - git+https://github.com/GlacioHack/GeoUtils.git
-    # - geoutils==0.0.9
+    # - git+https://github.com/GlacioHack/GeoUtils.git
+    - geoutils==0.0.10

--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,5 @@ dependencies:
   - pip
 
   - pip:
-    - geoutils==0.0.9
+    - git+https://github.com/GlacioHack/GeoUtils.git
+    # - geoutils==0.0.9

--- a/examples/advanced/plot_blockwise_coreg.py
+++ b/examples/advanced/plot_blockwise_coreg.py
@@ -79,7 +79,9 @@ aligned_dem = blockwise.apply(dem_to_be_aligned)
 # This shows the estimated shifts that would be applied in elevation; additional horizontal shifts will also be applied if the method supports it.
 # The :func:`xdem.coreg.BlockwiseCoreg.stats` method can be used to annotate each block with its associated Z shift.
 
-z_correction = blockwise.apply(np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform, crs=dem_to_be_aligned.crs)[0]
+z_correction = blockwise.apply(
+    np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform, crs=dem_to_be_aligned.crs
+)[0]
 plt.title("Vertical correction")
 plt.imshow(z_correction, cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
 for _, row in blockwise.stats().iterrows():

--- a/examples/advanced/plot_blockwise_coreg.py
+++ b/examples/advanced/plot_blockwise_coreg.py
@@ -79,7 +79,7 @@ aligned_dem = blockwise.apply(dem_to_be_aligned)
 # This shows the estimated shifts that would be applied in elevation; additional horizontal shifts will also be applied if the method supports it.
 # The :func:`xdem.coreg.BlockwiseCoreg.stats` method can be used to annotate each block with its associated Z shift.
 
-z_correction = blockwise.apply(np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform)
+z_correction = blockwise.apply(np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform, crs=dem_to_be_aligned.crs)[0]
 plt.title("Vertical correction")
 plt.imshow(z_correction, cmap="coolwarm_r", vmin=-10, vmax=10, extent=plt_extent)
 for _, row in blockwise.stats().iterrows():

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1238,8 +1238,8 @@ def test_dem_coregistration() -> None:
 
     # Test saving to file
     with tempfile.NamedTemporaryFile() as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name+'.tif')
-        dem_coreg2 = xdem.DEM(outfile.name+'.tif')
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name + ".tif")
+        dem_coreg2 = xdem.DEM(outfile.name + ".tif")
         assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,7 +1237,7 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file (mode = "w" is necessary to work on Windows)
-    outfile = tempfile.NamedTemporaryFile(suffix=".tif", mode="w")
+    outfile = tempfile.NamedTemporaryFile(suffix=".tif", mode="w", delete=False)
     xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
     dem_coreg2 = xdem.DEM(outfile.name)
     assert dem_coreg2 == dem_coreg
@@ -1257,7 +1257,7 @@ def test_dem_coregistration() -> None:
     assert np.all(~inlier_mask[gl_mask])
 
     # Testing with plot
-    out_fig = tempfile.NamedTemporaryFile(suffix=".png", mode="w")
+    out_fig = tempfile.NamedTemporaryFile(suffix=".png", mode="w", delete=False)
     assert os.path.getsize(out_fig.name) == 0
     xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
     assert os.path.getsize(out_fig.name) > 0

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,9 +1237,9 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file
-    with tempfile.NamedTemporaryFile() as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name + ".tif")
-        dem_coreg2 = xdem.DEM(outfile.name + ".tif")
+    with tempfile.NamedTemporaryFile(suffix=".tif") as outfile:
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
+        dem_coreg2 = xdem.DEM(outfile.name)
         assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines
@@ -1256,11 +1256,10 @@ def test_dem_coregistration() -> None:
     assert np.all(~inlier_mask[gl_mask])
 
     # Testing with plot
-    out_fig = tempfile.NamedTemporaryFile(suffix=".png")
-    assert os.path.getsize(out_fig.name) == 0
-    _, _, _, _ = xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
-    assert os.path.getsize(out_fig.name) > 0
-    out_fig.close()
+    with tempfile.NamedTemporaryFile(suffix=".png") as out_fig:
+        assert os.path.getsize(out_fig.name) == 0
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
+        assert os.path.getsize(out_fig.name) > 0
 
     # Testing different coreg method
     dem_coreg, coreg_method, coreg_stats, inlier_mask = xdem.coreg.dem_coregistration(

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,11 +1237,10 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file
-    outfile = tempfile.NamedTemporaryFile()
-    _, _, _, _ = xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
-    dem_coreg2 = xdem.DEM(outfile.name)
-    assert dem_coreg2 == dem_coreg
-    outfile.close()
+    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as outfile:
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
+        dem_coreg2 = xdem.DEM(outfile.name)
+        assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines
     # Need to use resample=True, to ensure that dem_coreg has same georef as inlier_mask

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,9 +1237,9 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file
-    with tempfile.NamedTemporaryFile(suffix=".tif") as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
-        dem_coreg2 = xdem.DEM(outfile.name)
+    with tempfile.NamedTemporaryFile() as outfile:
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name + ".tif")
+        dem_coreg2 = xdem.DEM(outfile.name + ".tif")
         assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines
@@ -1256,10 +1256,10 @@ def test_dem_coregistration() -> None:
     assert np.all(~inlier_mask[gl_mask])
 
     # Testing with plot
-    with tempfile.NamedTemporaryFile(suffix=".png") as out_fig:
-        assert os.path.getsize(out_fig.name) == 0
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
-        assert os.path.getsize(out_fig.name) > 0
+    with tempfile.NamedTemporaryFile() as out_fig:
+        assert os.path.getsize(out_fig.name + ".png") == 0
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name + ".png")
+        assert os.path.getsize(out_fig.name + ".png") > 0
 
     # Testing different coreg method
     dem_coreg, coreg_method, coreg_stats, inlier_mask = xdem.coreg.dem_coregistration(

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,10 +1237,11 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file (mode = "w" is necessary to work on Windows)
-    with tempfile.NamedTemporaryFile(suffix=".tif", mode="w") as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
-        dem_coreg2 = xdem.DEM(outfile.name)
-        assert dem_coreg2 == dem_coreg
+    outfile = tempfile.NamedTemporaryFile(suffix=".tif", mode="w")
+    xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
+    dem_coreg2 = xdem.DEM(outfile.name)
+    assert dem_coreg2 == dem_coreg
+    outfile.close()
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines
     # Need to use resample=True, to ensure that dem_coreg has same georef as inlier_mask
@@ -1256,10 +1257,11 @@ def test_dem_coregistration() -> None:
     assert np.all(~inlier_mask[gl_mask])
 
     # Testing with plot
-    with tempfile.NamedTemporaryFile(suffix=".png", mode="w") as out_fig:
-        assert os.path.getsize(out_fig.name) == 0
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
-        assert os.path.getsize(out_fig.name) > 0
+    out_fig = tempfile.NamedTemporaryFile(suffix=".png", mode="w")
+    assert os.path.getsize(out_fig.name) == 0
+    xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
+    assert os.path.getsize(out_fig.name) > 0
+    out_fig.close()
 
     # Testing different coreg method
     dem_coreg, coreg_method, coreg_stats, inlier_mask = xdem.coreg.dem_coregistration(

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1236,10 +1236,10 @@ def test_dem_coregistration() -> None:
     dem_coreg2, _, _, _ = xdem.coreg.dem_coregistration(tba_dem.filename, ref_dem.filename)
     assert dem_coreg2 == dem_coreg
 
-    # Test saving to file
-    with tempfile.NamedTemporaryFile() as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name + ".tif")
-        dem_coreg2 = xdem.DEM(outfile.name + ".tif")
+    # Test saving to file (mode = "w" is necessary to work on Windows)
+    with tempfile.NamedTemporaryFile(suffix=".tif", mode="w") as outfile:
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
+        dem_coreg2 = xdem.DEM(outfile.name)
         assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines
@@ -1256,10 +1256,10 @@ def test_dem_coregistration() -> None:
     assert np.all(~inlier_mask[gl_mask])
 
     # Testing with plot
-    with tempfile.NamedTemporaryFile() as out_fig:
-        assert os.path.getsize(out_fig.name + ".png") == 0
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name + ".png")
-        assert os.path.getsize(out_fig.name + ".png") > 0
+    with tempfile.NamedTemporaryFile(suffix=".png", mode="w") as out_fig:
+        assert os.path.getsize(out_fig.name) == 0
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, plot=True, out_fig=out_fig.name)
+        assert os.path.getsize(out_fig.name) > 0
 
     # Testing different coreg method
     dem_coreg, coreg_method, coreg_stats, inlier_mask = xdem.coreg.dem_coregistration(

--- a/tests/test_coreg.py
+++ b/tests/test_coreg.py
@@ -1237,9 +1237,9 @@ def test_dem_coregistration() -> None:
     assert dem_coreg2 == dem_coreg
 
     # Test saving to file
-    with tempfile.NamedTemporaryFile(dir=os.getcwd()) as outfile:
-        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name)
-        dem_coreg2 = xdem.DEM(outfile.name)
+    with tempfile.NamedTemporaryFile() as outfile:
+        xdem.coreg.dem_coregistration(tba_dem, ref_dem, out_dem_path=outfile.name+'.tif')
+        dem_coreg2 = xdem.DEM(outfile.name+'.tif')
         assert dem_coreg2 == dem_coreg
 
     # Test that shapefile is properly taken into account - inlier_mask should be False inside outlines


### PR DESCRIPTION
An update from GeoUtils is required after #329, this PR prepares that by pulling the latest GeoUtils directly
And fixing some remaining bugs that didn't make it through in the other PR (docs, Windows).

One tricky problem introduced in the tests of #329, the `NamedTemporaryFile` has permissions issues on Windows (see https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file). Details:
> Whether the name can be used to open the file a second time, 
> while the named temporary file is still open, varies across platforms 
> **(it can be so used on Unix; it cannot on Windows NT or later)**.
After some tweaking, I fixed it using the `mode` and `delete` arguments of, trick added to the Wiki: https://github.com/GlacioHack/xdem/wiki/Stuck-on-a-mysterious-error-during-CI%3F