### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # Run all shells using bash (including Windows)
     defaults:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     # Run all shells using bash (including Windows)
     defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,11 @@ The technical steps to contributing to xDEM are:
 
 ## Development environment
 
-xDEM currently supports Python versions of 3.9 to 3.11 (see `dev-environment.yml` for detailed dependencies), which are
+xDEM currently supports Python versions of 3.10 to 3.12 (see `dev-environment.yml` for detailed dependencies), which are
 tested in a continuous integration (CI) workflow running on GitHub Actions.
 
 When you open a PR on xDEM, a single linting action and 9 test actions will automatically start, corresponding to all
-supported Python versions (3.9, 3.10 and 3.11) and OS (Ubuntu, Mac, Windows). The coverage change of the tests will also
+supported Python versions (3.10, 3.11 and 3.12) and OS (Ubuntu, Mac, Windows). The coverage change of the tests will also
 be reported by CoverAlls.
 
 ### Setup

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -2,7 +2,7 @@ name: xdem-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - python>=3.10,<3.13
   - geopandas>=0.12.0
   - numba=0.*
   - numpy=1.*

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - tqdm
   - scikit-image=0.*
   - scikit-gstat>=1.0.18,<1.1
-  - geoutils=0.1.9
+  - geoutils=0.1.10
 
   # Development-specific, to mirror manually in setup.cfg [options.extras_require].
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: xdem
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9,<3.12
+  - python>=3.10,<3.13
   - geopandas>=0.12.0
   - numba=0.*
   - numpy=1.*
@@ -13,7 +13,7 @@ dependencies:
   - tqdm
   - scikit-image=0.*
   - scikit-gstat>=1.0.18,<1.1
-  - geoutils=0.1.9
+  - geoutils=0.1.10
   - pip
 
    # To run CI against latest GeoUtils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ version_file = "xdem/_version.py"
 fallback_version = "0.0.1"
 
 [tool.black]
-target_version = ['py36']
+target_version = ['py310']
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules -W error::UserWarning"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ scipy==1.*
 tqdm
 scikit-image==0.*
 scikit-gstat>=1.0.18,<1.1
-geoutils==0.1.9
+geoutils==0.1.10
 pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ download_url = https://pypi.org/project/xdem/
 packages = find:
 zip_safe = False # https://mypy.readthedocs.io/en/stable/installed_packages.html
 include_package_data = True
-python_requires = >=3.9,<3.13
+python_requires = >=3.10,<3.13
 # Avoid pinning dependencies in requirements.txt (which we don't do anyways, and we rely mostly on Conda)
 # (https://caremad.io/posts/2013/07/setup-vs-requirement/, https://github.com/pypa/setuptools/issues/1951)
 install_requires = file: requirements.txt


### PR DESCRIPTION
And remove CI support for 3.9.

 - [x] Resolves #619,
 - [x] New optional dependencies or Python version support added to both `dev-environment.yml` and `setup.cfg`,
 - [x] If contributor workflow (test, doc, linting) or Python version support changed, update `CONTRIBUTING.md`.
