### PR TITLE
Pin max Python version for PyPI publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.x'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ download_url = https://pypi.org/project/xdem/
 packages = find:
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.9,<3.12
+python_requires = >=3.9
 # Avoid pinning dependencies in requirements.txt (which we don't do anyways, and we rely mostly on Conda)
 # (https://caremad.io/posts/2013/07/setup-vs-requirement/, https://github.com/pypa/setuptools/issues/1951)
 install_requires = file: requirements.txt


### PR DESCRIPTION
Only pin in PyPI publish workflow, leave version open in `setup.cfg` to still allow install on Python 3.12 (at user's own risk).