### PR TITLE
Remove local table of contents in documentation 

### DIFF
--- a/doc/source/comparison.md
+++ b/doc/source/comparison.md
@@ -12,10 +12,6 @@ kernelspec:
 ---
 # Differencing and volume change
 
-```{contents} Contents
-:local: true
-```
-
 **Example data**
 
 Example data in this chapter are loaded as follows:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -59,7 +59,7 @@ extensions = [
 ]
 
 # For sphinx design to work properly
-myst_enable_extensions = ["colon_fence"]
+myst_enable_extensions = ["colon_fence", "dollarmath"]
 
 # For myst-nb to find the Jupyter kernel (=environment) to run from
 nb_kernel_rgx_aliases = {".*xdem.*": "python3"}
@@ -160,6 +160,7 @@ html_theme_options = {
         "notebook_interface": "jupyterlab",
         # For launching Binder in Jupyterlab to open MD files as notebook (downloads them otherwise)
     },
+    "show_toc_level": 2  # To show more levels on the right sidebar TOC
 }
 
 # For dark mode

--- a/doc/source/coregistration.md
+++ b/doc/source/coregistration.md
@@ -23,10 +23,6 @@ Those transformations include for instance:
 - rotations, reflections,
 - scalings.
 
-```{contents} Contents
-:local: true
-```
-
 ## Introduction
 
 Coregistration of a DEM is performed when it needs to be compared to a reference, but the DEM does not align with the reference perfectly.

--- a/doc/source/spatialstats.md
+++ b/doc/source/spatialstats.md
@@ -29,10 +29,6 @@ In particular, these tools help to:
 > - estimate robust errors for observations analyzed in space (e.g., average or sum of elevation, or of elevation changes),
 > - propagate errors between spatial ensembles at different scales (e.g., sum of glacier volume changes).
 
-```{contents} Contents
-:local: true
-```
-
 (spatialstats-intro)=
 
 ## Spatial statistics for DEM precision estimation

--- a/doc/source/terrain.md
+++ b/doc/source/terrain.md
@@ -5,10 +5,6 @@
 For analytic and visual purposes, deriving certain attributes of a DEM may be required.
 Some are useful for direct analysis, such as a slope map to differentiate features of different angles, while others, like the hillshade, are great tools for visualizing a DEM.
 
-```{contents} Contents
-:local: true
-```
-
 ## Slope
 
 {func}`xdem.terrain.slope`
@@ -29,7 +25,6 @@ example.
 
 ```{eval-rst}
 .. minigallery:: xdem.terrain.slope
-        :add-heading:
 ```
 
 ## Aspect


### PR DESCRIPTION
Redundant as those are now always displayed on the right side with `sphinx-book-theme`