### PR TITLE
Mirror geoutils API changes

### DIFF
--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -184,7 +184,7 @@ class TestAffineCoreg:
         shifted_ref = self.ref.copy()
         shifted_ref.shift(shift_px[0] * res, shift_px[1] * res)
 
-        shifted_ref_points = shifted_ref.to_points(as_array=False, subset=subsample, pixel_offset="center").ds
+        shifted_ref_points = shifted_ref.to_points(as_array=False, sample=subsample, pixel_offset="center").ds
         shifted_ref_points["E"] = shifted_ref_points.geometry.x
         shifted_ref_points["N"] = shifted_ref_points.geometry.y
         shifted_ref_points.rename(columns={"b1": "z"}, inplace=True)

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -259,7 +259,7 @@ class TestCoregClass:
         dem1.data[1, 1] = 100
 
         # Translate the DEM 1 "meter" right and add a vertical shift
-        dem2 = dem1.reproject(dst_bounds=rio.coords.BoundingBox(1, 0, 6, 5), silent=True)
+        dem2 = dem1.reproject(bounds=rio.coords.BoundingBox(1, 0, 6, 5), silent=True)
         dem2 += 1
 
         # Create a vertical shift correction for Rasters ("_r") and for arrays ("_a")
@@ -783,8 +783,8 @@ class TestBlockwiseCoreg:
     def test_blockwise_coreg_large_gaps(self) -> None:
         """Test BlockwiseCoreg when large gaps are encountered, e.g. around the frame of a rotated DEM."""
         warnings.simplefilter("error")
-        reference_dem = self.ref.reproject(dst_crs="EPSG:3413", dst_res=self.ref.res, resampling="bilinear")
-        dem_to_be_aligned = self.tba.reproject(dst_ref=reference_dem, resampling="bilinear")
+        reference_dem = self.ref.reproject(crs="EPSG:3413", res=self.ref.res, resampling="bilinear")
+        dem_to_be_aligned = self.tba.reproject(ref=reference_dem, resampling="bilinear")
 
         blockwise = xdem.coreg.BlockwiseCoreg(xdem.coreg.NuthKaab(), 64, warn_failures=False)
 

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -98,7 +98,7 @@ class TestDEM:
         # Tests 2: instantiation with a file that has a 3D CRS
         # Create such a file
         dem = DEM(fn_img)
-        dem_reproj = dem.reproject(dst_crs=4979)
+        dem_reproj = dem.reproject(crs=4979)
 
         # Save to temporary folder
         temp_dir = tempfile.TemporaryDirectory()
@@ -263,7 +263,7 @@ class TestDEM:
         dem = DEM(fn_dem)
 
         # Reproject in WGS84 2D
-        dem = dem.reproject(dst_crs=4326)
+        dem = dem.reproject(crs=4326)
         dem_before_trans = dem.copy()
 
         # Set ellipsoid as vertical reference

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -72,8 +72,8 @@ class TestBinning:
         """Check that the nd_binning function works adequately and save dataframes to files for later tests"""
 
         # Subsampler
-        indices = gu.raster.subsample_array(
-            self.diff.data.flatten(), subsample=10000, return_indices=True, random_state=42
+        indices = gu.raster.sample_array(
+            self.diff.data.flatten(), sample=10000, return_indices=True, random_state=42
         )
 
         # 1D binning, by default will create 10 bins

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -43,7 +43,7 @@ from geoutils.raster import (
     get_array_and_mask,
     raster,
     subdivide_array,
-    subsample_array,
+    sample_array,
 )
 from tqdm import tqdm
 
@@ -450,7 +450,7 @@ def deramping(
         print("Estimating deramp function...")
 
     # reduce number of elements for speed
-    rand_indices = subsample_array(x_coords, subsample=subsample, return_indices=True)
+    rand_indices = sample_array(x_coords, sample=subsample, return_indices=True)
     x_coords = x_coords[rand_indices]
     y_coords = y_coords[rand_indices]
     ddem = ddem[rand_indices]
@@ -748,9 +748,9 @@ class Coreg:
             # Build a low memory masked array with invalid values masked to pass to subsampling
             ma_valid = np.ma.masked_array(data=np.ones(np.shape(valid_mask), dtype=bool), mask=~valid_mask)
             # Take a subsample within the valid values
-            indices = gu.raster.subsample_array(
+            indices = gu.raster.sample_array(
                 ma_valid,
-                subsample=self._meta["subsample"],
+                sample=self._meta["subsample"],
                 return_indices=True,
                 random_state=self._meta["random_state"],
             )
@@ -1041,8 +1041,8 @@ class Coreg:
         if subsample != 1.0:
 
             # Randomly pick N inliers in the full_mask where N=subsample
-            random_valids = subsample_array(
-                ref_dem[z_name].values, subsample=subsample, return_indices=True, random_state=random_state
+            random_valids = sample_array(
+                ref_dem[z_name].values, sample=subsample, return_indices=True, random_state=random_state
             )
 
             # Subset to the N random inliers

--- a/xdem/fit.py
+++ b/xdem/fit.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 
 import numpy as np
 import scipy
-from geoutils.raster import subsample_array
+from geoutils.raster import sample_array
 from numpy.polynomial.polynomial import polyval, polyval2d
 
 from xdem._typing import NDArrayf
@@ -376,7 +376,7 @@ def robust_norder_polynomial_fit(
 
     # Subsample data
     if subsample != 1:
-        subsamp = subsample_array(x, subsample=subsample, return_indices=True, random_state=random_state)
+        subsamp = sample_array(x, subsample=subsample, return_indices=True, random_state=random_state)
         x = x[subsamp]
         y = y[subsamp]
 

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -20,7 +20,7 @@ from geoutils.raster import (
     Raster,
     RasterType,
     get_array_and_mask,
-    subsample_array,
+    sample_array,
 )
 from geoutils.vector import Vector, VectorType
 from numpy.typing import ArrayLike
@@ -974,7 +974,7 @@ def _subsample_wrapper(
         values_sp = values
         coords_sp = coords
 
-    index = subsample_array(values_sp, subsample=subsample, return_indices=True, random_state=rnd)
+    index = sample_array(values_sp, sample=subsample, return_indices=True, random_state=rnd)
     values_sub = values_sp[index[0]]
     coords_sub = coords_sp[index[0], :]
 
@@ -2402,7 +2402,7 @@ def number_effective_samples(
         elif isinstance(rasterize_resolution, Raster):
 
             # With a Raster we can get the coordinates directly
-            mask = V.create_mask(rst=rasterize_resolution, as_array=True).squeeze()
+            mask = V.create_mask(raster=rasterize_resolution, as_array=True).squeeze()
             coords = np.array(rasterize_resolution.coords())
             coords_on_mask = coords[:, mask].T
 


### PR DESCRIPTION
Ongoing.
Replaced:
- `Raster.subsample_array` -> `Raster.sample_array` (and therein argument `subsample` into `sample`)
- Remove all "dsy_" prefixes in `Raster.reproject`
- Replaces argument of `Raster.to_points` "subset" with "sample"

Left to do:
- renames all "subsample" with "sample" to mirror geoutils?
- pin to new geoutils version

 - [ ] Resolves #xxx,
 - [ ] Tests added, otherwise issue #xxx opened,
 - [ ] Fully documented, including `api/*.md` for new API,
 - [ ] New optional dependencies added to both `dev-environment.yml` and `setup.cfg`,
 - [ ] If contributor workflow (test, doc, linting) or Python version support changed, update `CONTRIBUTING.md`.
