### PR TITLE
Deprecate Mambaforge for Miniforge in CI

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Initiate empty environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           auto-update-conda: true
           use-mamba: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,6 @@ jobs:
     - name: Initiate empty environment
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Miniforge
         miniforge-version: latest
         auto-update-conda: true
         use-mamba: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Initiate empty environment
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge
         miniforge-version: latest
         auto-update-conda: true
         use-mamba: true


### PR DESCRIPTION
Their slow "sunsetting" procedure was making CI fail once every 10 days on purpose: https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/.