### PR TITLE
Transition to Apache License 2.0: License Update, Author Attribution, and Documentation Compliance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,3 +124,12 @@ repos:
                   files: ^(environment.yml|requirements.txt)$
                   pass_filenames: false
                   additional_dependencies: [tomli, pyyaml]
+
+        # Add license header to the source files
+        - repo: local
+          hooks:
+            - id: add-license_header
+              name: Add License Header
+              entry: python apply_license_header.py
+              language: python
+              files: \.py$

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,50 @@
+# Credits
+
+---
+© 2024 **xDEM developers**.
+
+**xDEM** is licensed under permissive Apache 2 license (See LICENSE file).
+
+All contributors listed in this document are part of the **xDEM developers**, and their
+contributions are subject to the project's copyright under the terms of the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+This file keeps track of authors contributions.
+
+## Development Lead
+
+---
+
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
+
+## Contributors
+
+---
+
+- **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
+- **Andrew Tedstone** [@atedstone](https://github/atedstone)
+- **Zhihao LIU** [@liuh886](https://github/liuh886)
+- **Diego Cusicanqui** [@cusicand](https://github/cusicand)
+- **Alessandro Gentilini** [@alessandro-gentilini](https://github/alessandro-gentilini)
+- **Ferdinand Schenck** [@fnands](https://github/fnands)
+- **Johannes Landmann** [@jlandmann](https://github/jlandmann)
+- **Valentin Schaffner** [@vschaffn](https://github/vschaffn) <valentin.schaffner@cs-soprasteria.com>
+- **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
+- **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
+- **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
+- **Enrico Mattea** [@MatteaE](https://github.com/MatteaE)
+- **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
+- **Simon Gascoin** [@sgascoin](https://github.com/sgascoin)
+
+Update here with new contributors.
+
+
+## Original Developers/Designers/Supporters
+
+---
+
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2020 GlacioHack
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,127 @@
+Copyright (c) 2024 xDEM developers.
+
+This file is part of xDEM (see https://github.com/GlacioHack/xdem).
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+xDEM software is distributed under the Apache Software License (ASL) v2.0, see
+LICENSE file or http://www.apache.org/licenses/LICENSE-2.0 for details.
+
+Python: programming language that lets you work quickly and integrate systems more effectively.
+Copyright (c) 2001-2023 Python Software Foundation. All Rights reserved.
+Website: http://python.org/
+License: Python Software License.
+
+NumPy: The fundamental package for scientific computing with Python.
+Copyright (c) 2005-2024, NumPy Developers.
+Website: https://numpy.org/
+License: BSD 3-Clause.
+
+Matplotlib: Comprehensive library for creating static, animated, and interactive visualizations in Python.
+Copyright (C) 2001-2023 Matplotlib Development Team.
+Website: https://matplotlib.org/
+License: Matplotlib only uses BSD compatible code, and its license is based on the PSF license.
+
+SciPy: Open-source software for mathematics, science, and engineering.
+Copyright (c) 2001-2002 Enthought, Inc. All rights reserved.
+Copyright (c) 2003-2019 SciPy Developers. All rights reserved.
+Website: https://www.scipy.org/scipylib/
+License: BSD 3-Clause.
+
+Geoutils: Libraries and command-line utilities for geospatial data processing/analysis in Python.
+Copyright (c) 2020 Amaury Dehecq, Andrew Tedstone.
+Website: https://github.com/GeoUtils/geoutils
+License: MIT License.
+
+Rasterio: Access to geospatial raster data
+Copyright (c) 2016, MapBox All rights reserved.
+Website: https://github.com/mapbox/rasterio
+License: BSD 3-Clause.
+
+GeoPandas: Python tools for geographic data.
+Copyright (c) 2013-2022, GeoPandas developers.
+Website: https://geopandas.org/
+License: BSD 3-Clause.
+
+pyogrio: Fast read/write access to OGR-compatible vector formats.
+Copyright (c) 2020-2024 Brendan C. Ward and pyogrio contributors.
+Website: https://github.com/geopandas/pyogrio
+License: MIT.
+
+pandas: Data analysis and manipulation library for Python.
+Copyright (c) 2008-2011, AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team.
+Copyright (c) 2011-2024, Open source contributors.
+Website: https://pandas.pydata.org/
+License: BSD 3-Clause.
+
+scikit-learn: Machine learning library for Python.
+Copyright (c) 2007-2023, scikit-learn Developers.
+Website: https://scikit-learn.org/
+License: BSD 3-Clause.
+
+Numba: A Just-in-Time Compiler for Python that accelerates numerical functions.
+Copyright (c) 2012-2023 Anaconda, Inc.
+Website: https://numba.pydata.org/
+License: BSD 2-Clause.
+
+OpenCV (cv2): Computer vision library.
+Copyright (C) 2015-2023, OpenCV Foundation, all rights reserved.
+Website: https://opencv.org/
+License: Apache License 2.0
+
+scikit-image: Image processing in Python.
+Copyright (c) 2009-2022 the scikit-image team.
+Website: https://scikit-image.org/
+License: BSD 3-Clause.
+
+scikit-gstat: A geostatistics toolbox for Python.
+Copyright (c) 2017 Mirko Mälicke.
+Website: https://github.com/mmaelicke/scikit-gstat
+Licence: MIT License.
+
+affine: Matrix transformations for geospatial coordinates.
+Copyright (c) 2014-2023, Sean Gillies.
+Website: https://github.com/sgillies/affine
+License: BDS 3-Clause.
+
+Shapely: Manipulation and analysis of geometric objects.
+Copyright (c) 2007, Sean C. Gillies. 2019, Casper van der Wel. 2007-2022, Shapely Contributors.
+Website: https://shapely.readthedocs.io/
+License: BSD 3-Clause.
+
+pyproj: Python interface to PROJ (cartographic projections and transformations library).
+Copyright (c) 2006-2018, Jeffrey Whitaker.
+Copyright (c) 2019-2024, Open source contributors.
+Website: https://pyproj4.github.io/pyproj/stable/
+License: MIT License.
+
+pytransform3d: 3D transformations for Python.
+Copyright (c) 2014-2023, Alexander Fabisch, and pytransform3d contributors.
+Website: https://github.com/rock-learning/pytransform3d
+License: BSD 3-Clause.
+
+tqdm: A fast, extensible progress bar for Python an CLI applications.
+Copyright (c) MIT 2013 Noam Yorav-Raphael, original author.
+Copyright (c) MPL-2.0 2015-2024 Casper da Costa-Luis.
+Website: https://github.com/tqdm/tqdm
+License: MPL-2.0 and MIT License.
+
+yaml (PyYAML): Python bindings for YAML, a human-readable data serialization language.
+Copyright (c) 2006-2023, PyYAML contributors.
+Website: https://pyyaml.org/
+License: CC-BY 2.0.
+
+noisyopt: Library for optimizing noisy functions in Python.
+Copyright (c) 2016-2017 Andreas Mayer.
+Website: https://pypi.org/project/noisyopt/
+License: MIT.

--- a/apply_license_header.py
+++ b/apply_license_header.py
@@ -1,0 +1,39 @@
+import os
+
+# Path to the license header
+HEADER_FILE = "license-header.txt"
+
+# read license header
+with open(HEADER_FILE) as file:
+    license_header = file.read()
+
+
+# Add license header to a file
+def add_license_header(file_path, header):
+    with open(file_path) as f:
+        content = f.read()
+
+    # Check if the header is already there
+    if content.startswith(header):
+        return
+
+    # If not, add it
+    with open(file_path, "w") as f:
+        f.write(header + "\n" + content)
+    print(f"Header added to {file_path}")
+
+
+# Check the header in every file in root_dir
+def apply_license_header_to_all_py_files(root_dir):
+    for subdir, _, files in os.walk(root_dir):
+        for file in files:
+            if file.endswith(".py"):
+                file_path = os.path.join(subdir, file)
+                add_license_header(file_path, license_header)
+
+
+# Source repertory
+PROJECT_SRC = "xdem"
+
+# Add header to every source files
+apply_license_header_to_all_py_files(PROJECT_SRC)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,9 +14,9 @@ help:
 
 clean:
 	echo "Removing build files..."
-	if [[ -d "$(BUILDDIR)" ]]; then rm -r "$(BUILDDIR)"; fi
-	if [[ -d "$(SOURCEDIR)/auto_examples" ]]; then rm -r "$(SOURCEDIR)/auto_examples"; fi
-	if [[ -d "$(SOURCEDIR)/gen_modules" ]]; then rm -r "$(SOURCEDIR)/gen_modules"; fi
+	if [ -d "$(BUILDDIR)" ]; then rm -r "$(BUILDDIR)"; fi
+	if [ -d "$(SOURCEDIR)/auto_examples" ]; then rm -r "$(SOURCEDIR)/auto_examples"; fi
+	if [ -d "$(SOURCEDIR)/gen_modules" ]; then rm -r "$(SOURCEDIR)/gen_modules"; fi
 
 .PHONY: help Makefile
 

--- a/doc/source/authors.md
+++ b/doc/source/authors.md
@@ -1,0 +1,63 @@
+---
+file_format: mystnb
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: xdem-env
+  language: python
+  name: xdem
+---
+(authors)=
+
+# Credits
+
+© 2024 **xDEM developers**.
+
+**xDEM** is licensed under permissive Apache 2 license (See [LICENSE file](license.md)).
+
+All contributors listed in this document are part of the **xDEM developers**, and their
+contributions are subject to the project's copyright under the terms of the
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+This file keeps track of authors contributions.
+
+---
+
+## Development Lead
+
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
+
+---
+
+## Contributors
+
+
+- **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
+- **Andrew Tedstone** [@atedstone](https://github/atedstone)
+- **Zhihao LIU** [@liuh886](https://github/liuh886)
+- **Diego Cusicanqui** [@cusicand](https://github/cusicand)
+- **Alessandro Gentilini** [@alessandro-gentilini](https://github/alessandro-gentilini)
+- **Ferdinand Schenck** [@fnands](https://github/fnands)
+- **Johannes Landmann** [@jlandmann](https://github/jlandmann)
+- **Valentin Schaffner** [@vschaffn](https://github/vschaffn) <valentin.schaffner@cs-soprasteria.com>
+- **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
+- **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
+- **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
+- **Enrico Mattea** [@MatteaE](https://github.com/MatteaE)
+- **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
+- **Simon Gascoin** [@sgascoin](https://github.com/sgascoin)
+
+Update here with new contributors.
+
+---
+
+## Original Developers/Designers/Supporters
+
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,8 +26,8 @@ import xdem
 # -- Project information -----------------------------------------------------
 
 project = "xDEM"
-copyright = "2020, GlacioHack"
-author = "xDEM contributors"
+copyright = "2024, xDEM developers"
+author = "Erik Mannerfelt, Romain Hugonnet, Amaury Dehecq and others"
 
 # The full version, including alpha/beta/rc tags
 release = xdem.__version__

--- a/doc/source/index.md
+++ b/doc/source/index.md
@@ -141,8 +141,16 @@ advanced_examples/index.rst
 api
 config
 release_notes
+```
+
+```{toctree}
+:caption: Project information
+:maxdepth: 2
+
 publis
 background
+authors
+license
 ```
 
 # Indices and tables

--- a/doc/source/license.md
+++ b/doc/source/license.md
@@ -1,0 +1,207 @@
+---
+file_format: mystnb
+jupytext:
+  formats: md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: xdem-env
+  language: python
+  name: xdem
+---
+(license)=
+
+# Apache License
+
+_Version 2.0, January 2004_
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+## Terms and Conditions for use, reproduction, and distribution
+
+### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+* **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+* **(b)** You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+* **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+* **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+## APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets `[]` replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same “printed page” as the copyright notice for easier identification within
+third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,12 @@
 [metadata]
-author = xDEM contributors
+author = xDEM developers
 name = xdem
 version = 0.0.20
 description = Analysis of digital elevation models (DEMs)
 keywords = dem, elevation, geoutils, xarray
 long_description = file: README.md
 long_description_content_type = text/markdown
-license = MIT
+license = Apache 2.0
 license_files = LICENSE
 platform = any
 classifiers =
@@ -14,7 +14,7 @@ classifiers =
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     Natural Language :: English
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering :: GIS
     Topic :: Scientific/Engineering :: Image Processing

--- a/xdem/__init__.py
+++ b/xdem/__init__.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from xdem import (  # noqa
     coreg,
     dem,

--- a/xdem/_typing.py
+++ b/xdem/_typing.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import sys

--- a/xdem/coreg/__init__.py
+++ b/xdem/coreg/__init__.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 DEM coregistration classes and functions, including affine methods, bias corrections (i.e. non-affine) and filters.
 """

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Affine coregistration classes."""
 
 from __future__ import annotations

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Base coregistration classes to define generic methods and pre/post-processing of input data."""
 
 from __future__ import annotations

--- a/xdem/coreg/biascorr.py
+++ b/xdem/coreg/biascorr.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Bias corrections (i.e., non-affine coregistration) classes."""
 from __future__ import annotations
 

--- a/xdem/coreg/filters.py
+++ b/xdem/coreg/filters.py
@@ -1,1 +1,18 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Coregistration filters (coming soon)."""

--- a/xdem/coreg/workflows.py
+++ b/xdem/coreg/workflows.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Coregistration pipelines pre-defined with convenient user inputs and parameters."""
 
 from __future__ import annotations

--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Difference of DEMs classes and functions."""
 from __future__ import annotations
 

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """DEM class and functions."""
 from __future__ import annotations
 

--- a/xdem/demcollection.py
+++ b/xdem/demcollection.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """DEM collection class and functions."""
 from __future__ import annotations
 

--- a/xdem/examples.py
+++ b/xdem/examples.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utility functions to download and find example data."""
 import os
 import tarfile

--- a/xdem/filters.py
+++ b/xdem/filters.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Filters to remove outliers and reduce noise in DEMs."""
 from __future__ import annotations
 

--- a/xdem/fit.py
+++ b/xdem/fit.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Functions to perform normal, weighted and robust fitting.
 """

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Small functions for testing, examples, and other miscellaneous uses."""
 from __future__ import annotations
 

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Spatial statistical tools to estimate uncertainties related to DEMs"""
 from __future__ import annotations
 

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Terrain attribute calculations, such as slope, aspect, hillshade, curvature and ruggedness indexes."""
 from __future__ import annotations
 

--- a/xdem/vcrs.py
+++ b/xdem/vcrs.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Routines for vertical CRS transformation (fully based on pyproj)."""
 from __future__ import annotations
 

--- a/xdem/volume.py
+++ b/xdem/volume.py
@@ -1,3 +1,20 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Volume change calculation tools (aimed for glaciers)."""
 from __future__ import annotations
 


### PR DESCRIPTION
# Description

This PR implements the transition of the **xDEM** project license from **MIT** to **Apache License 2.0**.
Resolves #555 

# Changes implemented
- The `LICENSE` file has been updated with the full text of the Apache v2.0 license.
- A `NOTICE` file has been added to comply with Apache licensing requirements. The file includes necessary copyright notices and details about dependencies used by xdem, including Python, NumPy, Matplotlib, SciPy, Geoutils, Rasterio, GeoPandas, Numba, pyproj, tqdm, scikit-image, scikit-gstat, pyogrio, pandas, scikit-learn, OpenCV, affine, Shapely, pytransform3d, yaml and noisyopt.
- An `AUTHORS.md` file has been created listing the main contributors of the project along with their contact information, while mentioning their affiliation with the **xDEM** developers' copyright.
- All source code files have been updated with the new Apache v2.0 license header, which is the following:

```
# Copyright (c) 2024 xDEM developers.
#
# This file is part of the xdem project:
#   https://github.com/glaciohack/xdem
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at:
#   http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.
```
The header is set up automatically via pre-commit for every source files.

- The `setup.cfg` has been updated with the new license and copyright as well as `conf.py`.

- The documentation has been updated with the license and the authors.

# Notes

- There are certainly other contributors to add to the project, so don't hesitate to let me know.
- The packages listed in `NOTICE` and in `setup.cfg` are not aligned anymore. This will be solved by #582.
- PR to be merged after #612.
- The copyrights and authors cited in the documentation must be checked for consistency with the project #431.