### PR TITLE
Silence numba warning for `@jit`

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
-  - scikit-gstat>=1.0.11
   - pytransform3d
   - geoutils==0.0.11
 
@@ -42,5 +41,6 @@ dependencies:
 
   - pip:
     - noisyopt
+    - scikit-gstat>=1.0.11
     - -e ./
 #     - git+https://github.com/GlacioHack/GeoUtils.git

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
-  - scikit-gstat>=0.6.8
+  - scikit-gstat>=1.0.11
   - pytransform3d
   - geoutils==0.0.11
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,13 +17,13 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
-  - scikit-gstat>=1.0.11
   - pytransform3d
   - geoutils==0.0.11
   - pip
 
   - pip:
     - noisyopt
+    - scikit-gstat>=1.0.11
 
 
 #  - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
-  - scikit-gstat>=0.6.8
+  - scikit-gstat>=1.0.11
   - pytransform3d
   - geoutils==0.0.11
   - pip

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -2532,7 +2532,7 @@ nd4type = numba.double[:, :, :, :]
 nd3type = numba.double[:, :, :]
 
 
-@jit((nd3type, nd3type, nd4type))  # type: ignore
+@njit((nd3type, nd3type, nd4type))  # type: ignore
 def _numba_convolution(imgs: NDArrayf, filters: NDArrayf, output: NDArrayf) -> None:
     """
     Numba convolution on a number n_N of 2D images of size N1 x N2 using a number of kernels n_M of sizes M1 x M2.

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -23,7 +23,6 @@ from geoutils.raster import (
     subsample_array,
 )
 from geoutils.vector import Vector, VectorType
-from numba import jit
 from numpy.typing import ArrayLike
 from scipy import integrate
 from scipy.interpolate import RegularGridInterpolator, griddata
@@ -2532,7 +2531,7 @@ nd4type = numba.double[:, :, :, :]
 nd3type = numba.double[:, :, :]
 
 
-@njit((nd3type, nd3type, nd4type))  # type: ignore
+@numba.njit((nd3type, nd3type, nd4type))  # type: ignore
 def _numba_convolution(imgs: NDArrayf, filters: NDArrayf, output: NDArrayf) -> None:
     """
     Numba convolution on a number n_N of 2D images of size N1 x N2 using a number of kernels n_M of sizes M1 x M2.


### PR DESCRIPTION
Resolves #393 

Should already be fixed in `scikit-gstat`: https://github.com/mmaelicke/scikit-gstat/issues/146
(`@njit` is equivalent to `@jit(nopython=True)`)

Opened #396 