### PR TITLE
Update README.md to point to xdem instead of geoutils

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Citing the related study:
 ## Start contributing
 
 1. Fork the repository, make a feature branch and push changes.
-2. When ready, submit a pull request from the feature branch of your fork to `GlacioHack/geoutils:main`.
+2. When ready, submit a pull request from the feature branch of your fork to `GlacioHack/xdem:main`.
 3. The PR will be reviewed by at least one maintainer, discussed, then merged.
 
 More info on [our contributing page](CONTRIBUTING.md).


### PR DESCRIPTION
In the end of the README, it states to push a feature branch to `geoutils:main` which is obviously wrong. 