### PR TITLE
Fix nodata not preserved when calculating terrain attributes with richdem

### DIFF
--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -255,8 +255,9 @@ class TestTerrainAttribute:
         dem.data.mask = np.zeros_like(dem.data, dtype=bool)
         dem.data.mask.ravel()[np.random.choice(dem.data.size, 50000, replace=False)] = True
 
-        # Validate that this doesn't raise weird warnings after introducing nans.
-        functions_richdem[attribute](dem)
+        # Validate that this doesn't raise weird warnings after introducing nans and that mask is preserved
+        output = functions_richdem[attribute](dem)
+        assert np.all(dem.data.mask == output.data.mask)
 
     def test_hillshade_errors(self) -> None:
         """Validate that the hillshade function raises appropriate errors."""

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -42,6 +42,7 @@ def _get_terrainattr_richdem(rst: RasterType, attribute: str = "slope_radians") 
     """
     rda = _raster_to_rda(rst)
     terrattr = rd.TerrainAttribute(rda, attrib=attribute)
+    terrattr[terrattr==terrattr.no_data] = np.nan
 
     return np.array(terrattr)
 


### PR DESCRIPTION
A one-line fix to solve #371.
A test has been updated to flag this issue in the future.