### PR TITLE
Fix GitHub Actions mamba caching

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,14 +40,14 @@ jobs:
 
     - name: Get month for resetting cache
       id: get-date
-      run: echo "::set-output name=month::$(/bin/date -u '+%Y%m')"
+      run: echo "cache_date=$(/bin/date -u '+%Y%m')" >> $GITHUB_ENV
       shell: bash
 
     - name: Cache conda env
       uses: actions/cache@v3
       with:
         path: ${{ env.CONDA }}/envs
-        key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ steps.get-date.outputs.month }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
+        key: conda-${{ matrix.os }}-${{ matrix.python-version }}-${{ env.cache_date }}-${{ hashFiles('dev-environment.yml') }}-${{ env.CACHE_NUMBER }}
       env:
         CACHE_NUMBER: 0 # Increase this value to reset cache if environment.yml has not changed
       id: cache


### PR DESCRIPTION
See #353 for the rationale.

For once, it seems the fix was rather simple! But maybe the test suite fails for other reasons now.. Oh well, you can see that the exact syntax works in [variete](https://github.com/erikmannerfelt/variete/blob/main/.github/workflows/python-test.yml)

Closing #353 