### PR TITLE
Make coregistration metadata consistent and public

### DIFF
--- a/doc/source/coregistration.md
+++ b/doc/source/coregistration.md
@@ -198,7 +198,7 @@ vshift.fit(ref_dem, tba_dem, inlier_mask=inlier_mask)
 shifted_dem = vshift.apply(tba_dem)
 
 # Use median shift instead
-vshift_median = coreg.VerticalShift(vshift_func=np.median)
+vshift_median = coreg.VerticalShift(vshift_reduc_func=np.median)
 ```
 
 ## ICP

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -512,16 +512,15 @@ class TestCoregPipeline:
 
         # Create a pipeline, add some .metadata, and copy it
         pipeline = coreg_class() + coreg_class()
-        pipeline.pipeline[0].meta["shift_z"] = 1
+        pipeline.pipeline[0]._meta["shift_z"] = 1
 
         pipeline_copy = pipeline.copy()
 
         # Add some more .metadata after copying (this should not be transferred)
-        pipeline_copy.pipeline[0].meta["shift_y"] = 0.5 * 30
+        pipeline_copy.pipeline[0]._meta["shift_y"] = 0.5 * 30
 
-        assert pipeline.meta != pipeline_copy.meta
         assert pipeline.pipeline[0].meta != pipeline_copy.pipeline[0].meta
-        assert pipeline_copy.pipeline[0].meta["shift_z"]
+        assert pipeline_copy.pipeline[0]._meta["shift_z"]
 
     def test_pipeline(self) -> None:
 

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -68,8 +68,7 @@ class TestCoregClass:
         corr_copy = corr.copy()
 
         # Assign some attributes and .metadata after copying, respecting the CoregDict type class
-        corr.vshift = 1
-        corr.meta["resolution"] = 30
+        corr._meta["shift_z"] = 30
         # Make sure these don't appear in the copy
         assert corr_copy.meta != corr.meta
         assert not hasattr(corr_copy, "shift_z")
@@ -518,8 +517,7 @@ class TestCoregPipeline:
         pipeline_copy = pipeline.copy()
 
         # Add some more .metadata after copying (this should not be transferred)
-        pipeline.meta["resolution"] = 30
-        pipeline_copy.pipeline[0].meta["shift_y"] = 0.5
+        pipeline_copy.pipeline[0].meta["shift_y"] = 0.5 * 30
 
         assert pipeline.meta != pipeline_copy.meta
         assert pipeline.pipeline[0].meta != pipeline_copy.pipeline[0].meta

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -67,12 +67,12 @@ class TestCoregClass:
         corr = coreg_class()
         corr_copy = corr.copy()
 
-        # Assign some attributes and metadata after copying, respecting the CoregDict type class
+        # Assign some attributes and .metadata after copying, respecting the CoregDict type class
         corr.vshift = 1
-        corr._meta["resolution"] = 30
+        corr.meta["resolution"] = 30
         # Make sure these don't appear in the copy
-        assert corr_copy._meta != corr._meta
-        assert not hasattr(corr_copy, "vshift")
+        assert corr_copy.meta != corr.meta
+        assert not hasattr(corr_copy, "shift_z")
 
     def test_error_method(self) -> None:
         """Test different error measures."""
@@ -90,7 +90,7 @@ class TestCoregClass:
         assert vshiftcorr.error(dem1, dem2, transform=affine, crs=crs, error_type="median") == 0
 
         # Remove the vertical shift fit and see what happens.
-        vshiftcorr._meta["vshift"] = 0
+        vshiftcorr.meta["shift_z"] = 0
         # Now it should be equal to dem1 - dem2
         assert vshiftcorr.error(dem1, dem2, transform=affine, crs=crs, error_type="median") == -2
 
@@ -108,7 +108,7 @@ class TestCoregClass:
         rng = np.random.default_rng(42)
         valid_mask = rng.integers(low=0, high=2, size=(width, height), dtype=bool)
 
-        # Define a class with a subsample and random_state in the metadata
+        # Define a class with a subsample and random_state in the .metadata
         coreg = Coreg(meta={"subsample": subsample, "random_state": 42})
         subsample_mask = coreg._get_subsample_on_valid_mask(valid_mask=valid_mask)
 
@@ -141,17 +141,17 @@ class TestCoregClass:
         # Check that default value is set properly
         coreg_full = coreg()
         argspec = inspect.getfullargspec(coreg)
-        assert coreg_full._meta["subsample"] == argspec.defaults[argspec.args.index("subsample") - 1]  # type: ignore
+        assert coreg_full.meta["subsample"] == argspec.defaults[argspec.args.index("subsample") - 1]  # type: ignore
 
         # But can be overridden during fit
         coreg_full.fit(**self.fit_params, subsample=10000, random_state=42)
-        assert coreg_full._meta["subsample"] == 10000
+        assert coreg_full.meta["subsample"] == 10000
         # Check that the random state is properly set when subsampling explicitly or implicitly
-        assert coreg_full._meta["random_state"] == 42
+        assert coreg_full.meta["random_state"] == 42
 
         # Test subsampled vertical shift correction
         coreg_sub = coreg(subsample=0.1)
-        assert coreg_sub._meta["subsample"] == 0.1
+        assert coreg_sub.meta["subsample"] == 0.1
 
         # Fit the vertical shift using 10% of the unmasked data using a fraction
         coreg_sub.fit(**self.fit_params, random_state=42)
@@ -159,14 +159,14 @@ class TestCoregClass:
         # They are not perfectly equal (np.count_nonzero(self.mask) // 2 would be exact)
         # But this would just repeat the subsample code, so that makes little sense to test.
         coreg_sub = coreg(subsample=self.tba.data.size // 10)
-        assert coreg_sub._meta["subsample"] == self.tba.data.size // 10
+        assert coreg_sub.meta["subsample"] == self.tba.data.size // 10
         coreg_sub.fit(**self.fit_params, random_state=42)
 
         # Add a few performance checks
         coreg_name = coreg.__name__
         if coreg_name == "VerticalShift":
             # Check that the estimated vertical shifts are similar
-            assert abs(coreg_sub._meta["vshift"] - coreg_full._meta["vshift"]) < 0.1
+            assert abs(coreg_sub.meta["shift_z"] - coreg_full.meta["shift_z"]) < 0.1
 
         elif coreg_name == "NuthKaab":
             # Calculate the difference in the full vs. subsampled matrices
@@ -176,7 +176,7 @@ class TestCoregClass:
 
         elif coreg_name == "Tilt":
             # Check that the estimated biases are similar
-            assert coreg_sub._meta["coefficients"] == pytest.approx(coreg_full._meta["coefficients"], rel=1e-1)
+            assert coreg_sub.meta["fit_params"] == pytest.approx(coreg_full.meta["fit_params"], rel=1e-1)
 
     def test_subsample__pipeline(self) -> None:
         """Test that the subsample argument works as intended for pipelines"""
@@ -185,14 +185,14 @@ class TestCoregClass:
         pipe = coreg.VerticalShift(subsample=200) + coreg.Deramp(subsample=5000)
 
         # Check the arguments are properly defined
-        assert pipe.pipeline[0]._meta["subsample"] == 200
-        assert pipe.pipeline[1]._meta["subsample"] == 5000
+        assert pipe.pipeline[0].meta["subsample"] == 200
+        assert pipe.pipeline[1].meta["subsample"] == 5000
 
         # Check definition during fit
         pipe = coreg.VerticalShift() + coreg.Deramp()
         pipe.fit(**self.fit_params, subsample=1000)
-        assert pipe.pipeline[0]._meta["subsample"] == 1000
-        assert pipe.pipeline[1]._meta["subsample"] == 1000
+        assert pipe.pipeline[0].meta["subsample"] == 1000
+        assert pipe.pipeline[1].meta["subsample"] == 1000
 
     def test_subsample__errors(self) -> None:
         """Check proper errors are raised when using the subsample argument"""
@@ -267,7 +267,7 @@ class TestCoregClass:
         )
 
         # Validate that they ended up giving the same result.
-        assert vshiftcorr_r._meta["vshift"] == vshiftcorr_a._meta["vshift"]
+        assert vshiftcorr_r.meta["shift_z"] == vshiftcorr_a.meta["shift_z"]
 
         # De-shift dem2
         dem2_r = vshiftcorr_r.apply(dem2)
@@ -511,19 +511,19 @@ class TestCoregPipeline:
     @pytest.mark.parametrize("coreg_class", [coreg.VerticalShift, coreg.ICP, coreg.NuthKaab])  # type: ignore
     def test_copy(self, coreg_class: Callable[[], Coreg]) -> None:
 
-        # Create a pipeline, add some metadata, and copy it
+        # Create a pipeline, add some .metadata, and copy it
         pipeline = coreg_class() + coreg_class()
-        pipeline.pipeline[0]._meta["vshift"] = 1
+        pipeline.pipeline[0].meta["shift_z"] = 1
 
         pipeline_copy = pipeline.copy()
 
-        # Add some more metadata after copying (this should not be transferred)
-        pipeline._meta["resolution"] = 30
-        pipeline_copy.pipeline[0]._meta["offset_north_px"] = 0.5
+        # Add some more .metadata after copying (this should not be transferred)
+        pipeline.meta["resolution"] = 30
+        pipeline_copy.pipeline[0].meta["shift_y"] = 0.5
 
-        assert pipeline._meta != pipeline_copy._meta
-        assert pipeline.pipeline[0]._meta != pipeline_copy.pipeline[0]._meta
-        assert pipeline_copy.pipeline[0]._meta["vshift"]
+        assert pipeline.meta != pipeline_copy.meta
+        assert pipeline.pipeline[0].meta != pipeline_copy.pipeline[0].meta
+        assert pipeline_copy.pipeline[0].meta["shift_z"]
 
     def test_pipeline(self) -> None:
 
@@ -538,8 +538,8 @@ class TestCoregPipeline:
         # Make a new pipeline with two vertical shift correction approaches.
         pipeline2 = coreg.CoregPipeline([coreg.VerticalShift(), coreg.VerticalShift()])
         # Set both "estimated" vertical shifts to be 1
-        pipeline2.pipeline[0]._meta["vshift"] = 1
-        pipeline2.pipeline[1]._meta["vshift"] = 1
+        pipeline2.pipeline[0].meta["shift_z"] = 1
+        pipeline2.pipeline[1].meta["shift_z"] = 1
 
         # Assert that the combined vertical shift is 2
         assert pipeline2.to_matrix()[2, 3] == 2.0
@@ -643,9 +643,9 @@ class TestCoregPipeline:
         pipeline.fit(reference_elev=ref_points, to_be_aligned_elev=self.tba)
 
         for part in pipeline.pipeline:
-            assert np.abs(part._meta["offset_east_px"]) > 0
+            assert np.abs(part.meta["shift_x"]) > 0
 
-        assert pipeline.pipeline[0]._meta["offset_east_px"] != pipeline.pipeline[1]._meta["offset_east_px"]
+        assert pipeline.pipeline[0].meta["shift_x"] != pipeline.pipeline[1].meta["shift_x"]
 
     def test_coreg_add(self) -> None:
 
@@ -657,7 +657,7 @@ class TestCoregPipeline:
 
         # Set the vertical shift attribute
         for vshift_corr in (vshift1, vshift2):
-            vshift_corr._meta["vshift"] = vshift
+            vshift_corr.meta["shift_z"] = vshift
 
         # Add the two coregs and check that the resulting vertical shift is 2* vertical shift
         vshift3 = vshift1 + vshift2
@@ -685,8 +685,8 @@ class TestCoregPipeline:
         aligned_dem, _ = many_vshifts.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         # The last steps should have shifts of EXACTLY zero
-        assert many_vshifts.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=10e-5)
-        assert many_vshifts.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=10e-5)
+        assert many_vshifts.pipeline[1].meta["shift_z"] == pytest.approx(0, abs=10e-5)
+        assert many_vshifts.pipeline[2].meta["shift_z"] == pytest.approx(0, abs=10e-5)
 
         # Many horizontal + vertical shifts
         many_nks = coreg.NuthKaab() + coreg.NuthKaab() + coreg.NuthKaab()
@@ -694,12 +694,12 @@ class TestCoregPipeline:
         aligned_dem, _ = many_nks.apply(self.tba.data, transform=self.ref.transform, crs=self.ref.crs)
 
         # The last steps should have shifts of NEARLY zero
-        assert many_nks.pipeline[1]._meta["vshift"] == pytest.approx(0, abs=0.02)
-        assert many_nks.pipeline[1]._meta["offset_east_px"] == pytest.approx(0, abs=0.02)
-        assert many_nks.pipeline[1]._meta["offset_north_px"] == pytest.approx(0, abs=0.02)
-        assert many_nks.pipeline[2]._meta["vshift"] == pytest.approx(0, abs=0.02)
-        assert many_nks.pipeline[2]._meta["offset_east_px"] == pytest.approx(0, abs=0.02)
-        assert many_nks.pipeline[2]._meta["offset_north_px"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[1].meta["shift_z"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[1].meta["shift_x"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[1].meta["shift_y"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2].meta["shift_z"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2].meta["shift_x"] == pytest.approx(0, abs=0.02)
+        assert many_nks.pipeline[2].meta["shift_y"] == pytest.approx(0, abs=0.02)
 
         # Test 2: Reflectivity
         # Those two pipelines should give almost the same result
@@ -763,7 +763,7 @@ class TestBlockwiseCoreg:
             coreg.BlockwiseCoreg(step=coreg.VerticalShift, subdivision=1)  # type: ignore
 
         # Metadata copying has been an issue. Validate that all chunks have unique ids
-        chunk_numbers = [m["i"] for m in blockwise._meta["step_meta"]]
+        chunk_numbers = [m["i"] for m in blockwise.meta["step_meta"]]
         assert np.unique(chunk_numbers).shape[0] == len(chunk_numbers)
 
         transformed_dem = blockwise.apply(self.tba)

--- a/tests/test_coreg/test_biascorr.py
+++ b/tests/test_coreg/test_biascorr.py
@@ -70,10 +70,10 @@ class TestBiasCorr:
         # Create a bias correction instance
         bcorr = biascorr.BiasCorr()
 
-        # Check default "fit" metadata was set properly
-        assert bcorr._meta["fit_func"] == biascorr.fit_workflows["norder_polynomial"]["func"]
-        assert bcorr._meta["fit_optimizer"] == biascorr.fit_workflows["norder_polynomial"]["optimizer"]
-        assert bcorr._meta["bias_var_names"] is None
+        # Check default "fit" .metadata was set properly
+        assert bcorr.meta["fit_func"] == biascorr.fit_workflows["norder_polynomial"]["func"]
+        assert bcorr.meta["fit_optimizer"] == biascorr.fit_workflows["norder_polynomial"]["optimizer"]
+        assert bcorr.meta["bias_var_names"] is None
 
         # Check that the _is_affine attribute is set correctly
         assert not bcorr._is_affine
@@ -83,29 +83,29 @@ class TestBiasCorr:
         # Or with default bin arguments
         bcorr2 = biascorr.BiasCorr(fit_or_bin="bin")
 
-        assert bcorr2._meta["bin_sizes"] == 10
-        assert bcorr2._meta["bin_statistic"] == np.nanmedian
-        assert bcorr2._meta["bin_apply_method"] == "linear"
+        assert bcorr2.meta["bin_sizes"] == 10
+        assert bcorr2.meta["bin_statistic"] == np.nanmedian
+        assert bcorr2.meta["bin_apply_method"] == "linear"
 
         assert bcorr2._fit_or_bin == "bin"
 
         # Or with default bin_and_fit arguments
         bcorr3 = biascorr.BiasCorr(fit_or_bin="bin_and_fit")
 
-        assert bcorr3._meta["bin_sizes"] == 10
-        assert bcorr3._meta["bin_statistic"] == np.nanmedian
-        assert bcorr3._meta["fit_func"] == biascorr.fit_workflows["norder_polynomial"]["func"]
-        assert bcorr3._meta["fit_optimizer"] == biascorr.fit_workflows["norder_polynomial"]["optimizer"]
+        assert bcorr3.meta["bin_sizes"] == 10
+        assert bcorr3.meta["bin_statistic"] == np.nanmedian
+        assert bcorr3.meta["fit_func"] == biascorr.fit_workflows["norder_polynomial"]["func"]
+        assert bcorr3.meta["fit_optimizer"] == biascorr.fit_workflows["norder_polynomial"]["optimizer"]
 
         assert bcorr3._fit_or_bin == "bin_and_fit"
 
         # Or defining bias variable names on instantiation as iterable
         bcorr4 = biascorr.BiasCorr(bias_var_names=("slope", "ncc"))
-        assert bcorr4._meta["bias_var_names"] == ["slope", "ncc"]
+        assert bcorr4.meta["bias_var_names"] == ["slope", "ncc"]
 
         # Same using an array
         bcorr5 = biascorr.BiasCorr(bias_var_names=np.array(["slope", "ncc"]))
-        assert bcorr5._meta["bias_var_names"] == ["slope", "ncc"]
+        assert bcorr5.meta["bias_var_names"] == ["slope", "ncc"]
 
     def test_biascorr__errors(self) -> None:
         """Test the errors that should be raised by BiasCorr."""
@@ -227,7 +227,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=100, random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation"]
+        assert bcorr.meta["bias_var_names"] == ["elevation"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -258,7 +258,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=100, p0=[0, 0, 0, 0], random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation", "slope"]
+        assert bcorr.meta["bias_var_names"] == ["elevation", "slope"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -281,7 +281,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=1000, random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation"]
+        assert bcorr.meta["bias_var_names"] == ["elevation"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -304,7 +304,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=10000, random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation", "slope"]
+        assert bcorr.meta["bias_var_names"] == ["elevation", "slope"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -353,7 +353,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=1000, random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation"]
+        assert bcorr.meta["bias_var_names"] == ["elevation"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -392,7 +392,7 @@ class TestBiasCorr:
         bcorr.fit(**elev_fit_args, subsample=100, p0=[0, 0, 0, 0], random_state=42)
 
         # Check that variable names are defined during fit
-        assert bcorr._meta["bias_var_names"] == ["elevation", "slope"]
+        assert bcorr.meta["bias_var_names"] == ["elevation", "slope"]
 
         # Apply the correction
         bcorr.apply(elev=self.tba, bias_vars=bias_vars_dict)
@@ -404,13 +404,13 @@ class TestBiasCorr:
         dirbias = biascorr.DirectionalBias(angle=45)
 
         assert dirbias._fit_or_bin == "bin_and_fit"
-        assert dirbias._meta["fit_func"] == biascorr.fit_workflows["nfreq_sumsin"]["func"]
-        assert dirbias._meta["fit_optimizer"] == biascorr.fit_workflows["nfreq_sumsin"]["optimizer"]
-        assert dirbias._meta["angle"] == 45
+        assert dirbias.meta["fit_func"] == biascorr.fit_workflows["nfreq_sumsin"]["func"]
+        assert dirbias.meta["fit_optimizer"] == biascorr.fit_workflows["nfreq_sumsin"]["optimizer"]
+        assert dirbias.meta["angle"] == 45
         assert dirbias._needs_vars is False
 
         # Check that variable names are defined during instantiation
-        assert dirbias._meta["bias_var_names"] == ["angle"]
+        assert dirbias.meta["bias_var_names"] == ["angle"]
 
     @pytest.mark.parametrize("fit_args", all_fit_args)  # type: ignore
     @pytest.mark.parametrize("angle", [20, 90])  # type: ignore
@@ -441,7 +441,7 @@ class TestBiasCorr:
             dirbias = biascorr.DirectionalBias(angle=angle, fit_or_bin="bin", bin_sizes=10000)
             dirbias.fit(reference_elev=self.ref, to_be_aligned_elev=bias_dem, subsample=10000, random_state=42)
             xdem.spatialstats.plot_1d_binning(
-                df=dirbias._meta["bin_dataframe"], var_name="angle", statistic_name="nanmedian", min_count=0
+                df=dirbias.meta["bin_dataframe"], var_name="angle", statistic_name="nanmedian", min_count=0
             )
             plt.show()
 
@@ -474,7 +474,7 @@ class TestBiasCorr:
         )
 
         # Check all fit parameters are the same within 10%
-        fit_params = dirbias._meta["fit_params"]
+        fit_params = dirbias.meta["fit_params"]
         assert np.shape(fit_params) == np.shape(params)
         assert np.allclose(params, fit_params, rtol=0.1)
 
@@ -490,13 +490,13 @@ class TestBiasCorr:
         deramp = biascorr.Deramp()
 
         assert deramp._fit_or_bin == "fit"
-        assert deramp._meta["fit_func"] == polynomial_2d
-        assert deramp._meta["fit_optimizer"] == scipy.optimize.curve_fit
-        assert deramp._meta["poly_order"] == 2
+        assert deramp.meta["fit_func"] == polynomial_2d
+        assert deramp.meta["fit_optimizer"] == scipy.optimize.curve_fit
+        assert deramp.meta["poly_order"] == 2
         assert deramp._needs_vars is False
 
         # Check that variable names are defined during instantiation
-        assert deramp._meta["bias_var_names"] == ["xx", "yy"]
+        assert deramp.meta["bias_var_names"] == ["xx", "yy"]
 
     @pytest.mark.parametrize("fit_args", all_fit_args)  # type: ignore
     @pytest.mark.parametrize("order", [1, 2, 3, 4])  # type: ignore
@@ -527,7 +527,7 @@ class TestBiasCorr:
         deramp.fit(elev_fit_args["reference_elev"], to_be_aligned_elev=bias_elev, subsample=20000, random_state=42)
 
         # Check high-order fit parameters are the same within 10%
-        fit_params = deramp._meta["fit_params"]
+        fit_params = deramp.meta["fit_params"]
         assert np.shape(fit_params) == np.shape(params)
         assert np.allclose(
             params.reshape(order + 1, order + 1)[-1:, -1:], fit_params.reshape(order + 1, order + 1)[-1:, -1:], rtol=0.1
@@ -545,12 +545,12 @@ class TestBiasCorr:
         tb = biascorr.TerrainBias()
 
         assert tb._fit_or_bin == "bin"
-        assert tb._meta["bin_sizes"] == 100
-        assert tb._meta["bin_statistic"] == np.nanmedian
-        assert tb._meta["terrain_attribute"] == "maximum_curvature"
+        assert tb.meta["bin_sizes"] == 100
+        assert tb.meta["bin_statistic"] == np.nanmedian
+        assert tb.meta["terrain_attribute"] == "maximum_curvature"
         assert tb._needs_vars is False
 
-        assert tb._meta["bias_var_names"] == ["maximum_curvature"]
+        assert tb.meta["bias_var_names"] == ["maximum_curvature"]
 
     @pytest.mark.parametrize("fit_args", all_fit_args)  # type: ignore
     def test_terrainbias__synthetic(self, fit_args) -> None:
@@ -591,7 +591,7 @@ class TestBiasCorr:
         )
 
         # Check high-order parameters are the same within 10%
-        bin_df = tb._meta["bin_dataframe"]
+        bin_df = tb.meta["bin_dataframe"]
         assert [interval.left for interval in bin_df["maximum_curvature"].values] == pytest.approx(list(bin_edges[:-1]))
         assert [interval.right for interval in bin_df["maximum_curvature"].values] == pytest.approx(list(bin_edges[1:]))
         # assert np.allclose(bin_df["nanmedian"], bias_per_bin, rtol=0.1)

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -412,7 +412,8 @@ class ICP(AffineCoreg):
     "centroid". The translation parameters are also stored individually in the keys "shift_x", "shift_y" and "shift_z"
     (in georeferenced units for horizontal shifts, and unit of the elevation dataset inputs for the vertical shift).
 
-    Requires 'opencv'. See opencv doc for more info: https://docs.opencv.org/master/dc/d9b/classcv_1_1ppf__match__3d_1_1ICP.html
+    Requires 'opencv'. See opencv doc for more info:
+    https://docs.opencv.org/master/dc/d9b/classcv_1_1ppf__match__3d_1_1ICP.html
     """
 
     def __init__(

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -1032,7 +1032,9 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
 
         applied_epc = gpd.GeoDataFrame(
             geometry=gpd.points_from_xy(
-                x=elev.geometry.x.values + self._meta["shift_x"], y=elev.geometry.y.values + self._meta["shift_y"], crs=elev.crs
+                x=elev.geometry.x.values + self._meta["shift_x"],
+                y=elev.geometry.y.values + self._meta["shift_y"],
+                crs=elev.crs,
             ),
             data={z_name: elev[z_name].values + self._meta["shift_z"]},
         )

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -226,14 +226,14 @@ class AffineCoreg(Coreg):
         super().__init__(meta=meta)
 
         # Define subsample size
-        self._meta["subsample"] = subsample
+        self.meta["subsample"] = subsample
 
         if matrix is not None:
             with warnings.catch_warnings():
                 # This error is fixed in the upcoming 1.8
                 warnings.filterwarnings("ignore", message="`np.float` is a deprecated alias for the builtin `float`")
                 valid_matrix = pytransform3d.transformations.check_transform(matrix)
-            self._meta["matrix"] = valid_matrix
+            self.meta["matrix"] = valid_matrix
         self._is_affine = True
 
     def to_matrix(self) -> NDArrayf:
@@ -242,7 +242,7 @@ class AffineCoreg(Coreg):
 
     def centroid(self) -> tuple[float, float, float] | None:
         """Get the centroid of the coregistration, if defined."""
-        meta_centroid = self._meta.get("centroid")
+        meta_centroid = self.meta.get("centroid")
 
         if meta_centroid is None:
             return None
@@ -290,10 +290,10 @@ class AffineCoreg(Coreg):
         return cls.from_matrix(matrix)
 
     def _to_matrix_func(self) -> NDArrayf:
-        # FOR DEVELOPERS: This function needs to be implemented if the `self._meta['matrix']` keyword is not None.
+        # FOR DEVELOPERS: This function needs to be implemented if the `self.meta['matrix']` keyword is not None.
 
         # Try to see if a matrix exists.
-        meta_matrix = self._meta.get("matrix")
+        meta_matrix = self.meta.get("matrix")
         if meta_matrix is not None:
             assert meta_matrix.shape == (4, 4), f"Invalid _meta matrix shape. Expected: (4, 4), got {meta_matrix.shape}"
             return meta_matrix
@@ -305,22 +305,23 @@ class VerticalShift(AffineCoreg):
     """
     DEM vertical shift correction.
 
-    Estimates the mean (or median, weighted avg., etc.) vertical offset between two DEMs.
+    Estimates the mean vertical offset between two DEMs based on a reductor function (median, mean, or any).
     """
 
     def __init__(
-        self, vshift_func: Callable[[NDArrayf], np.floating[Any]] = np.average, subsample: float | int = 1.0
+        self, vshift_reduc_func: Callable[[NDArrayf], np.floating[Any]] = np.median, subsample: float | int = 1.0
     ) -> None:  # pylint:
         # disable=super-init-not-called
         """
         Instantiate a vertical shift correction object.
 
-        :param vshift_func: The function to use for calculating the vertical shift. Default: (weighted) average.
+        :param vshift_reduc_func: Reductor function to estimate the central tendency of the vertical shift.
+            Defaults to the median.
         :param subsample: Subsample the input for speed-up. <1 is parsed as a fraction. >1 is a pixel count.
         """
-        self._meta: CoregDict = {}  # All __init__ functions should instantiate an empty dict.
+        self.meta: CoregDict = {}  # All __init__ functions should instantiate an empty dict.
 
-        super().__init__(meta={"vshift_func": vshift_func}, subsample=subsample)
+        super().__init__(meta={"vshift_reduc_func": vshift_reduc_func}, subsample=subsample)
 
     def _fit_rst_rst(
         self,
@@ -351,9 +352,9 @@ class VerticalShift(AffineCoreg):
 
         # Use weights if those were provided.
         vshift = (
-            self._meta["vshift_func"](diff)
+            self.meta["vshift_reduc_func"](diff)
             if weights is None
-            else self._meta["vshift_func"](diff, weights)  # type: ignore
+            else self.meta["vshift_reduc_func"](diff, weights)  # type: ignore
         )
 
         # TODO: We might need to define the type of bias_func with Callback protocols to get the optional argument,
@@ -362,7 +363,7 @@ class VerticalShift(AffineCoreg):
         if verbose:
             print("Vertical shift estimated")
 
-        self._meta["vshift"] = vshift
+        self.meta["shift_z"] = vshift
 
     def _apply_rst(
         self,
@@ -373,7 +374,7 @@ class VerticalShift(AffineCoreg):
         **kwargs: Any,
     ) -> tuple[NDArrayf, rio.transform.Affine]:
         """Apply the VerticalShift function to a DEM."""
-        return elev + self._meta["vshift"], transform
+        return elev + self.meta["shift_z"], transform
 
     def _apply_pts(
         self,
@@ -385,14 +386,14 @@ class VerticalShift(AffineCoreg):
 
         """Apply the VerticalShift function to a set of points."""
         dem_copy = elev.copy()
-        dem_copy[z_name] += self._meta["vshift"]
+        dem_copy[z_name] += self.meta["shift_z"]
         return dem_copy
 
     def _to_matrix_func(self) -> NDArrayf:
         """Convert the vertical shift to a transform matrix."""
         empty_matrix = np.diag(np.ones(4, dtype=float))
 
-        empty_matrix[2, 3] += self._meta["vshift"]
+        empty_matrix[2, 3] += self.meta["shift_z"]
 
         return empty_matrix
 
@@ -591,8 +592,8 @@ class ICP(AffineCoreg):
 
         assert residual < 1000, f"ICP coregistration failed: residual={residual}, threshold: 1000"
 
-        self._meta["centroid"] = centroid
-        self._meta["matrix"] = matrix
+        self.meta["centroid"] = centroid
+        self.meta["matrix"] = matrix
 
 
 class Tilt(AffineCoreg):
@@ -630,11 +631,11 @@ class Tilt(AffineCoreg):
         ddem[~inlier_mask] = np.nan
         x_coords, y_coords = _get_x_and_y_coords(ref_elev.shape, transform)
         fit_ramp, coefs = deramping(
-            ddem, x_coords, y_coords, degree=self.poly_order, subsample=self._meta["subsample"], verbose=verbose
+            ddem, x_coords, y_coords, degree=self.poly_order, subsample=self.meta["subsample"], verbose=verbose
         )
 
-        self._meta["coefficients"] = coefs[0]
-        self._meta["func"] = fit_ramp
+        self.meta["fit_params"] = coefs[0]
+        self.meta["fit_func"] = fit_ramp
 
     def _apply_rst(
         self,
@@ -647,7 +648,7 @@ class Tilt(AffineCoreg):
         """Apply the deramp function to a DEM."""
         x_coords, y_coords = _get_x_and_y_coords(elev.shape, transform)
 
-        ramp = self._meta["func"](x_coords, y_coords)
+        ramp = self.meta["fit_func"](x_coords, y_coords)
 
         return elev + ramp, transform
 
@@ -660,7 +661,7 @@ class Tilt(AffineCoreg):
     ) -> gpd.GeoDataFrame:
         """Apply the deramp function to a set of points."""
         dem_copy = elev.copy()
-        dem_copy[z_name].values += self._meta["func"](dem_copy.geometry.x.values, dem_copy.geometry.y.values)
+        dem_copy[z_name].values += self.meta["fit_func"](dem_copy.geometry.x.values, dem_copy.geometry.y.values)
 
         return dem_copy
 
@@ -677,7 +678,7 @@ class Tilt(AffineCoreg):
         # If degree==0, it's just a bias correction
         empty_matrix = np.diag(np.ones(4, dtype=float))
 
-        empty_matrix[2, 3] += self._meta["coefficients"][0]
+        empty_matrix[2, 3] += self.meta["fit_params"][0]
 
         return empty_matrix
 
@@ -697,7 +698,7 @@ class NuthKaab(AffineCoreg):
         :param offset_threshold: The residual offset threshold after which to stop the iterations (in pixels).
         :param subsample: Subsample the input for speed-up. <1 is parsed as a fraction. >1 is a pixel count.
         """
-        self._meta: CoregDict
+        self.meta: CoregDict
         self.max_iterations = max_iterations
         self.offset_threshold = offset_threshold
 
@@ -837,10 +838,9 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
             print("   Statistics on coregistered dh:")
             print(f"      Median = {vshift:.2f} - NMAD = {nmad_new:.2f}")
 
-        self._meta["offset_east_px"] = offset_east
-        self._meta["offset_north_px"] = offset_north
-        self._meta["vshift"] = vshift
-        self._meta["resolution"] = resolution
+        self.meta["shift_x"] = offset_east * resolution
+        self.meta["shift_y"] = offset_north * resolution
+        self.meta["shift_z"] = vshift
 
     def _fit_rst_pts(
         self,
@@ -993,21 +993,17 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
             print("   Statistics on coregistered dh:")
             print(f"      Median = {vshift:.3f} - NMAD = {nmad_new:.3f}")
 
-        self._meta["offset_east_px"] = offset_east if ref == "point" else -offset_east
-        self._meta["offset_north_px"] = offset_north if ref == "point" else -offset_north
-        self._meta["vshift"] = vshift if ref == "point" else -vshift
-        self._meta["resolution"] = resolution
-        self._meta["nmad"] = nmad_new
+        self.meta["shift_x"] = offset_east * resolution if ref == "point" else -offset_east
+        self.meta["shift_y"] = offset_north * resolution if ref == "point" else -offset_north
+        self.meta["shift_z"] = vshift if ref == "point" else -vshift
 
     def _to_matrix_func(self) -> NDArrayf:
         """Return a transformation matrix from the estimated offsets."""
-        offset_east = self._meta["offset_east_px"] * self._meta["resolution"]
-        offset_north = self._meta["offset_north_px"] * self._meta["resolution"]
 
         matrix = np.diag(np.ones(4, dtype=float))
-        matrix[0, 3] += offset_east
-        matrix[1, 3] += offset_north
-        matrix[2, 3] += self._meta["vshift"]
+        matrix[0, 3] += self.meta["shift_x"]
+        matrix[1, 3] += self.meta["shift_y"]
+        matrix[2, 3] += self.meta["shift_z"]
 
         return matrix
 
@@ -1020,11 +1016,9 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
         **kwargs: Any,
     ) -> tuple[NDArrayf, rio.transform.Affine]:
         """Apply the Nuth & Kaab shift to a DEM."""
-        offset_east = self._meta["offset_east_px"] * self._meta["resolution"]
-        offset_north = self._meta["offset_north_px"] * self._meta["resolution"]
 
-        updated_transform = apply_xy_shift(transform, -offset_east, -offset_north)
-        vshift = self._meta["vshift"]
+        updated_transform = apply_xy_shift(transform, -self.meta["shift_x"], -self.meta["shift_y"])
+        vshift = self.meta["shift_z"]
         return elev + vshift, updated_transform
 
     def _apply_pts(
@@ -1034,16 +1028,13 @@ projected CRS. First, reproject your DEMs in a local projected CRS, e.g. UTM, an
         bias_vars: dict[str, NDArrayf] | None = None,
         **kwargs: Any,
     ) -> gpd.GeoDataFrame:
-
-        """Apply the Nuth & Kaab shift to a set of points."""
-        offset_east = self._meta["offset_east_px"] * self._meta["resolution"]
-        offset_north = self._meta["offset_north_px"] * self._meta["resolution"]
+        """Apply the Nuth & Kaab shift to an elevation point cloud."""
 
         applied_epc = gpd.GeoDataFrame(
             geometry=gpd.points_from_xy(
-                x=elev.geometry.x.values + offset_east, y=elev.geometry.y.values + offset_north, crs=elev.crs
+                x=elev.geometry.x.values + self.meta["shift_x"], y=elev.geometry.y.values + self.meta["shift_y"], crs=elev.crs
             ),
-            data={z_name: elev[z_name].values + self._meta["vshift"]},
+            data={z_name: elev[z_name].values + self.meta["shift_z"]},
         )
 
         return applied_epc
@@ -1077,7 +1068,7 @@ class GradientDescending(AffineCoreg):
         or when the function value differs by less than the tolerance 'feps' along all directions.
 
         """
-        self._meta: CoregDict
+        self.meta: CoregDict
         self.bounds = bounds
         self.x0 = x0
         self.deltainit = deltainit
@@ -1122,9 +1113,9 @@ class GradientDescending(AffineCoreg):
         rst_elev = Raster.from_array(rst_elev, transform=transform, crs=crs, nodata=-9999)
 
         # Perform downsampling if subsample != None
-        if self._meta["subsample"] and len(point_elev) > self._meta["subsample"]:
+        if self.meta["subsample"] and len(point_elev) > self.meta["subsample"]:
             point_elev = point_elev.sample(
-                frac=self._meta["subsample"] / len(point_elev), random_state=self._meta["random_state"]
+                frac=self.meta["subsample"] / len(point_elev), random_state=self.meta["random_state"]
             ).copy()
         else:
             point_elev = point_elev.copy()
@@ -1145,7 +1136,7 @@ class GradientDescending(AffineCoreg):
 
         if verbose:
             print("Running Gradient Descending Coreg - Zhihao (in preparation) ")
-            if self._meta["subsample"]:
+            if self.meta["subsample"]:
                 print("Running on downsampling. The length of the gdf:", len(point_elev))
 
             elevation_difference = _residuals_df(rst_elev, point_elev, (0, 0), 0, z_name=z_name)
@@ -1191,10 +1182,9 @@ class GradientDescending(AffineCoreg):
         offset_east = res.x[0]
         offset_north = res.x[1]
 
-        self._meta["offset_east_px"] = offset_east if ref == "point" else -offset_east
-        self._meta["offset_north_px"] = offset_north if ref == "point" else -offset_north
-        self._meta["vshift"] = vshift if ref == "point" else -vshift
-        self._meta["resolution"] = resolution
+        self.meta["shift_x"] = offset_east * resolution if ref == "point" else -offset_east
+        self.meta["shift_y"] = offset_north * resolution if ref == "point" else -offset_north
+        self.meta["shift_z"] = vshift if ref == "point" else -vshift
 
     def _fit_rst_rst(
         self,
@@ -1230,12 +1220,10 @@ class GradientDescending(AffineCoreg):
 
     def _to_matrix_func(self) -> NDArrayf:
         """Return a transformation matrix from the estimated offsets."""
-        offset_east = self._meta["offset_east_px"] * self._meta["resolution"]
-        offset_north = self._meta["offset_north_px"] * self._meta["resolution"]
 
         matrix = np.diag(np.ones(4, dtype=float))
-        matrix[0, 3] += offset_east
-        matrix[1, 3] += offset_north
-        matrix[2, 3] += self._meta["vshift"]
+        matrix[0, 3] += self.meta["shift_x"]
+        matrix[1, 3] += self.meta["shift_y"]
+        matrix[2, 3] += self.meta["shift_z"]
 
         return matrix

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -1059,7 +1059,7 @@ class Coreg:
     _fit_called: bool = False  # Flag to check if the .fit() method has been called.
     _is_affine: bool | None = None
     _needs_vars: bool = False
-    _meta = CoregDict
+    _meta: CoregDict
 
     def __init__(self, meta: CoregDict | None = None) -> None:
         """Instantiate a generic processing step method."""

--- a/xdem/coreg/biascorr.py
+++ b/xdem/coreg/biascorr.py
@@ -32,10 +32,10 @@ BiasCorrType = TypeVar("BiasCorrType", bound="BiasCorr")
 
 class BiasCorr(Coreg):
     """
-    Parent class of bias correction methods: non-rigid coregistrations.
+    Bias-correction (non-rigid alignment) simultaneously with any number and type of variables.
 
-    Made to be subclassed to pass default parameters/dimensions more intuitively, or to provide wrappers for specific
-    types of bias corrections (directional, terrain, etc).
+    Variables for bias-correction can include the elevation coordinates (deramping, directional biases), terrain
+    attributes (terrain corrections), or any other user-input variable (quality metrics, land cover).
     """
 
     def __init__(
@@ -508,7 +508,8 @@ class DirectionalBias(BiasCorr):
         """
         Instantiate a directional bias correction.
 
-        :param angle: Angle in which to perform the directional correction (degrees).
+        :param angle: Angle in which to perform the directional correction (degrees) with 0° corresponding to X axis
+            direction and increasing clockwise.
         :param fit_or_bin: Whether to fit or bin. Use "fit" to correct by optimizing a function or
             "bin" to correct with a statistic of central tendency in defined bins.
         :param fit_func: Function to fit to the bias with variables later passed in .fit().
@@ -797,7 +798,8 @@ class TerrainBias(BiasCorr):
 
 class Deramp(BiasCorr):
     """
-    Correct for a 2D polynomial along X/Y coordinates, for example from residual camera model deformations.
+    Correct for a 2D polynomial along X/Y coordinates, for example from residual camera model deformations 
+    (dome-like errors).
     """
 
     def __init__(

--- a/xdem/coreg/biascorr.py
+++ b/xdem/coreg/biascorr.py
@@ -798,7 +798,7 @@ class TerrainBias(BiasCorr):
 
 class Deramp(BiasCorr):
     """
-    Correct for a 2D polynomial along X/Y coordinates, for example from residual camera model deformations 
+    Correct for a 2D polynomial along X/Y coordinates, for example from residual camera model deformations
     (dome-like errors).
     """
 

--- a/xdem/coreg/biascorr.py
+++ b/xdem/coreg/biascorr.py
@@ -133,10 +133,10 @@ class BiasCorr(Coreg):
             super().__init__(meta=meta_bin_and_fit)  # type: ignore
 
         # Add subsample attribute
-        self.meta["subsample"] = subsample
+        self._meta["subsample"] = subsample
 
         # Add number of dimensions attribute (length of bias_var_names, counted generically for iterator)
-        self.meta["nd"] = sum(1 for _ in bias_var_names) if bias_var_names is not None else None
+        self._meta["nd"] = sum(1 for _ in bias_var_names) if bias_var_names is not None else None
 
         # Update attributes
         self._fit_or_bin = fit_or_bin
@@ -166,7 +166,7 @@ class BiasCorr(Coreg):
             raise ValueError("At least one `bias_var` should be passed to the fitting function, got None.")
 
         # Check number of variables
-        nd = self.meta["nd"]
+        nd = self._meta["nd"]
         if nd is not None and len(bias_vars) != nd:
             raise ValueError(
                 "A number of {} variable(s) has to be provided through the argument 'bias_vars', "
@@ -174,15 +174,15 @@ class BiasCorr(Coreg):
             )
 
         # If bias var names were explicitly passed at instantiation, check that they match the one from the dict
-        if self.meta["bias_var_names"] is not None:
-            if not sorted(bias_vars.keys()) == sorted(self.meta["bias_var_names"]):
+        if self._meta["bias_var_names"] is not None:
+            if not sorted(bias_vars.keys()) == sorted(self._meta["bias_var_names"]):
                 raise ValueError(
                     "The keys of `bias_vars` do not match the `bias_var_names` defined during "
-                    "instantiation: {}.".format(self.meta["bias_var_names"])
+                    "instantiation: {}.".format(self._meta["bias_var_names"])
                 )
         # Otherwise, store bias variable names from the dictionary
         else:
-            self.meta["bias_var_names"] = list(bias_vars.keys())
+            self._meta["bias_var_names"] = list(bias_vars.keys())
 
         # Compute difference and mask of valid data
         # TODO: Move the check up to Coreg.fit()?
@@ -204,21 +204,21 @@ class BiasCorr(Coreg):
 
         # Remove random state for keyword argument if its value is not in the optimizer function
         if self._fit_or_bin in ["fit", "bin_and_fit"]:
-            fit_func_args = inspect.getfullargspec(self.meta["fit_optimizer"]).args
+            fit_func_args = inspect.getfullargspec(self._meta["fit_optimizer"]).args
             if "random_state" not in fit_func_args and "random_state" in kwargs:
                 kwargs.pop("random_state")
 
         # We need to sort the bin sizes in the same order as the bias variables if a dict is passed for bin_sizes
         if self._fit_or_bin in ["bin", "bin_and_fit"]:
-            if isinstance(self.meta["bin_sizes"], dict):
+            if isinstance(self._meta["bin_sizes"], dict):
                 var_order = list(bias_vars.keys())
                 # Declare type to write integer or tuple to the variable
                 bin_sizes: int | tuple[int, ...] | tuple[NDArrayf, ...] = tuple(
-                    np.array(self.meta["bin_sizes"][var]) for var in var_order
+                    np.array(self._meta["bin_sizes"][var]) for var in var_order
                 )
             # Otherwise, write integer directly
             else:
-                bin_sizes = self.meta["bin_sizes"]
+                bin_sizes = self._meta["bin_sizes"]
 
         # Option 1: Run fit and save optimized function parameters
         if self._fit_or_bin == "fit":
@@ -227,11 +227,11 @@ class BiasCorr(Coreg):
             if verbose:
                 print(
                     "Estimating bias correction along variables {} by fitting "
-                    "with function {}.".format(", ".join(list(bias_vars.keys())), self.meta["fit_func"].__name__)
+                    "with function {}.".format(", ".join(list(bias_vars.keys())), self._meta["fit_func"].__name__)
                 )
 
-            results = self.meta["fit_optimizer"](
-                f=self.meta["fit_func"],
+            results = self._meta["fit_optimizer"](
+                f=self._meta["fit_func"],
                 xdata=np.array([var[subsample_mask].flatten() for var in bias_vars.values()]).squeeze(),
                 ydata=diff[subsample_mask].flatten(),
                 sigma=weights[subsample_mask].flatten() if weights is not None else None,
@@ -245,7 +245,7 @@ class BiasCorr(Coreg):
             if verbose:
                 print(
                     "Estimating bias correction along variables {} by binning "
-                    "with statistic {}.".format(", ".join(list(bias_vars.keys())), self.meta["bin_statistic"].__name__)
+                    "with statistic {}.".format(", ".join(list(bias_vars.keys())), self._meta["bin_statistic"].__name__)
                 )
 
             df = xdem.spatialstats.nd_binning(
@@ -253,7 +253,7 @@ class BiasCorr(Coreg):
                 list_var=[var[subsample_mask] for var in bias_vars.values()],
                 list_var_names=list(bias_vars.keys()),
                 list_var_bins=bin_sizes,
-                statistics=(self.meta["bin_statistic"], "count"),
+                statistics=(self._meta["bin_statistic"], "count"),
             )
 
         # Option 3: Run binning, then fitting, and save both results
@@ -265,8 +265,8 @@ class BiasCorr(Coreg):
                     "Estimating bias correction along variables {} by binning with statistic {} and then fitting "
                     "with function {}.".format(
                         ", ".join(list(bias_vars.keys())),
-                        self.meta["bin_statistic"].__name__,
-                        self.meta["fit_func"].__name__,
+                        self._meta["bin_statistic"].__name__,
+                        self._meta["fit_func"].__name__,
                     )
                 )
 
@@ -275,7 +275,7 @@ class BiasCorr(Coreg):
                 list_var=[var[subsample_mask] for var in bias_vars.values()],
                 list_var_names=list(bias_vars.keys()),
                 list_var_bins=bin_sizes,
-                statistics=(self.meta["bin_statistic"], "count"),
+                statistics=(self._meta["bin_statistic"], "count"),
             )
 
             # Now, we need to pass this new data to the fitting function and optimizer
@@ -284,7 +284,7 @@ class BiasCorr(Coreg):
 
             # We get the middle of bin values for variable, and statistic for the diff
             new_vars = [pd.IntervalIndex(df_nd[var_name]).mid.values for var_name in bias_vars.keys()]
-            new_diff = df_nd[self.meta["bin_statistic"].__name__].values
+            new_diff = df_nd[self._meta["bin_statistic"].__name__].values
             # TODO: pass a new sigma based on "count" and original sigma (and correlation?)?
             #  sigma values would have to be binned above also
 
@@ -294,8 +294,8 @@ class BiasCorr(Coreg):
             if np.all(~ind_valid):
                 raise ValueError("Only NaNs values after binning, did you pass the right bin edges?")
 
-            results = self.meta["fit_optimizer"](
-                f=self.meta["fit_func"],
+            results = self._meta["fit_optimizer"](
+                f=self._meta["fit_func"],
                 xdata=np.array([var[ind_valid].flatten() for var in new_vars]).squeeze(),
                 ydata=new_diff[ind_valid].flatten(),
                 sigma=weights[ind_valid].flatten() if weights is not None else None,
@@ -310,28 +310,28 @@ class BiasCorr(Coreg):
         if self._fit_or_bin in ["fit", "bin_and_fit"]:
 
             # Write the results to metadata in different ways depending on optimizer returns
-            if self.meta["fit_optimizer"] in (w["optimizer"] for w in fit_workflows.values()):
+            if self._meta["fit_optimizer"] in (w["optimizer"] for w in fit_workflows.values()):
                 params = results[0]
                 order_or_freq = results[1]
-                if self.meta["fit_optimizer"] == robust_norder_polynomial_fit:
-                    self.meta["poly_order"] = order_or_freq
+                if self._meta["fit_optimizer"] == robust_norder_polynomial_fit:
+                    self._meta["poly_order"] = order_or_freq
                 else:
-                    self.meta["nb_sin_freq"] = order_or_freq
+                    self._meta["nb_sin_freq"] = order_or_freq
 
-            elif self.meta["fit_optimizer"] == scipy.optimize.curve_fit:
+            elif self._meta["fit_optimizer"] == scipy.optimize.curve_fit:
                 params = results[0]
                 # Calculation to get the error on parameters (see description of scipy.optimize.curve_fit)
                 perr = np.sqrt(np.diag(results[1]))
-                self.meta["fit_perr"] = perr
+                self._meta["fit_perr"] = perr
 
             else:
                 params = results[0]
 
-            self.meta["fit_params"] = params
+            self._meta["fit_params"] = params
 
         # Save results of binning if it was perfrmed
         elif self._fit_or_bin in ["bin", "bin_and_fit"]:
-            self.meta["bin_dataframe"] = df
+            self._meta["bin_dataframe"] = df
 
     def _fit_rst_rst(
         self,
@@ -452,24 +452,24 @@ class BiasCorr(Coreg):
             raise ValueError("At least one `bias_var` should be passed to the `apply` function, got None.")
 
         # Check the bias_vars passed match the ones stored for this bias correction class
-        if not sorted(bias_vars.keys()) == sorted(self.meta["bias_var_names"]):
+        if not sorted(bias_vars.keys()) == sorted(self._meta["bias_var_names"]):
             raise ValueError(
                 "The keys of `bias_vars` do not match the `bias_var_names` defined during "
-                "instantiation or fitting: {}.".format(self.meta["bias_var_names"])
+                "instantiation or fitting: {}.".format(self._meta["bias_var_names"])
             )
 
         # Apply function to get correction (including if binning was done before)
         if self._fit_or_bin in ["fit", "bin_and_fit"]:
-            corr = self.meta["fit_func"](tuple(bias_vars.values()), *self.meta["fit_params"])
+            corr = self._meta["fit_func"](tuple(bias_vars.values()), *self._meta["fit_params"])
 
         # Apply binning to get correction
         else:
-            if self.meta["bin_apply_method"] == "linear":
+            if self._meta["bin_apply_method"] == "linear":
                 # N-D interpolation of binning
                 bin_interpolator = xdem.spatialstats.interp_nd_binning(
-                    df=self.meta["bin_dataframe"],
+                    df=self._meta["bin_dataframe"],
                     list_var_names=list(bias_vars.keys()),
-                    statistic=self.meta["bin_statistic"],
+                    statistic=self._meta["bin_statistic"],
                 )
                 corr = bin_interpolator(tuple(var.flatten() for var in bias_vars.values()))
                 first_var = list(bias_vars.keys())[0]
@@ -478,10 +478,10 @@ class BiasCorr(Coreg):
             else:
                 # Get N-D binning statistic for each pixel of the new list of variables
                 corr = xdem.spatialstats.get_perbin_nd_binning(
-                    df=self.meta["bin_dataframe"],
+                    df=self._meta["bin_dataframe"],
                     list_var=list(bias_vars.values()),
                     list_var_names=list(bias_vars.keys()),
-                    statistic=self.meta["bin_statistic"],
+                    statistic=self._meta["bin_statistic"],
                 )
 
         dem_corr = elev + corr
@@ -522,7 +522,7 @@ class DirectionalBias(BiasCorr):
         super().__init__(
             fit_or_bin, fit_func, fit_optimizer, bin_sizes, bin_statistic, bin_apply_method, ["angle"], subsample
         )
-        self.meta["angle"] = angle
+        self._meta["angle"] = angle
         self._needs_vars = False
 
     def _fit_rst_rst(  # type: ignore
@@ -544,7 +544,7 @@ class DirectionalBias(BiasCorr):
 
         x, _ = gu.raster.get_xy_rotated(
             raster=gu.Raster.from_array(data=ref_elev, crs=crs, transform=transform, nodata=-9999),
-            along_track_angle=self.meta["angle"],
+            along_track_angle=self._meta["angle"],
         )
 
         # Parameters dependent on resolution cannot be derived from the rotated x coordinates, need to be passed below
@@ -588,7 +588,7 @@ class DirectionalBias(BiasCorr):
 
         x, _ = gu.raster.get_xy_rotated(
             raster=gu.Raster.from_array(data=rast_elev, crs=crs, transform=transform, nodata=-9999),
-            along_track_angle=self.meta["angle"],
+            along_track_angle=self._meta["angle"],
         )
 
         # Parameters dependent on resolution cannot be derived from the rotated x coordinates, need to be passed below
@@ -622,7 +622,7 @@ class DirectionalBias(BiasCorr):
         # Define the coordinates for applying the correction
         x, _ = gu.raster.get_xy_rotated(
             raster=gu.Raster.from_array(data=elev, crs=crs, transform=transform, nodata=-9999),
-            along_track_angle=self.meta["angle"],
+            along_track_angle=self._meta["angle"],
         )
 
         return super()._apply_rst(elev=elev, transform=transform, crs=crs, bias_vars={"angle": x}, **kwargs)
@@ -679,7 +679,7 @@ class TerrainBias(BiasCorr):
             subsample,
         )
         # This is the same as bias_var_names, but let's leave the duplicate for clarity
-        self.meta["terrain_attribute"] = terrain_attribute
+        self._meta["terrain_attribute"] = terrain_attribute
         self._needs_vars = False
 
     def _fit_rst_rst(  # type: ignore
@@ -697,18 +697,18 @@ class TerrainBias(BiasCorr):
     ) -> None:
 
         # If already passed by user, pass along
-        if bias_vars is not None and self.meta["terrain_attribute"] in bias_vars:
-            attr = bias_vars[self.meta["terrain_attribute"]]
+        if bias_vars is not None and self._meta["terrain_attribute"] in bias_vars:
+            attr = bias_vars[self._meta["terrain_attribute"]]
 
         # If only declared during instantiation
         else:
             # Derive terrain attribute
-            if self.meta["terrain_attribute"] == "elevation":
+            if self._meta["terrain_attribute"] == "elevation":
                 attr = ref_elev
             else:
                 attr = xdem.terrain.get_terrain_attribute(
                     dem=ref_elev,
-                    attribute=self.meta["terrain_attribute"],
+                    attribute=self._meta["terrain_attribute"],
                     resolution=(transform[0], abs(transform[4])),
                 )
 
@@ -717,7 +717,7 @@ class TerrainBias(BiasCorr):
             ref_elev=ref_elev,
             tba_elev=tba_elev,
             inlier_mask=inlier_mask,
-            bias_vars={self.meta["terrain_attribute"]: attr},
+            bias_vars={self._meta["terrain_attribute"]: attr},
             transform=transform,
             crs=crs,
             z_name=z_name,
@@ -741,8 +741,8 @@ class TerrainBias(BiasCorr):
     ) -> None:
 
         # If already passed by user, pass along
-        if bias_vars is not None and self.meta["terrain_attribute"] in bias_vars:
-            attr = bias_vars[self.meta["terrain_attribute"]]
+        if bias_vars is not None and self._meta["terrain_attribute"] in bias_vars:
+            attr = bias_vars[self._meta["terrain_attribute"]]
 
         # If only declared during instantiation
         else:
@@ -750,12 +750,12 @@ class TerrainBias(BiasCorr):
             rast_elev = ref_elev if not isinstance(ref_elev, gpd.GeoDataFrame) else tba_elev
 
             # Derive terrain attribute
-            if self.meta["terrain_attribute"] == "elevation":
+            if self._meta["terrain_attribute"] == "elevation":
                 attr = rast_elev
             else:
                 attr = xdem.terrain.get_terrain_attribute(
                     dem=rast_elev,
-                    attribute=self.meta["terrain_attribute"],
+                    attribute=self._meta["terrain_attribute"],
                     resolution=(transform[0], abs(transform[4])),
                 )
 
@@ -764,7 +764,7 @@ class TerrainBias(BiasCorr):
             ref_elev=ref_elev,
             tba_elev=tba_elev,
             inlier_mask=inlier_mask,
-            bias_vars={self.meta["terrain_attribute"]: attr},
+            bias_vars={self._meta["terrain_attribute"]: attr},
             transform=transform,
             crs=crs,
             z_name=z_name,
@@ -784,13 +784,13 @@ class TerrainBias(BiasCorr):
 
         if bias_vars is None:
             # Derive terrain attribute
-            if self.meta["terrain_attribute"] == "elevation":
+            if self._meta["terrain_attribute"] == "elevation":
                 attr = elev
             else:
                 attr = xdem.terrain.get_terrain_attribute(
-                    dem=elev, attribute=self.meta["terrain_attribute"], resolution=(transform[0], abs(transform[4]))
+                    dem=elev, attribute=self._meta["terrain_attribute"], resolution=(transform[0], abs(transform[4]))
                 )
-            bias_vars = {self.meta["terrain_attribute"]: attr}
+            bias_vars = {self._meta["terrain_attribute"]: attr}
 
         return super()._apply_rst(elev=elev, transform=transform, crs=crs, bias_vars=bias_vars, **kwargs)
 
@@ -835,7 +835,7 @@ class Deramp(BiasCorr):
             ["xx", "yy"],
             subsample,
         )
-        self.meta["poly_order"] = poly_order
+        self._meta["poly_order"] = poly_order
         self._needs_vars = False
 
     def _fit_rst_rst(  # type: ignore
@@ -853,7 +853,7 @@ class Deramp(BiasCorr):
     ) -> None:
 
         # The number of parameters in the first guess defines the polynomial order when calling np.polyval2d
-        p0 = np.ones(shape=((self.meta["poly_order"] + 1) ** 2))
+        p0 = np.ones(shape=((self._meta["poly_order"] + 1) ** 2))
 
         # Coordinates (we don't need the actual ones, just array coordinates)
         xx, yy = np.meshgrid(np.arange(0, ref_elev.shape[1]), np.arange(0, ref_elev.shape[0]))
@@ -890,7 +890,7 @@ class Deramp(BiasCorr):
         rast_elev = ref_elev if not isinstance(ref_elev, gpd.GeoDataFrame) else tba_elev
 
         # The number of parameters in the first guess defines the polynomial order when calling np.polyval2d
-        p0 = np.ones(shape=((self.meta["poly_order"] + 1) ** 2))
+        p0 = np.ones(shape=((self._meta["poly_order"] + 1) ** 2))
 
         # Coordinates (we don't need the actual ones, just array coordinates)
         xx, yy = np.meshgrid(np.arange(0, rast_elev.shape[1]), np.arange(0, rast_elev.shape[0]))

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -105,7 +105,7 @@ def process_coregistered_examples(name: str, overwrite: bool = False) -> None:
         nuth_kaab.fit(reference_raster, to_be_aligned_raster, inlier_mask=inlier_mask, random_state=42)
 
         # Check that random state is respected
-        assert nuth_kaab._meta["random_state"] == 42
+        assert nuth_kaabmeta["random_state"] == 42
 
         aligned_raster = nuth_kaab.apply(to_be_aligned_raster, resample=True)
 

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -104,9 +104,6 @@ def process_coregistered_examples(name: str, overwrite: bool = False) -> None:
         nuth_kaab = xdem.coreg.NuthKaab()
         nuth_kaab.fit(reference_raster, to_be_aligned_raster, inlier_mask=inlier_mask, random_state=42)
 
-        # Check that random state is respected
-        assert nuth_kaabmeta["random_state"] == 42
-
         aligned_raster = nuth_kaab.apply(to_be_aligned_raster, resample=True)
 
         diff = reference_raster - aligned_raster


### PR DESCRIPTION
This PR makes the `.meta` attribute a public property of `Coreg`, and makes the attribute names consistent.

In particular:
- `"offset_east_px"` is now `"shift_x"`, and is in georeferenced units (instead of pixels) which allows to remove the `"resolution"` key in the metadata,
- `"offset_north_px"` is now `"shift_y"`,
- `"vshift"` is now `"shift_z"`,
Others are renamed to be consistent with `BiasCorr`.

Will be documented in #502!
