### PR TITLE
Edit bands into indexes of DEM class

### DIFF
--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -4,6 +4,7 @@ import warnings
 
 import geoutils.georaster as gr
 import geoutils.satimg as si
+import rasterio as rio
 import numpy as np
 import pyproj
 import pytest
@@ -64,6 +65,10 @@ class TestDEM:
                 np.all(dem3.data.mask == dem4.data.mask),
             )
         )
+
+        # Check that an error is raised when more than one band is provided
+        with pytest.raises(ValueError, match="DEM rasters should be composed of one band only"):
+            xdem.DEM.from_array(data=np.zeros(shape=(2, 5, 5)), transform= rio.transform.from_bounds(0, 0, 1, 1, 5, 5), crs=None, nodata=None)
 
     def test_copy(self) -> None:
         """

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -4,10 +4,10 @@ import warnings
 
 import geoutils.georaster as gr
 import geoutils.satimg as si
-import rasterio as rio
 import numpy as np
 import pyproj
 import pytest
+import rasterio as rio
 from geoutils.georaster.raster import _default_rio_attrs
 
 import xdem
@@ -68,7 +68,12 @@ class TestDEM:
 
         # Check that an error is raised when more than one band is provided
         with pytest.raises(ValueError, match="DEM rasters should be composed of one band only"):
-            xdem.DEM.from_array(data=np.zeros(shape=(2, 5, 5)), transform= rio.transform.from_bounds(0, 0, 1, 1, 5, 5), crs=None, nodata=None)
+            xdem.DEM.from_array(
+                data=np.zeros(shape=(2, 5, 5)),
+                transform=rio.transform.from_bounds(0, 0, 1, 1, 5, 5),
+                crs=None,
+                nodata=None,
+            )
 
     def test_copy(self) -> None:
         """

--- a/xdem/coreg.py
+++ b/xdem/coreg.py
@@ -1401,7 +1401,7 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
 
         # Iteratively run the analysis until the maximum iterations or until the error gets low enough
         if verbose:
-            print("   Iteratively estimating horizontal shit:")
+            print("   Iteratively estimating horizontal shift:")
 
         # If verbose is True, will use progressbar and print additional statements
         pbar = trange(self.max_iterations, disable=not verbose, desc="   Progress")

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -83,8 +83,8 @@ class DEM(SatelliteImage):  # type: ignore
                 warnings.filterwarnings("ignore", message="Parse metadata from file not implemented")
                 super().__init__(filename_or_dataset, silent=silent, **kwargs)
 
-        # self.nbands can be None when data is not loaded through the Raster class
-        if self.nbands is not None and self.nbands > 1:
+        # self.indexes can be None when data is not loaded through the Raster class
+        if self.indexes is not None and len(self.indexes) > 1:
             raise ValueError("DEM rasters should be composed of one band only")
 
         # user input


### PR DESCRIPTION
Edit a few lines of the DEM class in xdem/dem.py, from

```
[86] # self.nbands can be None when data is not loaded through the Raster class
[87] if self.nbands is not None and self.nbands > 1:
[88]     raise ValueError("DEM rasters should be composed of one band only")
```

to 

```
[86] # self.indexes can be None when data is not loaded through the Raster class
[87] if self.indexes is not None and len(self.indexes) > 1:
[88]     raise ValueError("DEM rasters should be composed of one band only")
```

so that it fixed #339

EDIT from @rhugonnet:
Resolves #338 as well
