### PR TITLE
Replace print statements and verbose flag with logging and log levels

### DIFF
--- a/doc/source/logging.md
+++ b/doc/source/logging.md
@@ -1,0 +1,29 @@
+---
+file_format: mystnb
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: xdem-env
+  language: python
+  name: xdem
+---
+# Logging configuration
+ To configure logging for xDEM, you can utilize Python's built-in `logging` module. Begin by setting up the logging
+ configuration at the start. This involves specifying the logging level, format, and handlers. For example :
+ ```python
+import logging
+
+# Configuration
+logging.basicConfig(level=logging.INFO,
+                    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S',
+                    handlers=[
+                        logging.FileHandler('app.log'),  # Log messages will be saved to this file
+                        logging.StreamHandler()           # Log messages will also be printed to the console
+                    ])
+```
+This configuration will log messages with a severity level of `INFO` and above, including timestamps, logger names, and
+log levels in the output. You can change the logging level to `DEBUG`, `WARNING`, `ERROR` or `CRITICAL` as needed.

--- a/examples/basic/logging_configuration.py
+++ b/examples/basic/logging_configuration.py
@@ -1,0 +1,47 @@
+"""
+Configuring Logging in xDEM
+===============================
+
+This example demonstrates how to configure logging in xDEM by using the Nuth and Kääb
+(`2011 <https:https://doi.org/10.5194/tc-5-271-2011>`_) coregistration method.
+Logging can be customized to various levels, from `DEBUG` for detailed diagnostic output, to `INFO` for general
+updates, `WARNING` for potential issues, and `ERROR` or `CRITICAL` for serious problems.
+
+We will demonstrate how to set up logging and show logs while running a typical xDEM function.
+"""
+
+import logging
+
+import xdem
+
+# Step 1: Configure logging
+logging.basicConfig(
+    level=logging.INFO,  # Change this level to DEBUG or WARNING to see different outputs.
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    handlers=[
+        logging.FileHandler("../xdem_example.log"),  # Save logs to a file
+        logging.StreamHandler(),  # Print logs to the console
+    ],
+)
+
+# Step 2: Load example DEMs (Digital Elevation Models) to work with
+reference_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
+dem_to_be_aligned = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+
+# Step 3: Perform Nuth & Kaab coregistration (for alignment of DEMs)
+coreg = xdem.coreg.NuthKaab()
+
+# Step 4: Demonstrate logging at various levels
+logging.info("Starting Nuth & Kaab coregistration...")
+coreg.fit(reference_dem, dem_to_be_aligned)
+logging.debug("Coregistration successful. Applying transformation...")
+
+# Apply the coregistration
+aligned_dem = coreg.apply(dem_to_be_aligned)
+
+# Output some results
+logging.info(f"Coregistration completed. Aligned DEM shape: {aligned_dem.shape}")
+
+# Displaying final logs
+logging.debug("Aligned DEM has been computed and saved.")

--- a/examples/basic/temp.tif.aux.xml
+++ b/examples/basic/temp.tif.aux.xml
@@ -1,0 +1,12 @@
+<PAMDataset>
+  <PAMRasterBand band="1">
+    <Metadata>
+      <MDI key="STATISTICS_APPROXIMATE">YES</MDI>
+      <MDI key="STATISTICS_MAXIMUM">24.196350097656</MDI>
+      <MDI key="STATISTICS_MEAN">-1.1318853018028</MDI>
+      <MDI key="STATISTICS_MINIMUM">-45.626251220703</MDI>
+      <MDI key="STATISTICS_STDDEV">5.4521095015072</MDI>
+      <MDI key="STATISTICS_VALID_PERCENT">100</MDI>
+    </Metadata>
+  </PAMRasterBand>
+</PAMDataset>

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -96,32 +96,17 @@ class TestAffineCoreg:
     # Check all point-raster possibilities supported
     # Use the reference DEM for both, it will be artificially misaligned during tests
     # Raster-Raster
-    fit_args_rst_rst = dict(
-        reference_elev=ref,
-        to_be_aligned_elev=tba,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_rst_rst = dict(reference_elev=ref, to_be_aligned_elev=tba, inlier_mask=inlier_mask)
 
     # Convert DEMs to points with a bit of subsampling for speed-up
     ref_pts = ref.to_pointcloud(data_column_name="z", subsample=50000, random_state=42).ds
     tba_pts = ref.to_pointcloud(data_column_name="z", subsample=50000, random_state=42).ds
 
     # Raster-Point
-    fit_args_rst_pts = dict(
-        reference_elev=ref,
-        to_be_aligned_elev=tba_pts,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_rst_pts = dict(reference_elev=ref, to_be_aligned_elev=tba_pts, inlier_mask=inlier_mask)
 
     # Point-Raster
-    fit_args_pts_rst = dict(
-        reference_elev=ref_pts,
-        to_be_aligned_elev=tba,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_pts_rst = dict(reference_elev=ref_pts, to_be_aligned_elev=tba, inlier_mask=inlier_mask)
 
     all_fit_args = [fit_args_rst_rst, fit_args_rst_pts, fit_args_pts_rst]
 
@@ -289,7 +274,7 @@ class TestAffineCoreg:
         ],
     )  # type: ignore
     def test_coreg_translations__example(
-        self, coreg_method__shift: tuple[type[AffineCoreg], tuple[float, float, float]], verbose: bool = False
+        self, coreg_method__shift: tuple[type[AffineCoreg], tuple[float, float, float]]
     ) -> None:
         """
         Test that the translation co-registration outputs are always exactly the same on the real example data.
@@ -303,7 +288,7 @@ class TestAffineCoreg:
         coreg_method, expected_shifts = coreg_method__shift
 
         c = coreg_method(subsample=50000)
-        c.fit(ref, tba, inlier_mask=inlier_mask, verbose=verbose, random_state=42)
+        c.fit(ref, tba, inlier_mask=inlier_mask, random_state=42)
 
         # Check the output translations match the exact values
         shifts = [c.meta["outputs"]["affine"][k] for k in ["shift_x", "shift_y", "shift_z"]]  # type: ignore
@@ -367,7 +352,7 @@ class TestAffineCoreg:
 
     @pytest.mark.parametrize("coreg_method__vshift", [(coreg.VerticalShift, -2.305015)])  # type: ignore
     def test_coreg_vertical_translation__example(
-        self, coreg_method__vshift: tuple[type[AffineCoreg], tuple[float, float, float]], verbose: bool = False
+        self, coreg_method__vshift: tuple[type[AffineCoreg], tuple[float, float, float]]
     ) -> None:
         """
         Test that the vertical translation co-registration output is always exactly the same on the real example data.
@@ -382,7 +367,7 @@ class TestAffineCoreg:
 
         # Run co-registration
         c = coreg_method(subsample=50000)
-        c.fit(ref, tba, inlier_mask=inlier_mask, verbose=verbose, random_state=42)
+        c.fit(ref, tba, inlier_mask=inlier_mask, random_state=42)
 
         # Check the output translations match the exact values
         vshift = c.meta["outputs"]["affine"]["shift_z"]
@@ -479,9 +464,7 @@ class TestAffineCoreg:
         [(coreg.ICP, (8.738332, 1.584255, -1.943957, 0.0069004, -0.00703, -0.0119733))],
     )  # type: ignore
     def test_coreg_rigid__example(
-        self,
-        coreg_method__shifts_rotations: tuple[type[AffineCoreg], tuple[float, float, float]],
-        verbose: bool = False,
+        self, coreg_method__shifts_rotations: tuple[type[AffineCoreg], tuple[float, float, float]]
     ) -> None:
         """
         Test that the rigid co-registration outputs is always exactly the same on the real example data.
@@ -496,7 +479,7 @@ class TestAffineCoreg:
 
         # Run co-registration
         c = coreg_method(subsample=50000)
-        c.fit(ref, tba, inlier_mask=inlier_mask, verbose=verbose, random_state=42)
+        c.fit(ref, tba, inlier_mask=inlier_mask, random_state=42)
 
         # Check the output translations match the exact values
         fit_matrix = c.meta["outputs"]["affine"]["matrix"]

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -69,12 +69,7 @@ class TestCoregClass:
     ref, tba, outlines = load_examples()  # Load example reference, to-be-aligned and mask.
     inlier_mask = ~outlines.create_mask(ref)
 
-    fit_params = dict(
-        reference_elev=ref,
-        to_be_aligned_elev=tba,
-        inlier_mask=inlier_mask,
-        verbose=False,
-    )
+    fit_params = dict(reference_elev=ref, to_be_aligned_elev=tba, inlier_mask=inlier_mask)
     # Create some 3D coordinates with Z coordinates being 0 to try the apply functions.
     points_arr = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [0, 0, 0, 0]], dtype="float64").T
     points = gpd.GeoDataFrame(
@@ -131,7 +126,7 @@ class TestCoregClass:
 
         # Check that info() contains the mapped string for an example
         c = coreg.Coreg(meta={"subsample": 10000})
-        assert dict_key_to_str["subsample"] in c.info(verbose=False)
+        assert dict_key_to_str["subsample"] in c.info()
 
     @pytest.mark.parametrize("coreg_class", [coreg.VerticalShift, coreg.ICP, coreg.NuthKaab])  # type: ignore
     def test_copy(self, coreg_class: Callable[[], Coreg]) -> None:
@@ -629,7 +624,6 @@ class TestCoregPipeline:
         inlier_mask=inlier_mask,
         transform=ref.transform,
         crs=ref.crs,
-        verbose=True,
     )
     # Create some 3D coordinates with Z coordinates being 0 to try the apply functions.
     points_arr = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [0, 0, 0, 0]], dtype="float64").T
@@ -860,7 +854,6 @@ class TestBlockwiseCoreg:
         inlier_mask=inlier_mask,
         transform=ref.transform,
         crs=ref.crs,
-        verbose=False,
     )
     # Create some 3D coordinates with Z coordinates being 0 to try the apply functions.
     points_arr = np.array([[1, 2, 3, 4], [1, 2, 3, 4], [0, 0, 0, 0]], dtype="float64").T

--- a/tests/test_coreg/test_biascorr.py
+++ b/tests/test_coreg/test_biascorr.py
@@ -45,32 +45,17 @@ class TestBiasCorr:
 
     # Check all possibilities supported by biascorr:
     # Raster-Raster
-    fit_args_rst_rst = dict(
-        reference_elev=ref,
-        to_be_aligned_elev=tba,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_rst_rst = dict(reference_elev=ref, to_be_aligned_elev=tba, inlier_mask=inlier_mask)
 
     # Convert DEMs to points with a bit of subsampling for speed-up
     tba_pts = tba.to_pointcloud(data_column_name="z", subsample=50000, random_state=42).ds
     ref_pts = ref.to_pointcloud(data_column_name="z", subsample=50000, random_state=42).ds
 
     # Raster-Point
-    fit_args_rst_pts = dict(
-        reference_elev=ref,
-        to_be_aligned_elev=tba_pts,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_rst_pts = dict(reference_elev=ref, to_be_aligned_elev=tba_pts, inlier_mask=inlier_mask)
 
     # Point-Raster
-    fit_args_pts_rst = dict(
-        reference_elev=ref_pts,
-        to_be_aligned_elev=tba,
-        inlier_mask=inlier_mask,
-        verbose=True,
-    )
+    fit_args_pts_rst = dict(reference_elev=ref_pts, to_be_aligned_elev=tba, inlier_mask=inlier_mask)
 
     all_fit_args = [fit_args_rst_rst, fit_args_rst_pts, fit_args_pts_rst]
 

--- a/tests/test_demcollection.py
+++ b/tests/test_demcollection.py
@@ -74,7 +74,7 @@ class TestDEMCollection:
                 if "NaNs found in dDEM" not in str(exception):
                     raise exception
 
-        # print(cumulative_dh)
+        # logging.info(cumulative_dh)
 
         # raise NotImplementedError
 

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -1,4 +1,5 @@
 """Functions to test the documentation."""
+import logging
 import os
 import platform
 import shutil
@@ -34,7 +35,7 @@ class TestDocs:
                         exec(infile.read().replace("plt.show()", "plt.close()"))
                     except Exception as exception:
                         if isinstance(exception, DeprecationWarning):
-                            print(exception)
+                            logging.warning(exception)
                         else:
                             raise RuntimeError(f"Failed on {filename}") from exception
 

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -524,7 +524,7 @@ class TestVariogram:
         # Check that all type of coordinate inputs work
         # Only the array and the ground sampling distance
         xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff.data, gsd=self.diff.res[0], subsample=10, random_state=42, verbose=True
+            values=self.diff.data, gsd=self.diff.res[0], subsample=10, random_state=42
         )
 
         # Test multiple runs
@@ -583,7 +583,7 @@ class TestVariogram:
         # Shape
         shape = values.shape
 
-        keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape, "verbose": False}
+        keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
         runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(
             **keyword_arguments
         )
@@ -720,7 +720,7 @@ class TestVariogram:
         pdist_pairwise_combinations = subsample**2 / 2
 
         # Run the function
-        keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape, "verbose": False}
+        keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
         runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(
             **keyword_arguments
         )
@@ -745,7 +745,7 @@ class TestVariogram:
     def test_errors_subsample_parameter(self) -> None:
         """Tests that an error is raised when the subsample argument is too little"""
 
-        keyword_arguments = {"subsample": 3, "extent": (0, 1, 0, 1), "shape": (10, 10), "verbose": False}
+        keyword_arguments = {"subsample": 3, "extent": (0, 1, 0, 1), "shape": (10, 10)}
 
         with pytest.raises(ValueError, match="The number of subsamples needs to be at least 10."):
             xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(**keyword_arguments)

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from typing import Any, Callable, Iterable, Literal, TypeVar, overload
 
@@ -158,7 +159,6 @@ def _iterate_method(
     constant_inputs: tuple[Any, ...],
     tolerance: float,
     max_iterations: int,
-    verbose: bool = False,
 ) -> Any:
     """
     Function to iterate a method (e.g. ICP, Nuth and Kääb) until it reaches a tolerance or maximum number of iterations.
@@ -170,7 +170,6 @@ def _iterate_method(
     :param constant_inputs: Constant inputs to method, should be all positional arguments after first.
     :param tolerance: Tolerance to reach for the method statistic (i.e. maximum value for the statistic).
     :param max_iterations: Maximum number of iterations for the method.
-    :param verbose: Whether to print progress.
 
     :return: Final output of iterated method.
     """
@@ -179,8 +178,8 @@ def _iterate_method(
     new_inputs = iterating_input
 
     # Iteratively run the analysis until the maximum iterations or until the error gets low enough
-    # If verbose is True, will use progressbar and print additional statements
-    pbar = trange(max_iterations, disable=not verbose, desc="   Progress")
+    # If logging level <= INFO, will use progressbar and print additional statements
+    pbar = trange(max_iterations, disable=logging.getLogger().getEffectiveLevel() > logging.INFO, desc="   Progress")
     for i in pbar:
 
         # Apply method and get new statistic to compare to tolerance, new inputs for next iterations, and
@@ -189,11 +188,11 @@ def _iterate_method(
 
         # Print final results
         # TODO: Allow to pass a string to _iterate_method on how to print/describe exactly the iterating input
-        if verbose:
+        if logging.getLogger().getEffectiveLevel() <= logging.DEBUG:
             pbar.write(f"      Iteration #{i + 1:d} - Offset: {new_inputs}; Magnitude: {new_statistic}")
 
         if i > 1 and new_statistic < tolerance:
-            if verbose:
+            if logging.getLogger().getEffectiveLevel() <= logging.INFO:
                 pbar.write(f"   Last offset was below the residual offset threshold of {tolerance} -> stopping")
             break
 
@@ -305,7 +304,6 @@ def _preprocess_pts_rst_subsample_interpolator(
     area_or_point: Literal["Area", "Point"] | None,
     z_name: str,
     aux_vars: None | dict[str, NDArrayf] = None,
-    verbose: bool = False,
 ) -> tuple[Callable[[float, float], NDArrayf], None | dict[str, NDArrayf], int]:
     """
     Mirrors coreg.base._preprocess_pts_rst_subsample, but returning an interpolator for efficiency in iterative methods.
@@ -326,7 +324,6 @@ def _preprocess_pts_rst_subsample_interpolator(
         transform=transform,
         area_or_point=area_or_point,
         aux_vars=aux_vars,
-        verbose=verbose,
     )
 
     # Return interpolator of elevation differences and subsampled auxiliary variables
@@ -498,7 +495,6 @@ def _nuth_kaab_iteration_step(
     aspect: NDArrayf,
     res: tuple[int, int],
     params_fit_bin: InFitOrBinDict,
-    verbose: bool = False,
 ) -> tuple[tuple[float, float, float], float]:
     """
     Iteration step of Nuth and Kääb (2011), passed to the iterate_method function.
@@ -511,7 +507,6 @@ def _nuth_kaab_iteration_step(
     :param slope_tan: Array of slope tangent.
     :param aspect: Array of aspect.
     :param res: Resolution of DEM.
-    :param verbose: Whether to print statements.
     """
 
     # Calculate the elevation difference with offsets
@@ -566,7 +561,6 @@ def nuth_kaab(
     params_random: InRandomDict,
     z_name: str,
     weights: NDArrayf | None = None,
-    verbose: bool = False,
     **kwargs: Any,
 ) -> tuple[tuple[float, float, float], int]:
     """
@@ -574,8 +568,7 @@ def nuth_kaab(
 
     :return: Final estimated offset: east, north, vertical (in georeferenced units).
     """
-    if verbose:
-        print("Running Nuth and Kääb (2011) coregistration")
+    logging.info("Running Nuth and Kääb (2011) coregistration")
 
     # Check that DEM CRS is projected, otherwise slope is not correctly calculated
     if not crs.is_projected:
@@ -603,12 +596,10 @@ def nuth_kaab(
         aux_vars=aux_vars,
         transform=transform,
         area_or_point=area_or_point,
-        verbose=verbose,
         z_name=z_name,
     )
 
-    if verbose:
-        print("   Iteratively estimating horizontal shift:")
+    logging.info("Iteratively estimating horizontal shift:")
     # Initialise east, north and vertical offset variables (these will be incremented up and down)
     initial_offset = (0.0, 0.0, 0.0)
     # Resolution
@@ -622,7 +613,6 @@ def nuth_kaab(
         constant_inputs=constant_inputs,
         tolerance=tolerance,
         max_iterations=max_iterations,
-        verbose=verbose,
     )
 
     return final_offsets, subsample_final
@@ -655,7 +645,6 @@ def _dh_minimize_fit_func(
 def _dh_minimize_fit(
     dh_interpolator: Callable[[float, float], NDArrayf],
     params_fit_or_bin: InFitOrBinDict,
-    verbose: bool = False,
     **kwargs: Any,
 ) -> tuple[float, float, float]:
     """
@@ -664,7 +653,6 @@ def _dh_minimize_fit(
     :param dh_interpolator: Interpolator returning elevation differences at the subsampled points for a certain
         horizontal offset (see _preprocess_pts_rst_subsample_interpolator).
     :param params_fit_or_bin: Parameters for fitting or binning.
-    :param verbose: Whether to print statements.
 
     :return: Optimized offsets (easing, northing, vertical) in georeferenced unit.
     """
@@ -713,7 +701,6 @@ def dh_minimize(
     params_fit_or_bin: InFitOrBinDict,
     z_name: str,
     weights: NDArrayf | None = None,
-    verbose: bool = False,
     **kwargs: Any,
 ) -> tuple[tuple[float, float, float], int]:
     """
@@ -723,8 +710,7 @@ def dh_minimize(
     :return: Final estimated offset: east, north, vertical (in georeferenced units).
     """
 
-    if verbose:
-        print("Running dh minimization coregistration.")
+    logging.info("Running dh minimization coregistration.")
 
     # Perform preprocessing: subsampling and interpolation of inputs and auxiliary vars at same points
     dh_interpolator, _, subsample_final = _preprocess_pts_rst_subsample_interpolator(
@@ -734,15 +720,12 @@ def dh_minimize(
         inlier_mask=inlier_mask,
         transform=transform,
         area_or_point=area_or_point,
-        verbose=verbose,
         z_name=z_name,
     )
 
     # Perform fit
     # TODO: To match original implementation, need to add back weight support for point data
-    final_offsets = _dh_minimize_fit(
-        dh_interpolator=dh_interpolator, params_fit_or_bin=params_fit_or_bin, verbose=verbose
-    )
+    final_offsets = _dh_minimize_fit(dh_interpolator=dh_interpolator, params_fit_or_bin=params_fit_or_bin)
 
     return final_offsets, subsample_final
 
@@ -763,15 +746,13 @@ def vertical_shift(
     vshift_reduc_func: Callable[[NDArrayf], np.floating[Any]],
     z_name: str,
     weights: NDArrayf | None = None,
-    verbose: bool = False,
     **kwargs: Any,
 ) -> tuple[float, int]:
     """
     Vertical shift coregistration, for any point-raster or raster-raster input, including subsampling.
     """
 
-    if verbose:
-        print("Running vertical shift coregistration")
+    logging.info("Running vertical shift coregistration")
 
     # Pre-process point-raster inputs to the same subsampled points
     sub_ref, sub_tba, _ = _preprocess_pts_rst_subsample(
@@ -783,7 +764,6 @@ def vertical_shift(
         crs=crs,
         area_or_point=area_or_point,
         z_name=z_name,
-        verbose=verbose,
     )
     # Get elevation difference
     dh = sub_ref - sub_tba
@@ -794,8 +774,7 @@ def vertical_shift(
     # TODO: We might need to define the type of bias_func with Callback protocols to get the optional argument,
     # TODO: once we have the weights implemented
 
-    if verbose:
-        print("Vertical shift estimated")
+    logging.info("Vertical shift estimated")
 
     # Get final subsample size
     subsample_final = len(sub_ref)
@@ -870,7 +849,6 @@ class AffineCoreg(Coreg):
         crs: rio.crs.CRS | None = None,
         area_or_point: Literal["Area", "Point"] | None = None,
         z_name: str = "z",
-        verbose: bool = False,
     ) -> tuple[Callable[[float, float], NDArrayf], None | dict[str, NDArrayf]]:
         """
         Pre-process raster-raster or point-raster datasets into 1D arrays subsampled at the same points
@@ -892,7 +870,6 @@ class AffineCoreg(Coreg):
             transform=transform,
             area_or_point=area_or_point,
             aux_vars=aux_vars,
-            verbose=verbose,
         )
 
         # Return interpolator of elevation differences and subsampled auxiliary variables
@@ -1000,7 +977,6 @@ class VerticalShift(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Estimate the vertical shift using the vshift_func."""
@@ -1015,7 +991,6 @@ class VerticalShift(AffineCoreg):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -1030,7 +1005,6 @@ class VerticalShift(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Estimate the vertical shift using the vshift_func."""
@@ -1049,7 +1023,6 @@ class VerticalShift(AffineCoreg):
             vshift_reduc_func=self._meta["inputs"]["affine"]["vshift_reduc_func"],
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -1118,7 +1091,6 @@ class ICP(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Estimate the rigid transform from tba_dem to ref_dem."""
@@ -1158,7 +1130,6 @@ class ICP(AffineCoreg):
             transform=transform,
             crs=crs,
             area_or_point=area_or_point,
-            verbose=verbose,
             z_name="z",
         )
 
@@ -1173,7 +1144,6 @@ class ICP(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
 
@@ -1250,8 +1220,7 @@ class ICP(AffineCoreg):
         rej = self._meta["inputs"]["specific"]["rejection_scale"]
         num_lv = self._meta["inputs"]["specific"]["num_levels"]
         icp = cv2.ppf_match_3d_ICP(max_it, tol, rej, num_lv)
-        if verbose:
-            print("Running ICP...")
+        logging.info("Running ICP...")
         try:
             # Use points as reference
             _, residual, matrix = icp.registerModelToScene(points["raster"], points["point"])
@@ -1269,8 +1238,7 @@ class ICP(AffineCoreg):
         if ref == "raster":
             matrix = xdem.coreg.base.invert_matrix(matrix)
 
-        if verbose:
-            print("ICP finished")
+        logging.info("ICP finished")
 
         assert residual < 1000, f"ICP coregistration failed: residual={residual}, threshold: 1000"
 
@@ -1356,7 +1324,6 @@ class NuthKaab(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Estimate the x/y/z offset between two DEMs."""
@@ -1372,7 +1339,6 @@ class NuthKaab(AffineCoreg):
             z_name=z_name,
             weights=weights,
             bias_vars=bias_vars,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -1387,7 +1353,6 @@ class NuthKaab(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """
@@ -1408,7 +1373,6 @@ class NuthKaab(AffineCoreg):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             params_random=params_random,
             params_fit_or_bin=params_fit_or_bin,
             max_iterations=self._meta["inputs"]["iterative"]["max_iterations"],
@@ -1472,7 +1436,6 @@ class DhMinimize(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
 
@@ -1487,7 +1450,6 @@ class DhMinimize(AffineCoreg):
             z_name=z_name,
             weights=weights,
             bias_vars=bias_vars,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -1502,7 +1464,6 @@ class DhMinimize(AffineCoreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
 
@@ -1519,7 +1480,6 @@ class DhMinimize(AffineCoreg):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             params_random=params_random,
             params_fit_or_bin=params_fit_or_bin,
             **kwargs,

--- a/xdem/coreg/biascorr.py
+++ b/xdem/coreg/biascorr.py
@@ -1,6 +1,7 @@
 """Bias corrections (i.e., non-affine coregistration) classes."""
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Iterable, Literal, TypeVar
 
 import geopandas as gpd
@@ -153,7 +154,6 @@ class BiasCorr(Coreg):
         z_name: str,
         bias_vars: None | dict[str, NDArrayf] = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
         """Function for fitting raster-raster and raster-point for bias correction methods."""
@@ -168,7 +168,6 @@ class BiasCorr(Coreg):
             area_or_point=area_or_point,
             z_name=z_name,
             aux_vars=bias_vars,
-            verbose=verbose,
         )
 
         # Derive difference to get dh
@@ -179,7 +178,6 @@ class BiasCorr(Coreg):
             values=diff,
             bias_vars=sub_bias_vars,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -194,7 +192,6 @@ class BiasCorr(Coreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Called by other classes"""
@@ -209,7 +206,6 @@ class BiasCorr(Coreg):
             z_name=z_name,
             weights=weights,
             bias_vars=bias_vars,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -224,7 +220,6 @@ class BiasCorr(Coreg):
         z_name: str,
         weights: NDArrayf | None = None,
         bias_vars: dict[str, NDArrayf] | None = None,
-        verbose: bool = False,
         **kwargs: Any,
     ) -> None:
         """Called by other classes"""
@@ -239,7 +234,6 @@ class BiasCorr(Coreg):
             z_name=z_name,
             weights=weights,
             bias_vars=bias_vars,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -344,12 +338,10 @@ class DirectionalBias(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
-        if verbose:
-            print("Estimating rotated coordinates.")
+        logging.info("Estimating rotated coordinates.")
 
         x, _ = gu.raster.get_xy_rotated(
             raster=gu.Raster.from_array(data=ref_elev, crs=crs, transform=transform, nodata=-9999),
@@ -372,7 +364,6 @@ class DirectionalBias(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -387,15 +378,13 @@ class DirectionalBias(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
         # Figure out which data is raster format to get gridded attributes
         rast_elev = ref_elev if not isinstance(ref_elev, gpd.GeoDataFrame) else tba_elev
 
-        if verbose:
-            print("Estimating rotated coordinates.")
+        logging.info("Estimating rotated coordinates.")
 
         x, _ = gu.raster.get_xy_rotated(
             raster=gu.Raster.from_array(data=rast_elev, crs=crs, transform=transform, nodata=-9999),
@@ -418,7 +407,6 @@ class DirectionalBias(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -506,7 +494,6 @@ class TerrainBias(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
@@ -537,7 +524,6 @@ class TerrainBias(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -552,7 +538,6 @@ class TerrainBias(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
@@ -586,7 +571,6 @@ class TerrainBias(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             **kwargs,
         )
 
@@ -670,7 +654,6 @@ class Deramp(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] | None = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
@@ -690,7 +673,6 @@ class Deramp(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             p0=p0,
             **kwargs,
         )
@@ -706,7 +688,6 @@ class Deramp(BiasCorr):
         z_name: str,
         bias_vars: dict[str, NDArrayf] | None = None,
         weights: None | NDArrayf = None,
-        verbose: bool = False,
         **kwargs,
     ) -> None:
 
@@ -729,7 +710,6 @@ class Deramp(BiasCorr):
             area_or_point=area_or_point,
             z_name=z_name,
             weights=weights,
-            verbose=verbose,
             p0=p0,
             **kwargs,
         )

--- a/xdem/coreg/workflows.py
+++ b/xdem/coreg/workflows.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import geoutils as gu
 import matplotlib.pyplot as plt
 import numpy as np
@@ -140,7 +142,6 @@ def dem_coregistration(
     slope_lim: list[Number] | tuple[Number, Number] = (0.1, 40),
     plot: bool = False,
     out_fig: str = None,
-    verbose: bool = False,
 ) -> tuple[DEM, Coreg, pd.DataFrame, NDArrayf]:
     """
     A one-line function to coregister a selected DEM to a reference DEM.
@@ -168,7 +169,6 @@ to mask inside (resp. outside) of the polygons. Defaults to masking inside polyg
 be excluded.
     :param plot: Set to True to plot a figure of elevation diff before/after coregistration.
     :param out_fig: Path to the output figure. If None will display to screen.
-    :param verbose: Set to True to print details on screen during coregistration.
 
     :returns: A tuple containing 1) coregistered DEM as an xdem.DEM instance 2) the coregistration method \
 3) DataFrame of coregistration statistics (count of obs, median and NMAD over stable terrain) before and after \
@@ -197,8 +197,7 @@ coregistration and 4) the inlier_mask used.
         raise ValueError(f"`grid` must be either 'ref' or 'src' - currently set to {grid}")
 
     # Load both DEMs
-    if verbose:
-        print("Loading and reprojecting input data")
+    logging.info("Loading and reprojecting input data")
 
     if isinstance(ref_dem_path, str):
         if grid == "ref":
@@ -219,8 +218,7 @@ coregistration and 4) the inlier_mask used.
     src_dem = DEM(src_dem.astype(np.float32))
 
     # Create raster mask
-    if verbose:
-        print("Creating mask of inlier pixels")
+    logging.info("Creating mask of inlier pixels")
 
     inlier_mask = create_inlier_mask(
         src_dem,
@@ -242,7 +240,7 @@ coregistration and 4) the inlier_mask used.
     med_orig, nmad_orig = np.median(inlier_data), nmad(inlier_data)
 
     # Coregister to reference - Note: this will spread NaN
-    coreg_method.fit(ref_dem, src_dem, inlier_mask, verbose=verbose)
+    coreg_method.fit(ref_dem, src_dem, inlier_mask)
     dem_coreg = coreg_method.apply(src_dem, resample=resample, resampling=resampling)
 
     # Calculate coregistered ddem (might need resampling if resample set to False), needed for stats and plot only

--- a/xdem/fit.py
+++ b/xdem/fit.py
@@ -4,6 +4,7 @@ Functions to perform normal, weighted and robust fitting.
 from __future__ import annotations
 
 import inspect
+import logging
 import warnings
 from typing import Any, Callable
 
@@ -135,7 +136,7 @@ def polynomial_2d(xx: tuple[NDArrayf, NDArrayf], *params: NDArrayf) -> NDArrayf:
 #######################################################################
 
 
-def _choice_best_order(cost: NDArrayf, margin_improvement: float = 20.0, verbose: bool = False) -> int:
+def _choice_best_order(cost: NDArrayf, margin_improvement: float = 20.0) -> int:
     """
     Choice of the best order (polynomial, sum of sinusoids) with a margin of improvement. The best cost value does
     not necessarily mean the best predictive fit because high-degree polynomials tend to overfit, and sum of sinusoids
@@ -143,7 +144,6 @@ def _choice_best_order(cost: NDArrayf, margin_improvement: float = 20.0, verbose
 
     :param cost: cost function residuals to the polynomial
     :param margin_improvement: improvement margin (percentage) below which the lesser degree polynomial is kept
-    :param verbose: if text should be printed
 
     :return: degree: degree for the best-fit polynomial
     """
@@ -159,12 +159,11 @@ def _choice_best_order(cost: NDArrayf, margin_improvement: float = 20.0, verbose
     # Choose the good-performance cost with lowest degree
     ind = next((i for i, j in enumerate(below_margin) if j))
 
-    if verbose:
-        print("Order " + str(ind_min + 1) + " has the minimum cost value of " + str(min_cost))
-        print(
-            "Order " + str(ind + 1) + " is selected as its cost is within a " + str(margin_improvement) + "% margin of"
-            " the minimum cost"
-        )
+    logging.debug("Order " + str(ind_min + 1) + " has the minimum cost value of " + str(min_cost))
+    logging.debug(
+        "Order " + str(ind + 1) + " is selected as its cost is within a " + str(margin_improvement) + "% margin of"
+        " the minimum cost"
+    )
 
     return ind
 
@@ -185,7 +184,6 @@ def _wrapper_scipy_leastsquares(
     :param p0: Initial guess.
     :param x: X vector.
     :param y: Y vector.
-    :param verbose: Whether to print out statements.
     :return:
     """
 
@@ -328,7 +326,6 @@ def robust_norder_polynomial_fit(
     margin_improvement: float = 20.0,
     subsample: float | int = 1,
     linear_pkg: str = "scipy",
-    verbose: bool = False,
     random_state: int | np.random.Generator | None = None,
     **kwargs: Any,
 ) -> tuple[NDArrayf, int]:
@@ -349,7 +346,6 @@ def robust_norder_polynomial_fit(
         If > 1 will be considered the number of pixels to extract.
     :param linear_pkg: package to use for Linear estimator, one of 'scipy' and 'sklearn'.
     :param random_state: Random seed.
-    :param verbose: Whether to print text.
 
     :returns coefs, degree: Polynomial coefficients and degree for the best-fit polynomial
     """
@@ -418,7 +414,7 @@ def robust_norder_polynomial_fit(
         list_coeffs[deg - 1, 0 : coef.size] = coef
 
     # Choose the best polynomial with a margin of improvement on the cost
-    final_index = _choice_best_order(cost=list_costs, margin_improvement=margin_improvement, verbose=verbose)
+    final_index = _choice_best_order(cost=list_costs, margin_improvement=margin_improvement)
 
     # The degree of the best polynomial corresponds to the index plus one
     return np.trim_zeros(list_coeffs[final_index], "b"), final_index + 1
@@ -447,7 +443,6 @@ def robust_nfreq_sumsin_fit(
     subsample: float | int = 1,
     hop_length: float | None = None,
     random_state: int | np.random.Generator | None = None,
-    verbose: bool = False,
     **kwargs: Any,
 ) -> tuple[NDArrayf, int]:
     """
@@ -468,7 +463,6 @@ def robust_nfreq_sumsin_fit(
     :param subsample: If <= 1, will be considered a fraction of valid pixels to extract.
         If > 1 will be considered the number of pixels to extract.
     :param random_state: Random seed.
-    :param verbose: If text should be printed.
     :param kwargs: Keyword arguments to pass to scipy.optimize.basinhopping
 
     :returns coefs, degree: sinusoid coefficients (amplitude, frequency, phase) x N, Number N of summed sinusoids
@@ -508,8 +502,7 @@ def robust_nfreq_sumsin_fit(
 
     for nb_freq in np.arange(1, max_nb_frequency + 1):
 
-        if verbose:
-            print(f"Fitting with {nb_freq} frequency")
+        logging.info("Fitting with %d frequency", nb_freq)
 
         b = bounds_amp_wave_phase
         # If bounds are not provided, define as the largest possible bounds
@@ -537,17 +530,16 @@ def robust_nfreq_sumsin_fit(
         # First guess for the mean parameters
         p0 = (np.abs((lb + ub) / 2)).squeeze()
 
-        if verbose:
-            print("Bounds")
-            print(lb)
-            print(ub)
+        logging.debug("Bounds")
+        logging.debug(lb)
+        logging.debug(ub)
 
         # Minimize the globalization with a larger number of points
         minimizer_kwargs = dict(args=(xdata, ydata), method="L-BFGS-B", bounds=scipy_bounds)
         myresults = scipy.optimize.basinhopping(
             wrapper_cost_sumofsin,
             p0,
-            disp=verbose,
+            disp=logging.getLogger().getEffectiveLevel() < logging.WARNING,
             T=hop_length * 50,
             minimizer_kwargs=minimizer_kwargs,
             seed=random_state,
@@ -556,9 +548,8 @@ def robust_nfreq_sumsin_fit(
         myresults = myresults.lowest_optimization_result
         myresults_x = np.array([np.round(myres, 5) for myres in myresults.x])
 
-        if verbose:
-            print("Final result")
-            print(myresults_x)
+        logging.info("Final result")
+        logging.info(myresults_x)
 
         # Write results for this number of frequency
         costs[nb_freq - 1] = wrapper_cost_sumofsin(myresults_x, xdata, ydata)
@@ -567,17 +558,15 @@ def robust_nfreq_sumsin_fit(
     # Replace NaN cost by infinity
     costs[np.isnan(costs)] = np.inf
 
-    if verbose:
-        print("Costs")
-        print(costs)
+    logging.info("Costs")
+    logging.info(costs)
 
     final_index = _choice_best_order(cost=costs)
 
     final_coefs = amp_freq_phase[final_index][~np.isnan(amp_freq_phase[final_index])]
 
-    if verbose:
-        print("Selecting best performing number of frequencies:")
-        print(final_coefs)
+    logging.info("Selecting best performing number of frequencies:")
+    logging.info(final_coefs)
 
     # If an amplitude coefficient is almost zero, remove the coefs of that frequency and lower the degree
     final_degree = final_index + 1

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import inspect
 import itertools
+import logging
 import math as m
 import multiprocessing as mp
 import warnings
@@ -1146,15 +1147,17 @@ def _choose_cdist_equidistant_sampling_parameters(**kwargs: Any) -> tuple[int, i
     # And the number of total pairwise comparison
     total_pairwise_comparison = runs * subsample_per_disk_per_run**2 * nb_rings
 
-    if kwargs["verbose"]:
-        print(
-            "Equidistant circular sampling will be performed for {} runs (random center points) with pairwise "
-            "comparison between {} samples (points) of the central disk and again {} samples times {} independent "
-            "rings centered on the same center point. This results in approximately {} pairwise comparisons (duplicate"
-            " pairwise points randomly selected will be removed).".format(
-                runs, subsample_per_disk_per_run, subsample_per_disk_per_run, nb_rings, total_pairwise_comparison
-            )
-        )
+    logging.info(
+        "Equidistant circular sampling will be performed for %d runs (random center points) with pairwise "
+        "comparison between %d samples (points) of the central disk and again %d samples times %d independent "
+        "rings centered on the same center point. This results in approximately %d pairwise comparisons (duplicate "
+        "pairwise points randomly selected will be removed).",
+        runs,
+        subsample_per_disk_per_run,
+        subsample_per_disk_per_run,
+        nb_rings,
+        total_pairwise_comparison,
+    )
 
     return runs, subsample_per_disk_per_run, ratio_subsample
 
@@ -1243,8 +1246,7 @@ def _wrapper_get_empirical_variogram(argdict: dict[str, Any]) -> pd.DataFrame:
     :return: Empirical variogram (variance, upper bound of lag bin, counts)
 
     """
-    if argdict["verbose"]:
-        print("Working on run " + str(argdict["i"]) + " out of " + str(argdict["imax"]))
+    logging.debug("Working on run " + str(argdict["i"]) + " out of " + str(argdict["imax"]))
     argdict.pop("i")
     argdict.pop("imax")
 
@@ -1275,7 +1277,6 @@ def sample_empirical_variogram(
     subsample_method: str = "cdist_equidistant",
     n_variograms: int = 1,
     n_jobs: int = 1,
-    verbose: bool = False,
     random_state: int | np.random.Generator | None = None,
     # **kwargs: **EmpiricalVariogramKArgs, # This will work in Python 3.12, fails in the meantime, we'll be able to
     # remove some type ignores from this function in the future
@@ -1331,7 +1332,6 @@ def sample_empirical_variogram(
     :param subsample_method: Spatial subsampling method
     :param n_variograms: Number of independent empirical variogram estimations (to estimate empirical variogram spread)
     :param n_jobs: Number of processing cores
-    :param verbose: Print statements during processing
     :param random_state: Random state or seed number to use for calculations (to fix random sampling during testing)
 
     :return: Empirical variogram (variance, upper bound of lag bin, counts)
@@ -1428,7 +1428,6 @@ def sample_empirical_variogram(
         "coords": coords,
         "subsample_method": subsample_method,
         "subsample": subsample,
-        "verbose": verbose,
     }
     if subsample_method in ["cdist_equidistant", "pdist_ring", "pdist_disk", "pdist_point"]:
         # The shape is needed for those three methods
@@ -1456,8 +1455,7 @@ def sample_empirical_variogram(
     # Differentiate between 1 core and several cores for multiple runs
     # All variogram runs have random sampling inherent to their subfunctions, so we provide the same input arguments
     if n_jobs == 1:
-        if verbose:
-            print("Using 1 core...")
+        logging.info("Using 1 core...")
 
         list_df_run = []
         for i in range(n_variograms):
@@ -1473,8 +1471,7 @@ def sample_empirical_variogram(
 
             list_df_run.append(df_run)
     else:
-        if verbose:
-            print("Using " + str(n_jobs) + " cores...")
+        logging.info("Using " + str(n_jobs) + " cores...")
 
         pool = mp.Pool(n_jobs, maxtasksperchild=1)
         list_argdict = [
@@ -1785,7 +1782,6 @@ def estimate_model_spatial_correlation(
     subsample_method: str = "cdist_equidistant",
     n_variograms: int = 1,
     n_jobs: int = 1,
-    verbose: bool = False,
     random_state: int | np.random.Generator | None = None,
     bounds: list[tuple[float, float]] = None,
     p0: list[float] = None,
@@ -1815,7 +1811,6 @@ def estimate_model_spatial_correlation(
     :param subsample_method: Spatial subsampling method
     :param n_variograms: Number of independent empirical variogram estimations (to estimate empirical variogram spread)
     :param n_jobs: Number of processing cores
-    :param verbose: Print statements during processing
     :param random_state: Random state or seed number to use for calculations (to fix random sampling during testing)
     :param bounds: Bounds of range and sill parameters for each model (shape K x 4 = K x range lower, range upper,
         sill lower, sill upper).
@@ -1834,7 +1829,6 @@ def estimate_model_spatial_correlation(
         subsample_method=subsample_method,
         n_variograms=n_variograms,
         n_jobs=n_jobs,
-        verbose=verbose,
         random_state=random_state,
         **kwargs,
     )
@@ -1861,7 +1855,6 @@ def infer_spatial_correlation_from_stable(
     subsample_method: str = "cdist_equidistant",
     n_variograms: int = 1,
     n_jobs: int = 1,
-    verbose: bool = False,
     bounds: list[tuple[float, float]] = None,
     p0: list[float] = None,
     random_state: int | np.random.Generator | None = None,
@@ -1897,7 +1890,6 @@ def infer_spatial_correlation_from_stable(
     :param subsample_method: Spatial subsampling method
     :param n_variograms: Number of independent empirical variogram estimations (to estimate empirical variogram spread)
     :param n_jobs: Number of processing cores
-    :param verbose: Print statements during processing
     :param bounds: Bounds of range and sill parameters for each model (shape K x 4 = K x range lower, range upper,
         sill lower, sill upper).
     :param p0: Initial guess of ranges and sills each model (shape K x 2 = K x range first guess, sill first guess).
@@ -1932,7 +1924,6 @@ def infer_spatial_correlation_from_stable(
         subsample_method=subsample_method,
         n_variograms=n_variograms,
         n_jobs=n_jobs,
-        verbose=verbose,
         random_state=random_state,
         bounds=bounds,
         p0=p0,
@@ -2646,7 +2637,6 @@ def _patches_convolution(
     patch_shape: str = "circular",
     method: str = "scipy",
     statistic_between_patches: Callable[[NDArrayf], np.floating[Any]] = nmad,
-    verbose: bool = False,
     return_in_patch_statistics: bool = False,
 ) -> tuple[float, float, float] | tuple[float, float, float, pd.DataFrame]:
     """
@@ -2659,7 +2649,6 @@ def _patches_convolution(
     :param method: Method to perform the convolution, "scipy" or "numba"
     :param statistic_between_patches: Statistic to compute between all patches, typically a measure of spread, applied
         to the first in-patch statistic, which is typically the mean
-    :param verbose: Print statement to console
     :param return_in_patch_statistics: Whether to return the dataframe of statistics for all patches and areas
 
 
@@ -2678,8 +2667,7 @@ def _patches_convolution(
     else:
         raise ValueError('Kernel shape should be "square" or "circular".')
 
-    if verbose:
-        print("Computing the convolution on the entire array...")
+    logging.info("Computing the convolution on the entire array...")
     mean_img, nb_valid_img, nb_pixel_per_kernel = mean_filter_nan(
         img=values, kernel_size=kernel_size, kernel_shape=patch_shape, method=method
     )
@@ -2692,8 +2680,7 @@ def _patches_convolution(
     # kernel size (i.e., the diameter of the circular patch, or side of the square patch) to ensure no dependency
 
     # There are as many combinations for this calculation as the square of the kernel_size
-    if verbose:
-        print("Computing statistic between patches for all independent combinations...")
+    logging.info("Computing statistic between patches for all independent combinations...")
     list_statistic_estimates = []
     list_nb_independent_patches = []
     for i in range(kernel_size):
@@ -2733,7 +2720,6 @@ def _patches_loop_quadrants(
     perc_min_valid: float = 80.0,
     statistics_in_patch: Iterable[Callable[[NDArrayf], np.floating[Any]] | str] = (np.nanmean,),
     statistic_between_patches: Callable[[NDArrayf], np.floating[Any]] = nmad,
-    verbose: bool = False,
     random_state: int | np.random.Generator | None = None,
     return_in_patch_statistics: bool = False,
 ) -> tuple[float, float, float] | tuple[float, float, float, pd.DataFrame]:
@@ -2751,7 +2737,6 @@ def _patches_loop_quadrants(
         to the first in-patch statistic, which is typically the mean
     :param patch_shape: Shape of patch, either "circular" or "square".
     :param n_patches: Maximum number of patches to sample
-    :param verbose: Print statement to console
     :param random_state: Random state or seed number to use for calculations (to fix random sampling during testing)
     :param return_in_patch_statistics: Whether to return the dataframe of statistics for all patches and areas
 
@@ -2801,8 +2786,7 @@ def _patches_loop_quadrants(
 
         for idx_quadrant in list_idx_quadrant:
 
-            if verbose:
-                print("Working on a new quadrant")
+            logging.info("Working on a new quadrant")
 
             # Select center coordinates
             i = list_quadrant[idx_quadrant][0]
@@ -2828,8 +2812,7 @@ def _patches_loop_quadrants(
                 u = u + 1
                 if u > n_patches:
                     break
-                if verbose:
-                    print("Found valid quadrant " + str(u) + " (maximum: " + str(n_patches) + ")")
+                logging.info("Found valid quadrant " + str(u) + " (maximum: " + str(n_patches) + ")")
 
                 df = pd.DataFrame()
                 df = df.assign(tile=[str(i) + "_" + str(j)])
@@ -2882,7 +2865,6 @@ def patches_method(
     vectorized: bool = True,
     convolution_method: str = "scipy",
     n_patches: int = 1000,
-    verbose: bool = False,
     *,
     return_in_patch_statistics: Literal[False] = False,
     random_state: int | np.random.Generator | None = None,
@@ -2904,7 +2886,6 @@ def patches_method(
     vectorized: bool = True,
     convolution_method: str = "scipy",
     n_patches: int = 1000,
-    verbose: bool = False,
     *,
     return_in_patch_statistics: Literal[True],
     random_state: int | np.random.Generator | None = None,
@@ -2925,7 +2906,6 @@ def patches_method(
     vectorized: bool = True,
     convolution_method: str = "scipy",
     n_patches: int = 1000,
-    verbose: bool = False,
     return_in_patch_statistics: bool = False,
     random_state: int | np.random.Generator | None = None,
 ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
@@ -2964,7 +2944,6 @@ def patches_method(
     :param vectorized: Whether to use the vectorized (convolution) method or the for loop in quadrants
     :param convolution_method: Convolution method to use, either "scipy" or "numba" (only for vectorized)
     :param n_patches: Maximum number of patches to sample (only for non-vectorized)
-    :param verbose: Print statement to console
     :param return_in_patch_statistics: Whether to return the dataframe of statistics for all patches and areas
     :param random_state: Random state or seed number to use for calculations (only for non-vectorized, for testing)
 
@@ -2998,7 +2977,6 @@ def patches_method(
                 patch_shape=patch_shape,
                 method=convolution_method,
                 statistic_between_patches=statistic_between_patches,
-                verbose=verbose,
                 return_in_patch_statistics=return_in_patch_statistics,
             )
 
@@ -3013,7 +2991,6 @@ def patches_method(
                 perc_min_valid=perc_min_valid,
                 statistics_in_patch=statistics_in_patch,
                 statistic_between_patches=statistic_between_patches,
-                verbose=verbose,
                 return_in_patch_statistics=return_in_patch_statistics,
                 random_state=random_state,
             )


### PR DESCRIPTION
# Replace `print` statements with `logging` 
Resolves #565 

## Summary
This pull request addresses the transition from using `print()`statements to the Python `logging` module. The update improves flexibility for managing output messages.

## Changes made:

- Replaced all occurences of `print` with appropriate logging levels (`debug`, `info`, `warning`, `error`)
- Removed the `verbose` flag in favor of log levels
- Replaced all `f-strings` with `%` formatting in logging statements to comply with `pylint` requirements

### Note on `tdqm` and `logging` integration in `xdem.correg.affine.py`
Since `tdqm` directly manages output to the console, mixing its output with standard logging (especially at lower verbosity levels) can lead to overlapping or garbled output.

To addess this, I ensured that:
- The `pbar`(from `tdqm.trange`) is conditionnally displayed depending on the current logging level. When the logging level is set to `INFO` or higher, the progress bar is visible.
- `pbar.write()` is used for logging messages within the loop, after checking the logging level.

## Documentation
Updated the documentation to include instructions on how users can configure logging verbosity.

## Example
Added an example showing how a users can use and configure logging
