### PR TITLE
Add `coveragerc` to ignore specific lines when estimating test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines =
+    pragma: not covered
+    @overload
+    except ImportError


### PR DESCRIPTION
Mirroring what was done in GeoUtils