### PR TITLE
Update link to `xdem-data` to use COGs example files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,10 +145,7 @@ dmypy.json
 xdem/_version.py
 
 # Example data downloaded/produced during tests
-examples/data/Longyearbyen/data/
-examples/data/Longyearbyen/processed/
-examples/data/*.tif
-examples/data/*.csv
+examples/data/
 
 doc/source/basic_examples/
 doc/source/advanced_examples/

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -47,9 +47,10 @@ def download_longyearbyen_examples(overwrite: bool = False) -> None:
                 os.remove(fn)
 
     # Static commit hash to be bumped every time it needs to be.
-    commit = "fd832bc2e366cf2ba8b543f7e43f90ee02384f4f"
+    commit = "b3ce14b3c685abf62ae1cd916031034595c3af28"
     # The URL from which to download the repository
-    url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
+    # url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
+    url = f"https://github.com/ameliefroessl/xdem-data/tarball/cog-files#commit={commit}"
 
     # Create a temporary directory to extract the tarball in.
     temp_dir = tempfile.TemporaryDirectory()

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -47,10 +47,11 @@ def download_longyearbyen_examples(overwrite: bool = False) -> None:
                 os.remove(fn)
 
     # Static commit hash to be bumped every time it needs to be.
-    commit = "b3ce14b3c685abf62ae1cd916031034595c3af28"
+    commit = "ff5ede952fc422ebd2a3c6340041a118850bc905"
     # The URL from which to download the repository
-    # url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
-    url = f"https://github.com/ameliefroessl/xdem-data/tarball/cog-files#commit={commit}"
+    url = f"https://github.com/GlacioHack/xdem-data/tarball/main#commit={commit}"
+    # To test new data from a user-branch before merging in xdem-data
+    # url = f"https://github.com/ameliefroessl/xdem-data/tarball/cog-files#commit={commit}"
 
     # Create a temporary directory to extract the tarball in.
     temp_dir = tempfile.TemporaryDirectory()


### PR DESCRIPTION
Stemmed in #525 
Following https://github.com/GlacioHack/xdem-data/pull/1