### PR TITLE
Fix inheritance diagram rendering in documentation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,13 +54,15 @@ jobs:
 
     # The trick below is necessary because the generic environment file does not specify a Python version, and only
     # "conda env update" can be used to update with an environment file, which upgrades the Python version
+    # (we add "graphviz" from dev-environment to solve all dependencies at once, at graphviz relies on image
+    # processing packages very much like geo-packages; not a problem for docs, dev installs where all is done at once)
     - name: Install base environment with a fixed Python version
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         mamba install pyyaml python=${{ matrix.python-version }}
         pkgs_conda_base=`python .github/get_yml_env_nopy.py "environment.yml" --p "conda"`
         pkgs_pip_base=`python .github/get_yml_env_nopy.py "environment.yml" --p "pip"`
-        mamba install python=${{ matrix.python-version }} $pkgs_conda_base
+        mamba install python=${{ matrix.python-version }} $pkgs_conda_base graphviz
         if [[ "$pkgs_pip_base" != "None" ]]; then
           pip install $pkgs_pip_base
         fi

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pip
   - sphinx-book-theme
   - autovizwidget
+  - graphviz
   - pytest
   - pytest-xdist
   - sphinx
@@ -42,5 +43,4 @@ dependencies:
 
   - pip:
      - -e ./
-     - graphviz
      - git+https://github.com/GlacioHack/GeoUtils.git

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - pip
   - sphinx-book-theme
   - autovizwidget
-  - graphviz
   - pytest
   - pytest-xdist
   - sphinx
@@ -43,4 +42,5 @@ dependencies:
 
   - pip:
      - -e ./
+     - graphviz
      - git+https://github.com/GlacioHack/GeoUtils.git

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - pip
   - sphinx-book-theme
   - autovizwidget
+  - graphviz
   - pytest
   - pytest-xdist
   - sphinx

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -116,6 +116,9 @@ inheritance_alias = {
     "xdem.dem.Coreg": "xdem.Coreg",
 }
 
+# To have an edge color that works in both dark and light mode
+inheritance_edge_attrs = {"color": "dodgerblue1"}
+
 # To avoid fuzzy PNGs
 graphviz_output_format = "svg"
 


### PR DESCRIPTION
This PR fixes the inheritance diagrams rendering in the doc (that was shown as text).

Inheritance diagrams require `graphviz` to build. However, `mamba` has trouble updating the base `environment.yml` with `graphviz` in the CI (that runs into two steps: base environment + update with dev packages), because some image-processing package dependencies are similar.

To fix this, this PR explicitly adds `graphviz` when building the base `environment.yml` **only in the CI**.

All other scripts building from `dev-environment.yml` are functioning fine (readthedocs, developper install).

Resolves #359