### PR TITLE
Fix typo in `.readthedocs.yaml`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ sphinx:
 # Build the doc in offline formats
 formats:
   - pdf
-  - hmtlzip
+  - htmlzip
 
 conda:
   environment: dev-environment.yml


### PR DESCRIPTION
Fix typo in #363 (cannot be tested by CI), during build on Readthedocs:

> Problem in your project's configuration. Invalid "formats": expected one of (htmlzip, pdf, epub), got hmtlzip