### PR TITLE
Only use `conda-forge` channel in environment

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
+  - scikit-gstat>=1.0
   - pytransform3d
   - geoutils==0.0.11
 
@@ -40,7 +41,6 @@ dependencies:
 #  - richdem
 
   - pip:
-    - scikit-gstat>=1.0.11
     - -e ./
 
     # Development-specific

--- a/environment.yml
+++ b/environment.yml
@@ -17,13 +17,10 @@ dependencies:
   - scipy
   - tqdm
   - scikit-image
+  - scikit-gstat>=1.0
   - pytransform3d
   - geoutils==0.0.11
   - pip
-
-  - pip:
-    - scikit-gstat>=1.0.11
-
 
 #  - pip:
 #     - git+https://github.com/GlacioHack/GeoUtils.git

--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ with open(os.path.join(os.path.dirname(__file__), "README.md")) as infile:
 setup(
     name="xdem",
     version=FULLVERSION,
-    description="Set of tools to manipulate Digital Elevation Models (DEMs) ",
+    description="Analysis of digital elevation models (DEMs)",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     url="https://github.com/GlacioHack/xdem",
     author="The GlacioHack Team",
     author_email="this-is-not-an-email@a.com",  # This is needed for PyPi unfortunately.
     license="BSD-3",
-    packages=["xdem"],
+    packages=["xdem", "xdem.coreg"],
     install_requires=[
         "numpy",
         "scipy",


### PR DESCRIPTION
Forgot `pip` cannot be called from `conda build`, so versions would be inconsistent between PyPI and conda.

Reverting back `scikit-gstat` to `conda-forge`, the warnings (#395) will go away by themselves when its `1.0.11` release is made on `conda-forge`.

Additionally, still trying to figure out the circular import issue in `xdem-feedstock`...

Resolves #396 