### PR TITLE
Increase sample size of empirical variograms in advanced examples for clearer plots

### DIFF
--- a/examples/advanced/plot_standardization.py
+++ b/examples/advanced/plot_standardization.py
@@ -128,7 +128,7 @@ plt.show()
 df_vgm = xdem.spatialstats.sample_empirical_variogram(
     values=z_dh.data.squeeze(),
     gsd=dh.res[0],
-    subsample=300,
+    subsample=1000,
     n_variograms=10,
     estimator="dowd",
     random_state=42,

--- a/examples/advanced/plot_variogram_estimation_modelling.py
+++ b/examples/advanced/plot_variogram_estimation_modelling.py
@@ -78,9 +78,7 @@ dh.plot(ax=plt.gca(), cmap="RdYlBu", vmin=-4, vmax=4, cbar_title="Elevation diff
 # conveniently by :func:`xdem.spatialstats.sample_empirical_variogram`:
 # Dowd's variogram is used for robustness in conjunction with the NMAD (see :ref:`robuststats-corr`).
 
-df = xdem.spatialstats.sample_empirical_variogram(
-    values=dh.data, gsd=dh.res[0], subsample=100, n_variograms=10, estimator="dowd", random_state=42
-)
+df = xdem.spatialstats.sample_empirical_variogram(values=dh, subsample=1000, n_variograms=10, estimator="dowd", random_state=42)
 
 # %%
 # *Note: in this example, we add a* ``random_state`` *argument to yield a reproducible random sampling of pixels within


### PR DESCRIPTION
It was just that the number of samples were too low, easy fix!

Resolves https://github.com/GlacioHack/xdem/issues/445
