### PR TITLE
Add Initial shift Capability to DEM Coregistration

### DIFF
--- a/doc/source/api.md
+++ b/doc/source/api.md
@@ -231,6 +231,14 @@ To build and pass your coregistration pipeline to {func}`~xdem.DEM.coregister_3d
     coreg.Coreg.meta
 ```
 
+#### Quick coregistration
+```{eval-rst}
+.. autosummary::
+    :toctree: gen_modules/
+
+    coreg.workflows.dem_coregistration
+```
+
 ### Affine coregistration
 
 #### Parent object (to define custom methods)

--- a/doc/source/coregistration.md
+++ b/doc/source/coregistration.md
@@ -55,7 +55,8 @@ my_coreg_pipeline = xdem.coreg.ICP() + xdem.coreg.NuthKaab()
 my_coreg_pipeline = xdem.coreg.NuthKaab()
 ```
 
-Then, coregistering a pair of elevation data can be done by calling {func}`xdem.DEM.coregister_3d` from the DEM that should be aligned.
+Then, coregistering a pair of elevation data can be done by calling {func}`xdem.coreg.workflows.dem_coregistration`, or
+{func}`xdem.DEM.coregister_3d` from the DEM that should be aligned.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
@@ -66,10 +67,16 @@ Then, coregistering a pair of elevation data can be done by calling {func}`xdem.
 import geoutils as gu
 import numpy as np
 import matplotlib.pyplot as plt
+from xdem.coreg.workflows import dem_coregistration
 
 # Open a reference and to-be-aligned DEM
 ref_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
 tba_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
+```
+
+```{code-cell} ipython3
+# Coregister by calling the dem_coregistration function
+aligned_dem = dem_coregistration(tba_dem, ref_dem, coreg_method=my_coreg_pipeline)
 ```
 
 ```{code-cell} ipython3

--- a/tests/test_coreg/test_workflows.py
+++ b/tests/test_coreg/test_workflows.py
@@ -320,3 +320,19 @@ class TestWorkflows:
                 estimated_initial_shift=test_shift_tuple,
                 random_state=42,
             )
+
+        # Check if the appropriate exception is raised with a wrong type initial shift
+        with pytest.raises(ValueError, match=r".*two numerical values.*"):
+            dem_coregistration(
+                tba_dem,
+                ref_dem,
+                estimated_initial_shift=["2", 2],
+                random_state=42,
+            )
+        with pytest.raises(ValueError, match=r".*two numerical values.*"):
+            dem_coregistration(
+                tba_dem,
+                ref_dem,
+                estimated_initial_shift=[2, 3, 5],
+                random_state=42,
+            )

--- a/tests/test_coreg/test_workflows.py
+++ b/tests/test_coreg/test_workflows.py
@@ -256,9 +256,67 @@ class TestWorkflows:
         out_fig.close()
 
         # Testing different coreg method
-        dem_coreg, coreg_method, coreg_stats, inlier_mask = dem_coregistration(
+        dem_coreg2, coreg_method2, coreg_stats2, inlier_mask2 = dem_coregistration(
             tba_dem, ref_dem, coreg_method=xdem.coreg.Deramp()
         )
-        assert isinstance(coreg_method, xdem.coreg.Deramp)
-        assert abs(coreg_stats["med_orig"].values) > abs(coreg_stats["med_coreg"].values)
-        assert coreg_stats["nmad_orig"].values > coreg_stats["nmad_coreg"].values
+        assert isinstance(coreg_method2, xdem.coreg.Deramp)
+        assert abs(coreg_stats2["med_orig"].values) > abs(coreg_stats2["med_coreg"].values)
+        assert coreg_stats2["nmad_orig"].values > coreg_stats2["nmad_coreg"].values
+
+        # Testing with initial shift
+        test_shift_list = [10, 5]
+        tba_dem_origin = tba_dem.copy()
+        coreg_pipeline = xdem.coreg.affine.NuthKaab() + xdem.coreg.affine.VerticalShift()
+
+        dem_coreg2, coreg_method2, coreg_stats2, inlier_mask2 = dem_coregistration(
+            tba_dem, ref_dem, coreg_method=coreg_pipeline, estimated_initial_shift=test_shift_list, random_state=42
+        )
+        dem_coreg3, coreg_method3, coreg_stats3, inlier_mask3 = dem_coregistration(
+            tba_dem, ref_dem, coreg_method=coreg_pipeline, random_state=42
+        )
+        assert tba_dem.raster_equal(tba_dem_origin)
+        assert isinstance(coreg_method2, xdem.coreg.CoregPipeline)
+        assert isinstance(coreg_method3, xdem.coreg.CoregPipeline)
+        assert isinstance(coreg_method2.pipeline[0], xdem.coreg.AffineCoreg)
+        assert isinstance(coreg_method3.pipeline[0], xdem.coreg.AffineCoreg)
+        assert (
+            coreg_method2.pipeline[0].meta["outputs"]["affine"]["shift_x"]
+            == coreg_method3.pipeline[0].meta["outputs"]["affine"]["shift_x"]
+        )
+        assert (
+            coreg_method2.pipeline[0].meta["outputs"]["affine"]["shift_y"]
+            == coreg_method3.pipeline[0].meta["outputs"]["affine"]["shift_y"]
+        )
+
+        # Testing without coreg pipeline
+        test_shift_tuple = (-5, 2)  # tuple
+        coreg_simple = xdem.coreg.affine.DhMinimize()
+
+        dem_coreg2, coreg_method2, coreg_stats2, inlier_mask2 = dem_coregistration(
+            tba_dem, ref_dem, coreg_method=coreg_simple, estimated_initial_shift=test_shift_tuple, random_state=42
+        )
+        dem_coreg3, coreg_method3, coreg_stats3, inlier_mask3 = dem_coregistration(
+            tba_dem, ref_dem, coreg_method=coreg_simple, random_state=42
+        )
+        assert isinstance(coreg_method2, xdem.coreg.AffineCoreg)
+        assert isinstance(coreg_method3, xdem.coreg.AffineCoreg)
+        assert coreg_method2.meta["outputs"]["affine"]["shift_x"] == coreg_method3.meta["outputs"]["affine"]["shift_x"]
+        assert coreg_method2.meta["outputs"]["affine"]["shift_y"] == coreg_method3.meta["outputs"]["affine"]["shift_y"]
+
+        # Check if the appropriate exception is raised with an initial shift and without affine coreg
+        with pytest.raises(TypeError, match=r".*affine.*"):
+            dem_coregistration(
+                tba_dem,
+                ref_dem,
+                coreg_method=xdem.coreg.Deramp(),
+                estimated_initial_shift=test_shift_tuple,
+                random_state=42,
+            )
+        with pytest.raises(TypeError, match=r".*affine.*"):
+            dem_coregistration(
+                tba_dem,
+                ref_dem,
+                coreg_method=xdem.coreg.Deramp() + xdem.coreg.TerrainBias(),
+                estimated_initial_shift=test_shift_tuple,
+                random_state=42,
+            )

--- a/xdem/coreg/workflows.py
+++ b/xdem/coreg/workflows.py
@@ -227,6 +227,14 @@ coregistration and 4) the inlier_mask used.
 
     # Ensure that if an initial shift is provided, at least one coregistration method is affine.
     if estimated_initial_shift:
+        if not (
+            isinstance(estimated_initial_shift, (list, tuple))
+            and len(estimated_initial_shift) == 2
+            and all(isinstance(val, (float, int)) for val in estimated_initial_shift)
+        ):
+            raise ValueError(
+                "Argument `estimated_initial_shift` must be a list or tuple of exactly two numerical values."
+            )
         if isinstance(coreg_method, CoregPipeline):
             if not any(isinstance(step, AffineCoreg) for step in coreg_method.pipeline):
                 raise TypeError(


### PR DESCRIPTION
Resolves #603.

## Description:
This PR introduces the ability to specify an initial shift (in X and Y) for DEM co-registration. The key changes include the integration of an `estimated_initial_shift` parameter in the `dem_coregistration()` function, allowing users to apply a custom translation (affine-based) to the source DEM before coregistration.

## Key Modifications:
1. **`dem_coregistration()` function:**
   - A new `estimated_initial_shift` parameter is added, allowing users to input a list representing the initial shifts along the X and Y axes.
   - If a shift is provided, the source DEM is translated using `geoutils.translate()` based on the calculated pixel resolution.
   - The `shift_x` and `shift_y` values in the coregistration method’s metadata (`meta['outputs']['affine']`) are updated to include the initial shifts.

2. **Raise `TypeError`** if the coregistration method or one of the coregistration method in the coregistration pipeline is not affine when an initial shift is provided.

2. **Recursive Shift Update Logic:**
   - A recursive `update_shift()` function is implemented to handle both `Coreg` and `CoregPipeline` objects, ensuring that the shift is propagated across all coregistration steps in a pipeline.
   - Metadata handling ensures shifts are correctly updated in all pipeline steps and for standalone `Coreg` objects.

3. **Unit Tests:**
   - Added a test to verify the correct behavior of the `estimated_initial_shift` parameter.
   - Added a test to ensure `TypeError` is raised an initial shift is provided and the coregistration method is not affine.

## How It Works:
- The `estimated_initial_shift` input, given as a list `[x_shift, y_shift]`, is multiplied by the DEM’s pixel resolution to calculate the translation in map units.
- This shift is then applied before coregistration, and the resulting `shift_x` and `shift_y` in the `meta` are updated accordingly.
- For `CoregPipeline`, this process is repeated for each coregistration step to ensure consistency.

## Example:
```python
dem_coregistration(
    src_dem_path="path/to/src_dem.tif",
    ref_dem_path="path/to/ref_dem.tif",
    estimated_initial_shift=[10, 5]
)
```
In this case, the source DEM is initially translated by 10 pixels in the X direction and 5 pixels in the Y direction before the coregistration process begins.

## Documentation
- Updated the function docstring to reflect the new `estimated_initial_shift` parameter and its usage.
- Update API documentation.


