### PR TITLE
Fix documentation rendering due to Pydata theme update

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -36,7 +36,7 @@ dependencies:
   # Doc dependencies
   - sphinx
   - pydata-sphinx-theme==0.13.3
-  - sphinx-book-theme
+  - sphinx-book-theme>=1.0
   - sphinxcontrib-programoutput
   - sphinx-design
   - sphinx-autodoc-typehints

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -35,6 +35,7 @@ dependencies:
 
   # Doc dependencies
   - sphinx
+  - pydata-sphinx-theme==0.13.3
   - sphinx-book-theme
   - sphinxcontrib-programoutput
   - sphinx-design


### PR DESCRIPTION
Fixes the wrong rendering of the documentation since the pydate-sphinx-theme 0.14 by forcing 0.13 (see issue https://github.com/executablebooks/sphinx-book-theme/issues/761).

We should be able to update soon, `sphinx-book-theme` is catching up with a pre-release: https://github.com/executablebooks/sphinx-book-theme/releases.
Opened #452
