### PR TITLE
Declare `xdem.coreg` module explicitly for `conda-forge`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ xdem =
 [options.packages.find]
 include =
     xdem
-    coreg
+    xdem.coreg
 
 [options.extras_require]
 opt =


### PR DESCRIPTION
To fix a `conda-forge` error similar than https://github.com/GlacioHack/xdem/issues/394

Triggered by the changes in #429
Mirrors https://github.com/GlacioHack/geoutils/pull/404