### PR TITLE
Pin max Python version for `setuptools`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ download_url = https://pypi.org/project/xdem/
 packages = find:
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.9,<3.12
 # Avoid pinning dependencies in requirements.txt (which we don't do anyways, and we rely mostly on Conda)
 # (https://caremad.io/posts/2013/07/setup-vs-requirement/, https://github.com/pypa/setuptools/issues/1951)
 install_requires = file: requirements.txt


### PR DESCRIPTION
Currently `pip install xdem` can fail on Python 3.12 because some dependencies (`numba`, notably) don't support it. And does so during publish.

We pin the version between 3.9 and 3.11 to ensure the PyPI publish always works.