### PR TITLE
Makefile initial installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ be reported by CoverAlls.
 
 ### Setup
 
+#### With `mamba`
 Clone the git repo and create a `mamba` environment (see how to install `mamba` in the [mamba documentation](https://mamba.readthedocs.io/en/latest/)):
 
 ```bash
@@ -37,6 +38,15 @@ cd xdem
 mamba env create -f dev-environment.yml  # Add '-n custom_name' if you want.
 mamba activate xdem-dev  # Or any other name specified above
 ```
+
+#### With `pip`
+```bash
+git clone https://github.com/GlacioHack/xdem.git
+cd xdem
+make install
+```
+
+Please note: pip installation is currently only possible under python3.10.
 
 ### Tests
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,88 @@
+# Autodocumented Makefile for xDEM
+# see: https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+# Dependencies : python3 venv
+
+############### GLOBAL VARIABLES ######################
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+
+# Virtualenv directory name (can be overridden)
+ifndef VENV
+	VENV = "venv"
+endif
+
+# Python version requirement
+PYTHON_VERSION_MIN = 3.9
+
+ifndef PYTHON
+	PYTHON = "python3"
+endif
+PYTHON_CMD=$(shell command -v $(PYTHON))
+
+PYTHON_VERSION_CUR=$(shell $(PYTHON_CMD) -c 'import sys; print("%d.%d" % sys.version_info[0:2])')
+PYTHON_VERSION_OK=$(shell $(PYTHON_CMD) -c 'import sys; cur_ver = sys.version_info[0:2]; min_ver = tuple(map(int, "$(PYTHON_VERSION_MIN)".split("."))); print(int(cur_ver >= min_ver))')
+
+############### Check python version supported ############
+
+ifeq (, $(PYTHON_CMD))
+    $(error "PYTHON_CMD=$(PYTHON_CMD) not found in $(PATH)")
+endif
+
+ifeq ($(PYTHON_VERSION_OK), 0)
+    $(error "Requires python version >= $(PYTHON_VERSION_MIN). Current version is $(PYTHON_VERSION_CUR)")
+endif
+
+################ MAKE Targets ######################
+
+help: ## Show this help
+	@echo "      XDEM MAKE HELP"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: venv
+venv: ## Create a virtual environment in 'venv' directory if it doesn't exist
+	@test -d ${VENV} || $(PYTHON_CMD) -m venv ${VENV}
+	@touch ${VENV}/bin/activate
+	@${VENV}/bin/python -m pip install --upgrade wheel setuptools pip
+
+.PHONY: install
+install: venv ## Install xDEM for development (depends on venv)
+	@test -f ${VENV}/bin/xdem || echo "Installing xdem in development mode"
+	@test -f ${VENV}/bin/xdem || ${VENV}/bin/pip install -e .[dev]
+	@test -f .git/hooks/pre-commit || echo "Installing pre-commit hooks"
+	@test -f .git/hooks/pre-commit || ${VENV}/bin/pre-commit install -t pre-commit
+	@test -f .git/hooks/pre-push || ${VENV}/bin/pre-commit install -t pre-push
+	@echo "XDEM installed in development mode in virtualenv ${VENV}"
+	@echo "To use: source ${VENV}/bin/activate; xdem -h"
+
+#.PHONY: test
+#test: ## run tests
+#	@${VENV}/bin/pytest
+
+## Clean section
+
+.PHONY: clean
+clean: clean-venv clean-build clean-pyc clean-precommit ## Clean all
+
+.PHONY: clean-venv
+clean-venv: ## Clean the virtual environment
+	@echo "+ $@"
+	@rm -rf ${VENV}
+
+.PHONY: clean-build
+clean-build: ## Remove build artifacts
+	@echo "+ $@"
+	@rm -rf build/ dist/ .eggs/
+	@find . -name '*.egg-info' -exec rm -rf {} +
+	@find . -name '*.egg' -exec rm -f {} +
+
+.PHONY: clean-precommit
+clean-precommit: ## Remove pre-commit hooks from .git/hooks
+	@rm -f .git/hooks/pre-commit
+	@rm -f .git/hooks/pre-push
+
+.PHONY: clean-pyc
+clean-pyc: ## Remove Python cache and artifacts
+	@echo "+ $@"
+	@find . -type f -name "*.py[co]" -exec rm -rf {} +
+	@find . -type d -name "__pycache__" -exec rm -rf {} +
+	@find . -name '*~' -exec rm -rf {} +

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,16 @@ ifndef VENV
 endif
 
 # Python version requirement
-PYTHON_VERSION_MIN = 3.9
+PYTHON_VERSION_REQUIRED = 3.10
 
 ifndef PYTHON
-	PYTHON = "python3"
+	# Try to find python version required
+	PYTHON = "python$(PYTHON_VERSION_REQUIRED)"
 endif
 PYTHON_CMD=$(shell command -v $(PYTHON))
 
 PYTHON_VERSION_CUR=$(shell $(PYTHON_CMD) -c 'import sys; print("%d.%d" % sys.version_info[0:2])')
-PYTHON_VERSION_OK=$(shell $(PYTHON_CMD) -c 'import sys; cur_ver = sys.version_info[0:2]; min_ver = tuple(map(int, "$(PYTHON_VERSION_MIN)".split("."))); print(int(cur_ver >= min_ver))')
+PYTHON_VERSION_OK=$(shell $(PYTHON_CMD) -c 'import sys; req_ver = tuple(map(int, "$(PYTHON_VERSION_REQUIRED)".split("."))); cur_ver = sys.version_info[0:2]; print(int(cur_ver == req_ver))')
 
 ############### Check python version supported ############
 
@@ -29,7 +30,7 @@ ifeq (, $(PYTHON_CMD))
 endif
 
 ifeq ($(PYTHON_VERSION_OK), 0)
-    $(error "Requires python version >= $(PYTHON_VERSION_MIN). Current version is $(PYTHON_VERSION_CUR)")
+    $(error "Requires Python version == $(PYTHON_VERSION_REQUIRED). Current version is $(PYTHON_VERSION_CUR)")
 endif
 
 ################ MAKE Targets ######################
@@ -44,6 +45,20 @@ venv: ## Create a virtual environment in 'venv' directory if it doesn't exist
 	@touch ${VENV}/bin/activate
 	@${VENV}/bin/python -m pip install --upgrade wheel setuptools pip
 
+.PHONY: install-gdal
+install-gdal: ## Install GDAL version matching the system's GDAL via pip
+	@if command -v gdalinfo >/dev/null 2>&1; then \
+		GDAL_VERSION=$$(gdalinfo --version | awk '{print $$2}'); \
+		echo "System GDAL version: $$GDAL_VERSION"; \
+		${VENV}/bin/pip install gdal==$$GDAL_VERSION; \
+	else \
+		echo "Warning: GDAL not found on the system. Proceeding without GDAL."; \
+		echo "Try installing GDAL by running the following commands depending on your system:"; \
+		echo "Debian/Ubuntu: sudo apt-get install -y gdal-bin libgdal-dev"; \
+		echo "Red Hat/CentOS: sudo yum install -y gdal gdal-devel"; \
+		echo "Then run 'make install-gdal' to proceed with GDAL installation."; \
+	fi
+
 .PHONY: install
 install: venv ## Install xDEM for development (depends on venv)
 	@test -f ${VENV}/bin/xdem || echo "Installing xdem in development mode"
@@ -51,12 +66,21 @@ install: venv ## Install xDEM for development (depends on venv)
 	@test -f .git/hooks/pre-commit || echo "Installing pre-commit hooks"
 	@test -f .git/hooks/pre-commit || ${VENV}/bin/pre-commit install -t pre-commit
 	@test -f .git/hooks/pre-push || ${VENV}/bin/pre-commit install -t pre-push
-	@echo "XDEM installed in development mode in virtualenv ${VENV}"
+	@echo "Attempting to install GDAL..."
+	@make install-gdal
+	@echo "xdem installed in development mode in virtualenv ${VENV}"
 	@echo "To use: source ${VENV}/bin/activate; xdem -h"
 
-#.PHONY: test
-#test: ## run tests
-#	@${VENV}/bin/pytest
+
+.PHONY: test
+test: ## run tests
+	@if ! ${VENV}/bin/python -m pip show gdal >/dev/null 2>&1; then \
+		echo "Error: GDAL is not installed in the virtual environment. Tests require GDAL to run."; \
+		echo "Please ensure GDAL is installed by running 'make install-gdal'."; \
+		exit 1; \
+	else \
+		${VENV}/bin/pytest; \
+	fi
 
 ## Clean section
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,18 @@ For a quick start, full feature description or search through the API, see xDEM'
 
 ## Installation
 
+### With `mamba`
+
 ```bash
 mamba install -c conda-forge xdem
 ```
 See [mamba's documentation](https://mamba.readthedocs.io/en/latest/) to install `mamba`, which will solve your environment much faster than `conda`.
+
+### With `pip`
+
+```bash
+pip install xdem
+```
 
 ## Citing methods implemented in the package
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -14,12 +14,18 @@ dependencies:
   - scikit-image=0.*
   - scikit-gstat>=1.0.18,<1.1
   - geoutils=0.1.12
+  - affine
+  - pandas
+  - pyogrio
+  - shapely
 
   # Development-specific, to mirror manually in setup.cfg [options.extras_require].
   - pip
 
   # Optional dependencies
   - pytransform3d
+  - pyyaml
+  - scikit-learn
 
   # Test dependencies
   - gdal  # To test against GDAL
@@ -28,7 +34,7 @@ dependencies:
   - pyyaml
   - flake8
   - pylint
-  - richdem
+  - richdem # To test against richdem
 
   # Doc dependencies
   - sphinx
@@ -47,6 +53,7 @@ dependencies:
     # Optional dependency
     - -e ./
 
+    - noisyopt
     # "Headless" needed for opencv to install without requiring system dependencies
     - opencv-contrib-python-headless
 

--- a/doc/source/how_to_install.md
+++ b/doc/source/how_to_install.md
@@ -28,9 +28,20 @@ Updating packages with `pip` (and sometimes `mamba`) can break your installation
 
 ## Installing for contributors
 
+### With ``mamba``
+
 ```bash
 git clone https://github.com/GlacioHack/xdem.git
 mamba env create -f xdem/dev-environment.yml
+```
+
+### With ``pip``
+
+Please note: pip installation is currently only possible under python3.10.
+
+```bash
+git clone https://github.com/GlacioHack/xdem.git
+make install
 ```
 
 After installing, you can check that everything is working by running the tests: `pytest`.

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,10 @@ dependencies:
   - scikit-gstat>=1.0.18,<1.1
   - geoutils=0.1.12
   - pip
+  - affine
+  - pandas
+  - pyogrio
+  - shapely
 
    # To run CI against latest GeoUtils
 #  - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ scikit-image==0.*
 scikit-gstat>=1.0.18,<1.1
 geoutils==0.1.12
 pip
+affine
+pandas
+pyogrio
+shapely

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,11 +57,11 @@ opt =
 test =
     pytest
     pytest-xdist
+    pre-commit
     flake8
     pylint
     scikit-learn
     richdem
-    gdal
 doc =
     sphinx
     sphinx-book-theme
@@ -74,9 +74,8 @@ doc =
     myst-nb
     numpydoc
 dev =
-    pre-commit
     %(opt)s
     %(doc)s
+    %(test)s
 all =
     %(dev)s
-    %(test)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,17 +49,19 @@ include =
 
 [options.extras_require]
 opt =
-    opencv
-    openh264
+    opencv-contrib-python-headless
     pytransform3d
     noisyopt
+    scikit-learn
+    pyyaml
 test =
     pytest
     pytest-xdist
-    pyyaml
     flake8
     pylint
+    scikit-learn
     richdem
+    gdal
 doc =
     sphinx
     sphinx-book-theme
@@ -72,8 +74,9 @@ doc =
     myst-nb
     numpydoc
 dev =
+    pre-commit
     %(opt)s
-    %(test)s
     %(doc)s
 all =
     %(dev)s
+    %(test)s


### PR DESCRIPTION
Resolves #582.

## Description
This PR introduces the initial Makefile for the `xdem` project, aimed at streamlining the installation process for developers on Linux systems. By implementing a Makefile, we provide a simple command-line interface for common setup tasks, enhancing the developer experience and reducing the potential for errors during installation.

### Key Changes:

1. **Makefile Structure**: The Makefile has been created based on the existing structure of the `demcompare` project. 

2. **Targets Implemented**:
   - **`help`**: Displays help information about available targets.
   - **`venv`**: Creates a virtual environment in the specified directory if it does not exist.
   - **`install-gdal`**: Installs the version of GDAL corresponding to that of the system.
   - **`install`**: Installs the `xdem` package in editable mode along with necessary dependencies and sets up pre-commit hooks for Git.
   - **`clean`**: A comprehensive clean target to remove build artifacts, virtual environment, and pre-commit hooks.
   - **`test`**: Run pytest (if GDAL is in the virtual environment).

3. **Update dependencies**:
The dependencies used in each sections (required, optionnal, test, doc) have been updated to match with the projet.

## Documentation
The documentation https://xdem.readthedocs.io/en/stable/how_to_install.html, README.md and CONTRIBUTING.md have been updated with the `make install` command for contributors.

## Constraints
- GDAL is needed on the system to be installed on the virtual environment and run the tests.
- For now `richdem` is not stable enough to build a wheel on python > 3.10. For the moment, the `make install` command only works on python 3.10 and fails if this version is not installed on the system.