### PR TITLE
Extrapolate using nearest neighbour in `interp_nd_binning`

### DIFF
--- a/tests/test_biascorr.py
+++ b/tests/test_biascorr.py
@@ -216,7 +216,7 @@ class TestBiasCorr:
         elev_fit_params.update({"bias_vars": bias_vars_dict})
 
         # Run with input parameter, and using only 100 subsamples for speed
-        bcorr.fit(**elev_fit_params, subsample=1000, random_state=42)
+        bcorr.fit(**elev_fit_params, subsample=10000, random_state=42)
 
         # Apply the correction
         bcorr.apply(dem=self.tba, bias_vars=bias_vars_dict)

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -158,7 +158,8 @@ class TestBinning:
         )
         arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((3, 3))
         fun = xdem.spatialstats.interp_nd_binning(
-            df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None)
+            df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None
+        )
 
         # Check that the dimensions are rightly ordered
         assert fun((1, 3)) == df[np.logical_and(df["var1"] == 1, df["var2"] == 3)]["statistic"].values[0]
@@ -220,17 +221,17 @@ class TestBinning:
             elif point[0] == 4:
                 near = arr[x - 1, y]
             elif point[1] == 0:
-                near = arr[x, y+1]
+                near = arr[x, y + 1]
             else:
-                near = arr[x, y-1]
+                near = arr[x, y - 1]
             assert near == val_extra
 
         # Check that the output extrapolates as "nearest neighbour" far outside the grid
         points_far_out = (
-                [(-10, i) for i in np.arange(1, 4)]
-                + [(i, -10) for i in np.arange(1, 4)]
-                + [(14, i) for i in np.arange(1, 4)]
-                + [(i, 14) for i in np.arange(4, 1)]
+            [(-10, i) for i in np.arange(1, 4)]
+            + [(i, -10) for i in np.arange(1, 4)]
+            + [(14, i) for i in np.arange(1, 4)]
+            + [(i, 14) for i in np.arange(4, 1)]
         )
         for point in points_far_out:
             x = point[0] - 1

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -257,9 +257,9 @@ def interp_nd_binning(
     >>> fun((1.5, 1.5))
     array(3.)
 
-    # Extrapolated linearly outside the 2D frame.
+    # Extrapolated linearly outside the 2D frame: nearest neighbour.
     >>> fun((-1, 1))
-    array(-1.)
+    array(1.)
     """
     # If list of variable input is simply a string
     if isinstance(list_var_names, str):


### PR DESCRIPTION
Resolves #380 

The extrapolation is always done using "nearest", and interpolation is "linear" by default.
The workflow is a bit complex in order to deal with nodata in the grid, see comments in the code.

Added tests to ensure all works as intended.