### PR TITLE
Refactor `GradientDescending` to `DhMinimize` with generic inputs

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -45,8 +45,6 @@ dependencies:
   - pip:
     - -e ./
 
-    # Optional dependencies
-    - noisyopt
     # "Headless" needed for opencv to install without requiring system dependencies
     - opencv-contrib-python-headless
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - richdem
 
   # Test dependencies
+  - gdal  # To test against GDAL
   - pytest
   - pytest-xdist
   - pyyaml

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy=1.*
   - matplotlib=3.*
   - pyproj>=3.4,<4
-  - rasterio>=1.3,<2
+  - rasterio>=1.3,<1.4
   - scipy=1.*
   - tqdm
   - scikit-image=0.*
@@ -28,7 +28,6 @@ dependencies:
   - pyyaml
   - flake8
   - pylint
-  - gdal
 
   # Doc dependencies
   - sphinx

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - pyyaml
   - flake8
   - pylint
+  - gdal
 
   # Doc dependencies
   - sphinx

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy=1.*
   - matplotlib=3.*
   - pyproj>=3.4,<4
-  - rasterio>=1.3,<1.4
+  - rasterio>=1.3,<2
   - scipy=1.*
   - tqdm
   - scikit-image=0.*
@@ -44,7 +44,6 @@ dependencies:
 
   - pip:
     # Optional dependency
-    - noisyopt
     - -e ./
 
     # "Headless" needed for opencv to install without requiring system dependencies

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy=1.*
   - matplotlib=3.*
   - pyproj>=3.4,<4
-  - rasterio>=1.3,<2
+  - rasterio>=1.3,<1.4
   - scipy=1.*
   - tqdm
   - scikit-image=0.*

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -43,6 +43,8 @@ dependencies:
   - numpydoc
 
   - pip:
+    # Optional dependency
+    - noisyopt
     - -e ./
 
     # "Headless" needed for opencv to install without requiring system dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy=1.*
   - matplotlib=3.*
   - pyproj>=3.4,<4
-  - rasterio>=1.3,<1.4
+  - rasterio>=1.3,<2
   - scipy=1.*
   - tqdm
   - scikit-image=0.*

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - numpy=1.*
   - matplotlib=3.*
   - pyproj>=3.4,<4
-  - rasterio>=1.3,<2
+  - rasterio>=1.3,<1.4
   - scipy=1.*
   - tqdm
   - scikit-image=0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba==0.*
 numpy==1.*
 matplotlib==3.*
 pyproj>=3.4,<4
-rasterio>=1.3,<1.4
+rasterio>=1.3,<2
 scipy==1.*
 tqdm
 scikit-image==0.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numba==0.*
 numpy==1.*
 matplotlib==3.*
 pyproj>=3.4,<4
-rasterio>=1.3,<2
+rasterio>=1.3,<1.4
 scipy==1.*
 tqdm
 scikit-image==0.*

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -13,7 +13,6 @@ from geoutils import Raster, Vector
 from geoutils._typing import NDArrayNum
 from geoutils.raster import RasterType
 from geoutils.raster.raster import _shift_transform
-from noisyopt import minimizeCompass
 from scipy.ndimage import binary_dilation
 
 from xdem import coreg, examples
@@ -232,12 +231,7 @@ class TestAffineCoreg:
 
         warnings.filterwarnings("ignore", message="Covariance of the parameters*")
 
-        # Initiate coregistration
-        if coreg_method == coreg.DhMinimize:
-            kwargs = {"fit_minimizer": minimizeCompass}
-        else:
-            kwargs = {}
-        horizontal_coreg = coreg_method(**kwargs)
+        horizontal_coreg = coreg_method()
 
         # Copy dictionary and remove inlier mask
         elev_fit_args = fit_args.copy()
@@ -290,7 +284,7 @@ class TestAffineCoreg:
         "coreg_method__shift",
         [
             (coreg.NuthKaab, (9.202739, 2.735573, -1.97733)),
-            (coreg.DhMinimize, (10.125, 2.875, -1.943813)),
+            (coreg.DhMinimize, (10.0850892, 2.898166, -1.943001)),
             (coreg.ICP, (8.73833, 1.584255, -1.943957)),
         ],
     )  # type: ignore
@@ -308,12 +302,7 @@ class TestAffineCoreg:
         # Get the coregistration method and expected shifts from the inputs
         coreg_method, expected_shifts = coreg_method__shift
 
-        # Run co-registration
-        if coreg_method == coreg.DhMinimize:
-            kwargs = {"fit_minimizer": minimizeCompass}
-        else:
-            kwargs = {}
-        c = coreg_method(subsample=50000, **kwargs)
+        c = coreg_method(subsample=50000)
         c.fit(ref, tba, inlier_mask=inlier_mask, verbose=verbose, random_state=42)
 
         # Check the output translations match the exact values

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -1,6 +1,8 @@
 """Functions to test the affine coregistrations."""
 from __future__ import annotations
 
+import warnings
+
 import geopandas as gpd
 import geoutils
 import numpy as np
@@ -213,11 +215,11 @@ class TestAffineCoreg:
 
     @pytest.mark.parametrize("fit_args", all_fit_args)  # type: ignore
     @pytest.mark.parametrize("shifts", [(20, 5, 2), (-50, 100, 2)])  # type: ignore
-    @pytest.mark.parametrize("coreg_method", [coreg.NuthKaab, coreg.GradientDescending, coreg.ICP])  # type: ignore
+    @pytest.mark.parametrize("coreg_method", [coreg.NuthKaab, coreg.DhMinimize, coreg.ICP])  # type: ignore
     def test_coreg_translations__synthetic(self, fit_args, shifts, coreg_method) -> None:
         """
         Test the horizontal/vertical shift coregistrations with synthetic shifted data. These tests include NuthKaab,
-        ICP and GradientDescending.
+        ICP and DhMinimize.
 
         We test all combinaison of inputs: raster-raster, point-raster and raster-point.
 
@@ -226,6 +228,8 @@ class TestAffineCoreg:
         99% of the variance from the initial elevation differences (hence, that the direction of coregistration has
         to be the right one; and that there is no other errors introduced in the process).
         """
+
+        warnings.filterwarnings("ignore", message="Covariance of the parameters*")
 
         # Initiate coregistration
         horizontal_coreg = coreg_method()
@@ -281,7 +285,7 @@ class TestAffineCoreg:
         "coreg_method__shift",
         [
             (coreg.NuthKaab, (9.202739, 2.735573, -1.97733)),
-            (coreg.GradientDescending, (10.0, 2.5, -1.964539)),
+            (coreg.DhMinimize, (10.0, 2.5, -1.964539)),
             (coreg.ICP, (8.73833, 1.584255, -1.943957)),
         ],
     )  # type: ignore

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -13,11 +13,12 @@ from geoutils import Raster, Vector
 from geoutils._typing import NDArrayNum
 from geoutils.raster import RasterType
 from geoutils.raster.raster import _shift_transform
+from noisyopt import minimizeCompass
 from scipy.ndimage import binary_dilation
 
 from xdem import coreg, examples
 from xdem.coreg.affine import AffineCoreg, _reproject_horizontal_shift_samecrs
-from noisyopt import minimizeCompass
+
 
 def load_examples(crop: bool = True) -> tuple[RasterType, RasterType, Vector]:
     """Load example files to try coregistration methods with."""

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -113,16 +113,11 @@ class TestCoregClass:
         # Assert all keys exist in the mapping key to str dictionary used for info
         list_info_keys = list(dict_key_to_str.keys())
 
-        # TODO: Remove GradientDescending + ICP keys here once generic optimizer is used
+        # TODO: Remove ICP keys here once generic optimizer is used
         # Temporary exceptions: pipeline/blockwise + gradientdescending/icp
         list_exceptions = [
             "step_meta",
             "pipeline",
-            "x0",
-            "bounds",
-            "deltainit",
-            "deltatol",
-            "feps",
             "rejection_scale",
             "num_levels",
         ]
@@ -771,7 +766,7 @@ class TestCoregPipeline:
 
     def test_pipeline_pts(self) -> None:
 
-        pipeline = coreg.NuthKaab() + coreg.GradientDescending()
+        pipeline = coreg.NuthKaab() + coreg.DhMinimize()
         ref_points = self.ref.to_pointcloud(subsample=5000, random_state=42).ds
         ref_points["E"] = ref_points.geometry.x
         ref_points["N"] = ref_points.geometry.y

--- a/xdem/coreg/__init__.py
+++ b/xdem/coreg/__init__.py
@@ -5,7 +5,7 @@ DEM coregistration classes and functions, including affine methods, bias correct
 from xdem.coreg.affine import (  # noqa
     ICP,
     AffineCoreg,
-    GradientDescending,
+    DhMinimize,
     NuthKaab,
     VerticalShift,
 )

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -682,7 +682,8 @@ def _dh_minimize_fit(
         if "method" not in kwargs.keys():
             kwargs.update({"method": "Nelder-Mead"})
             kwargs.update({"options": {"xatol": 10e-6, "maxiter": 500}})
-            # This method has trouble when initialized with 0,0, so defaulting to 1,1 (tip from Simon Gascoin)
+            # This method has trouble when initialized with 0,0, so defaulting to 1,1
+            # (tip from Simon Gascoin: https://github.com/GlacioHack/xdem/pull/595#issuecomment-2387104719)
             init_offsets = (1, 1)
 
     elif _HAS_NOISYOPT and params_fit_or_bin["fit_minimizer"] == minimizeCompass:

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -27,7 +27,6 @@ from xdem.coreg.base import (
     CoregDict,
     InFitOrBinDict,
     InRandomDict,
-    InSpecificDict,
     OutAffineDict,
     _bin_or_and_fit_nd,
     _get_subsample_mask_pts_rst,
@@ -651,6 +650,7 @@ def _dh_minimize_fit_func(
     dh = dh_interpolator(coords_offsets[0], coords_offsets[1]).flatten()
 
     return dh
+
 
 def _dh_minimize_fit(
     dh_interpolator: Callable[[float, float], NDArrayf],
@@ -1518,7 +1518,7 @@ class DhMinimize(AffineCoreg):
             verbose=verbose,
             params_random=params_random,
             params_fit_or_bin=params_fit_or_bin,
-            **kwargs
+            **kwargs,
         )
 
         # Write output to class

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -674,11 +674,16 @@ def _dh_minimize_fit(
     def fit_func(coords_offsets: tuple[float, float]) -> np.floating[Any]:
         return loss_func(_dh_minimize_fit_func(coords_offsets=coords_offsets, dh_interpolator=dh_interpolator))
 
-    # Default parameters for scipy.minimize
+    # Initial offset near zero
+    init_offsets = (0, 0)
+
+    # Default parameters depending on optimizer used
     if params_fit_or_bin["fit_minimizer"] == scipy.optimize.minimize:
         if "method" not in kwargs.keys():
             kwargs.update({"method": "Nelder-Mead"})
             kwargs.update({"options": {"xatol": 10e-6, "maxiter": 500}})
+            # This method has trouble when initialized with 0,0, so defaulting to 1,1 (tip from Simon Gascoin)
+            init_offsets = (1, 1)
 
     elif _HAS_NOISYOPT and params_fit_or_bin["fit_minimizer"] == minimizeCompass:
         kwargs.update({"errorcontrol": False})
@@ -687,8 +692,6 @@ def _dh_minimize_fit(
         if "feps" not in kwargs.keys():
             kwargs.update({"feps": 10e-5})
 
-    # Initial offset near zero
-    init_offsets = (0, 0)
     results = params_fit_or_bin["fit_minimizer"](fit_func, init_offsets, **kwargs)
 
     # Get final offsets with the right sign direction

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -42,13 +42,6 @@ try:
 except ImportError:
     _HAS_P3D = False
 
-try:
-    from noisyopt import minimizeCompass
-
-    _has_noisyopt = True
-except ImportError:
-    _has_noisyopt = False
-
 ######################################
 # Generic functions for affine methods
 ######################################
@@ -629,17 +622,17 @@ def nuth_kaab(
     return final_offsets, subsample_final
 
 
-########################
-# 2/ Gradient descending
-########################
+####################
+# 2/ Dh minimization
+####################
 
 
-def _gradient_descending_fit_func(
+def _dh_minimize_fit_func(
     coords_offsets: tuple[float, float],
     dh_interpolator: Callable[[float, float], NDArrayf],
-) -> float:
+) -> NDArrayf:
     """
-    Fitting function of gradient descending method, returns the NMAD of elevation residuals.
+    Fitting function of dh minimization method, returns the NMAD of elevation differences.
 
     :param coords_offsets: Coordinate offsets at this iteration (easting, northing) in georeferenced unit.
     :param dh_interpolator: Interpolator returning elevation differences at the subsampled points for a certain
@@ -648,16 +641,13 @@ def _gradient_descending_fit_func(
     """
 
     # Calculate the elevation difference
-    dh = dh_interpolator(coords_offsets[0], coords_offsets[1])
+    dh = dh_interpolator(coords_offsets[0], coords_offsets[1]).flatten()
 
-    # Return NMAD of residuals
-    return float(nmad(dh))
+    return dh
 
-
-def _gradient_descending_fit(
+def _dh_minimize_fit(
     dh_interpolator: Callable[[float, float], NDArrayf],
-    res: tuple[float, float],
-    params_noisyopt: InSpecificDict,
+    params_fit_or_bin: InFitOrBinDict,
     verbose: bool = False,
 ) -> tuple[float, float, float]:
     """
@@ -665,64 +655,55 @@ def _gradient_descending_fit(
 
     :param dh_interpolator: Interpolator returning elevation differences at the subsampled points for a certain
         horizontal offset (see _preprocess_pts_rst_subsample_interpolator).
-    :param res: Resolution of DEM.
-    :param params_noisyopt: Parameters for noisyopt minimization.
+    :param params_fit_or_bin: Parameters for fitting or binning.
     :param verbose: Whether to print statements.
 
     :return: Optimized offsets (easing, northing, vertical) in georeferenced unit.
     """
-    # Define cost function
-    def func_cost(offset: tuple[float, float]) -> float:
-        return _gradient_descending_fit_func(offset, dh_interpolator=dh_interpolator)
+    # Define partial function
+    loss_func = params_fit_or_bin["fit_loss_func"]
 
-    # Mean resolution
-    mean_res = (res[0] + res[1]) / 2
-    # Run pattern search minimization
-    res = minimizeCompass(
-        func_cost,
-        x0=tuple(x * mean_res for x in params_noisyopt["x0"]),
-        deltainit=params_noisyopt["deltainit"] * mean_res,
-        deltatol=params_noisyopt["deltatol"] * mean_res,
-        feps=params_noisyopt["feps"] * mean_res,
-        bounds=(
-            tuple(b * mean_res for b in params_noisyopt["bounds"]),
-            tuple(b * mean_res for b in params_noisyopt["bounds"]),
-        ),
-        disp=verbose,
-        errorcontrol=False,
-    )
+    def fit_func(coords_offsets: tuple[float, float]) -> NDArrayf:
+        return loss_func(_dh_minimize_fit_func(coords_offsets=coords_offsets, dh_interpolator=dh_interpolator))
+
+    # Add to parameters
+    params_fit_or_bin.update({"fit_func": fit_func, "nd": 1, "bias_var_names": ["placeholder"]})
+
+    # Pass zero for Y to match during fit
+    zero_residuals = np.atleast_1d(0.)
+
+    init_offsets = (0, 0)
+    results = params_fit_or_bin["fit_minimizer"](fit_func, init_offsets, method="Nelder-Mead", bounds=[(-200, 200), (-200, 200)], tol=0.00001)
 
     # Get final offsets with the right sign direction
-    offset_east = -res.x[0]
-    offset_north = -res.x[1]
+    offset_east = -results.x[0]
+    offset_north = -results.x[1]
     offset_vertical = float(np.nanmedian(dh_interpolator(-offset_east, -offset_north)))
 
     return offset_east, offset_north, offset_vertical
 
 
-def gradient_descending(
+def dh_minimize(
     ref_elev: NDArrayf | gpd.GeoDataFrame,
     tba_elev: NDArrayf | gpd.GeoDataFrame,
     inlier_mask: NDArrayb,
     transform: rio.transform.Affine,
     area_or_point: Literal["Area", "Point"] | None,
     params_random: InRandomDict,
-    params_noisyopt: InSpecificDict,
+    params_fit_or_bin: InFitOrBinDict,
     z_name: str,
     weights: NDArrayf | None = None,
     verbose: bool = False,
 ) -> tuple[tuple[float, float, float], int]:
     """
-    Gradient descending coregistration method (Zhihao, in prep.), for any point-raster or raster-raster input,
+    Elevation difference minimization coregistration method, for any point-raster or raster-raster input,
     including subsampling and interpolation to the same points.
 
     :return: Final estimated offset: east, north, vertical (in georeferenced units).
     """
-    if not _has_noisyopt:
-        raise ValueError("Optional dependency needed. Install 'noisyopt'")
 
     if verbose:
-        print("Running gradient descending coregistration (Zhihao, in prep.)")
+        print("Running dh minimization coregistration.")
 
     # Perform preprocessing: subsampling and interpolation of inputs and auxiliary vars at same points
     dh_interpolator, _, subsample_final = _preprocess_pts_rst_subsample_interpolator(
@@ -737,10 +718,9 @@ def gradient_descending(
     )
 
     # Perform fit
-    res = _res(transform)
-    # TODO: To match original implementation, need to first add back weight support for point data
-    final_offsets = _gradient_descending_fit(
-        dh_interpolator=dh_interpolator, res=res, params_noisyopt=params_noisyopt, verbose=verbose
+    # TODO: To match original implementation, need to add back weight support for point data
+    final_offsets = _dh_minimize_fit(
+        dh_interpolator=dh_interpolator, params_fit_or_bin=params_fit_or_bin, verbose=verbose
     )
 
     return final_offsets, subsample_final
@@ -1432,9 +1412,9 @@ class NuthKaab(AffineCoreg):
         return matrix
 
 
-class GradientDescending(AffineCoreg):
+class DhMinimize(AffineCoreg):
     """
-    Gradient descending coregistration.
+    Elevation difference minimization coregistration.
 
     Estimates vertical and horizontal translations.
 
@@ -1445,29 +1425,20 @@ class GradientDescending(AffineCoreg):
 
     def __init__(
         self,
-        x0: tuple[float, float] = (0, 0),
-        bounds: tuple[float, float] = (-10, 10),
-        deltainit: int = 2,
-        deltatol: float = 0.004,
-        feps: float = 0.0001,
-        subsample: int | float = 6000,
+        fit_minimizer: Callable[..., tuple[NDArrayf, Any]] = scipy.optimize.minimize,
+        fit_loss_func: Callable[[NDArrayf], np.floating[Any]] = nmad,
+        subsample: int | float = 5e5,
     ) -> None:
         """
-        Instantiate gradient descending coregistration object.
+        Instantiate dh minimization object.
 
-        :param x0: The initial point of gradient descending iteration.
-        :param bounds: The boundary of the maximum shift.
-        :param deltainit: Initial pattern size.
-        :param deltatol: Target pattern size, or the precision you want achieve.
-        :param feps: Parameters for algorithm. Smallest difference in function value to resolve.
+        :param fit_minimizer: Minimizer for the coregistration function.
+        :param fit_loss_func: Loss function for the minimization of residuals.
         :param subsample: Subsample the input for speed-up. <1 is parsed as a fraction. >1 is a pixel count.
-
-        The algorithm terminates when the iteration is locally optimal at the target pattern size 'deltatol',
-        or when the function value differs by less than the tolerance 'feps' along all directions.
-
         """
-        meta = {"bounds": bounds, "x0": x0, "deltainit": deltainit, "deltatol": deltatol, "feps": feps}
-        super().__init__(subsample=subsample, meta=meta)
+
+        meta_fit = {"fit_or_bin": "fit", "fit_minimizer": fit_minimizer, "fit_loss_func": fit_loss_func}
+        super().__init__(subsample=subsample, meta=meta_fit)  # type: ignore
 
     def _fit_rst_rst(
         self,
@@ -1516,11 +1487,10 @@ class GradientDescending(AffineCoreg):
 
         # Get parameters stored in class
         params_random = self._meta["inputs"]["random"]
-        # TODO: Replace params noisyopt by kwargs? (=classic optimizer parameters)
-        params_noisyopt = self._meta["inputs"]["specific"]
+        params_fit_or_bin = self._meta["inputs"]["fitorbin"]
 
         # Call method
-        (easting_offset, northing_offset, vertical_offset), subsample_final = gradient_descending(
+        (easting_offset, northing_offset, vertical_offset), subsample_final = dh_minimize(
             ref_elev=ref_elev,
             tba_elev=tba_elev,
             inlier_mask=inlier_mask,
@@ -1530,7 +1500,7 @@ class GradientDescending(AffineCoreg):
             weights=weights,
             verbose=verbose,
             params_random=params_random,
-            params_noisyopt=params_noisyopt,
+            params_fit_or_bin=params_fit_or_bin,
         )
 
         # Write output to class

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -1428,6 +1428,12 @@ class InFitOrBinDict(TypedDict, total=False):
     # Fit parameters: function to fit and optimizer
     fit_func: Callable[..., NDArrayf]
     fit_optimizer: Callable[..., tuple[NDArrayf, Any]]
+
+    # TODO: Solve redundancy between optimizer and minimizer (curve_fit or minimize as default?)
+    # For a minimization problem
+    fit_minimizer: Callable[..., tuple[NDArrayf, Any]]
+    fit_loss_func: Callable[[NDArrayf], np.floating[Any]]
+
     # Bin parameters: bin sizes, statistic and apply method
     bin_sizes: int | dict[str, int | Iterable[float]]
     bin_statistic: Callable[[NDArrayf], np.floating[Any]]
@@ -1474,15 +1480,6 @@ class InSpecificDict(TypedDict, total=False):
     angle: float
     # (Using Deramp) Polynomial order selected for deramping
     poly_order: int
-
-    # (Using GradientDescending)
-    # (Temporary) Parameters of gradient descending
-    # TODO: Remove in favor of kwargs like for curve_fit?
-    x0: tuple[float, float]
-    bounds: tuple[float, float]
-    deltainit: int
-    deltatol: float
-    feps: float
 
     # (Using ICP)
     rejection_scale: float

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -77,6 +77,8 @@ dict_key_to_str = {
     "fit_or_bin": "Fit, bin or bin+fit",
     "fit_func": "Function to fit",
     "fit_optimizer": "Optimizer for fitting",
+    "fit_minimizer": "Minimizer of method",
+    "fit_loss_func": "Loss function of method",
     "bin_statistic": "Binning statistic",
     "bin_sizes": "Bin sizes or edges",
     "bin_apply_method": "Bin apply method",


### PR DESCRIPTION
This PR performs the renaming and generalization as discussed in #231

@liuh886 @erikmannerfelt I indeed found a fairly big difference in performance between `scipy.optimize.minimize()` and `noisyopt.minimizeCompass()`. For SciPy, the "Nelder-Mead" method examplified by @sgascoin in #231 performed best of all, but it still had some trouble consistently correcting an artificial shift introduced in our Longyearbyen example data at different shift magnitudes and subsample sizes (even when passing bounds and various tolerances), while `minimizeCompass` performed OK on all cases. So between the default `minimize()` and `minimizeCompass()`, there is a big difference in performance, but the difference is much smaller between  `minimize(method="Nelder-Mead")` and `minimizeCompass`.

So, to avoid imposing the `noisopt` dependency on users that want to try this function, I was thinking of having the new function `DhMinimize` with default to `minimize(method="Nelder-Mead")`, and adding a "Tip" box in the documentation (Coregistration page, new "DhMinimize" section) to remind that `noisyopt` might perform better. 
And a similar note in the function description.

Does that sound good to all?

Opens #596 
Opens #597 
Resolves #231
Resolves #594
Resolves #599