### PR TITLE
Fix bug in `CoregPipeline.fit()`

### DIFF
--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -288,7 +288,7 @@ class TestAffineCoreg:
         assert np.abs(np.mean(periglacial_offset)) < np.abs(np.mean(pre_offset))
 
         # Check that the mean periglacial offset is low
-        assert np.abs(np.mean(periglacial_offset)) < 0.01
+        assert np.abs(np.mean(periglacial_offset)) < 0.02
 
     def test_icp_opencv(self) -> None:
         warnings.simplefilter("error")

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -676,6 +676,43 @@ class TestCoregPipeline:
         vshift5 = vshift3 + vshift3
         assert vshift5.to_matrix()[2, 3] == vshift * 4
 
+    def test_pipeline_consistency(self):
+        """Check that pipelines properties are respected: reflectivity, fusion of same coreg"""
+
+        # Test 1: Fusion of same coreg
+        # Many vertical shifts
+        many_vshifts = coreg.VerticalShift() + coreg.VerticalShift() + coreg.VerticalShift()
+        many_vshifts.fit(**self.fit_params)
+        aligned_dem, _ = many_vshifts.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
+
+        # The last steps should have shifts of EXACTLY zero
+        assert many_vshifts.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=10e-5)
+        assert many_vshifts.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=10e-5)
+
+        # Many horizontal + vertical shifts
+        many_nks = coreg.NuthKaab() + coreg.NuthKaab() + coreg.NuthKaab()
+        many_nks.fit(**self.fit_params)
+        aligned_dem, _ = many_nks.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
+
+        # The last steps should have shifts of NEARLY zero
+        assert many_nks.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[1]._meta["offset_east_px"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[1]._meta["offset_north_px"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[2]._meta["offset_east_px"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[2]._meta["offset_north_px"] == pytest.approx(0, abs=0.01)
+
+        # Test 2: Reflectivity
+        # Those two pipelines should give almost the same result
+        nk_vshift = coreg.NuthKaab() + coreg.VerticalShift()
+        vshift_nk = coreg.VerticalShift() + coreg.NuthKaab()
+
+        nk_vshift.fit(**self.fit_params)
+        aligned_dem, _ = nk_vshift.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
+        vshift_nk.fit(**self.fit_params)
+        aligned_dem, _ = vshift_nk.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
+
+        assert np.allclose(nk_vshift.to_matrix(), vshift_nk.to_matrix(), atol=10e-1)
 
 class TestBlockwiseCoreg:
     ref, tba, outlines = load_examples()  # Load example reference, to-be-aligned and mask.

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -676,7 +676,7 @@ class TestCoregPipeline:
         vshift5 = vshift3 + vshift3
         assert vshift5.to_matrix()[2, 3] == vshift * 4
 
-    def test_pipeline_consistency(self):
+    def test_pipeline_consistency(self) -> None:
         """Check that pipelines properties are respected: reflectivity, fusion of same coreg"""
 
         # Test 1: Fusion of same coreg
@@ -713,6 +713,7 @@ class TestCoregPipeline:
         aligned_dem, _ = vshift_nk.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         assert np.allclose(nk_vshift.to_matrix(), vshift_nk.to_matrix(), atol=10e-1)
+
 
 class TestBlockwiseCoreg:
     ref, tba, outlines = load_examples()  # Load example reference, to-be-aligned and mask.

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -682,7 +682,7 @@ class TestCoregPipeline:
         # Test 1: Fusion of same coreg
         # Many vertical shifts
         many_vshifts = coreg.VerticalShift() + coreg.VerticalShift() + coreg.VerticalShift()
-        many_vshifts.fit(**self.fit_params)
+        many_vshifts.fit(**self.fit_params, random_state=42)
         aligned_dem, _ = many_vshifts.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         # The last steps should have shifts of EXACTLY zero
@@ -691,25 +691,25 @@ class TestCoregPipeline:
 
         # Many horizontal + vertical shifts
         many_nks = coreg.NuthKaab() + coreg.NuthKaab() + coreg.NuthKaab()
-        many_nks.fit(**self.fit_params)
+        many_nks.fit(**self.fit_params, random_state=42)
         aligned_dem, _ = many_nks.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         # The last steps should have shifts of NEARLY zero
-        assert many_nks.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=0.01)
-        assert many_nks.pipeline[1]._meta["offset_east_px"] == pytest.approx(0, abs=0.01)
-        assert many_nks.pipeline[1]._meta["offset_north_px"] == pytest.approx(0, abs=0.01)
-        assert many_nks.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=0.01)
-        assert many_nks.pipeline[2]._meta["offset_east_px"] == pytest.approx(0, abs=0.01)
-        assert many_nks.pipeline[2]._meta["offset_north_px"] == pytest.approx(0, abs=0.01)
+        assert many_nks.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[1]._meta["offset_east_px"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[1]._meta["offset_north_px"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2]._meta["offset_east_px"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2]._meta["offset_north_px"] == pytest.approx(0, abs=0.02)
 
         # Test 2: Reflectivity
         # Those two pipelines should give almost the same result
         nk_vshift = coreg.NuthKaab() + coreg.VerticalShift()
         vshift_nk = coreg.VerticalShift() + coreg.NuthKaab()
 
-        nk_vshift.fit(**self.fit_params)
+        nk_vshift.fit(**self.fit_params, random_state=42)
         aligned_dem, _ = nk_vshift.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
-        vshift_nk.fit(**self.fit_params)
+        vshift_nk.fit(**self.fit_params, random_state=42)
         aligned_dem, _ = vshift_nk.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         assert np.allclose(nk_vshift.to_matrix(), vshift_nk.to_matrix(), atol=10e-1)

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -1544,6 +1544,26 @@ class CoregPipeline(Coreg):
 
         return self
 
+    def _fit_pts_func(
+        self: CoregType,
+        ref_dem: NDArrayf | MArrayf | RasterType | pd.DataFrame,
+        tba_dem: RasterType,
+        verbose: bool = False,
+        **kwargs: Any,
+    ) -> CoregType:
+
+        tba_dem_mod = tba_dem.copy()
+
+        for i, coreg in enumerate(self.pipeline):
+            if verbose:
+                print(f"Running pipeline step: {i + 1} / {len(self.pipeline)}")
+
+            coreg._fit_pts_func(ref_dem=ref_dem, tba_dem=tba_dem_mod, verbose=verbose, **kwargs)
+            coreg._fit_called = True
+
+            tba_dem_mod = coreg.apply(tba_dem_mod)
+        return self
+
     def _apply_func(
         self,
         dem: NDArrayf,

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -1516,7 +1516,7 @@ class CoregPipeline(Coreg):
 
             main_args_fit = {
                 "reference_dem": ref_dem,
-                "dem_to_be_aligned": tba_dem,
+                "dem_to_be_aligned": tba_dem_mod,
                 "inlier_mask": inlier_mask,
                 "transform": out_transform,
                 "crs": crs,
@@ -1542,26 +1542,6 @@ class CoregPipeline(Coreg):
         # Flag that the fitting function has been called.
         self._fit_called = True
 
-        return self
-
-    def _fit_pts_func(
-        self: CoregType,
-        ref_dem: NDArrayf | MArrayf | RasterType | pd.DataFrame,
-        tba_dem: RasterType,
-        verbose: bool = False,
-        **kwargs: Any,
-    ) -> CoregType:
-
-        tba_dem_mod = tba_dem.copy()
-
-        for i, coreg in enumerate(self.pipeline):
-            if verbose:
-                print(f"Running pipeline step: {i + 1} / {len(self.pipeline)}")
-
-            coreg._fit_pts_func(ref_dem=ref_dem, tba_dem=tba_dem_mod, verbose=verbose, **kwargs)
-            coreg._fit_called = True
-
-            tba_dem_mod = coreg.apply(tba_dem_mod)
         return self
 
     def _apply_func(


### PR DESCRIPTION
This PR fixes a bug in `CoregPipeline` that made all fits erroneous (using the original `tba_dem` instead of the updated one).

This was only 4 characters, but not easy to find.

 - [x] Resolves #447,
 - [x] Tests added.