### PR TITLE
[WIP] Implement linting with Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,58 +30,39 @@ repos:
           hooks:
                 - id: absolufy-imports
 
-        # Format the code aggressively using black
-        - repo: https://github.com/psf/black
-          rev: 24.10.0
+        # Ruff linter and code formatter
+        - repo: https://github.com/astral-sh/ruff-pre-commit
+          # Ruff version.
+          rev: v0.8.6
           hooks:
-                  - id: black
-                    args: [--line-length=120]
+            # Run the linter.
+            - id: ruff
+            # Run the formatter.
+            - id: ruff-format
 
-        # Lint the code using flake8
-        - repo: https://github.com/pycqa/flake8
-          rev: 7.1.1
+        # Enable lint fixes with ruff
+        - repo: https://github.com/astral-sh/ruff-pre-commit
+          # Ruff version.
+          rev: v0.8.6
           hooks:
-                - id: flake8
-                  # More than one argument in the second list, so need to pass arguments as below (and -- to finish)
-                  args: [
-                          '--max-line-length', '120',  # we can write dicts however we want
-                          '--extend-ignore', 'E203,C408,B028', # flake8 disagrees with black, so this should be ignored.
-                          '--'
-                  ]
-                  additional_dependencies:
-                          - flake8-comprehensions
-                          - flake8-bugbear
-                  files: ^(xdem|tests)
+            # Run the linter.
+            - id: ruff
+              args: [ --fix ]
+            # Run the formatter.
+            - id: ruff-format
 
-        # Lint the code using mypy
-        - repo: https://github.com/pre-commit/mirrors-mypy
-          rev: v1.13.0
+        # To run ruff over Jupyter Notebooks
+        - repo: https://github.com/astral-sh/ruff-pre-commit
+          # Ruff version.
+          rev: v0.8.6
           hooks:
-                - id: mypy
-                  args: [
-                        --config-file=mypy.ini,
-                        --strict,
-                        --implicit-optional,
-                        --ignore-missing-imports,  # Don't warn about stubs since pre-commit runs in a limited env
-                        --allow-untyped-calls,  # Dynamic function/method calls are okay. Untyped function definitions are not okay.
-                        --show-error-codes,
-                        --no-warn-unused-ignores,  # Ignore 'type: ignore' comments that are not used.
-                        --disable-error-code=attr-defined,  # "Module has no attribute 'XXX'" occurs because of the pre-commit env.
-                        --disable-error-code=name-defined,  # "Name 'XXX' is not defined" occurs because of the pre-commit env.
-                        --disable-error-code=var-annotated,
-                        --disable-error-code=no-any-return
-
-                  ]
-                  additional_dependencies: [tokenize-rt==3.2.0, numpy==1.26]
-                  files: ^(xdem|tests|doc/code)
-
-
-        # Sort imports using isort
-        - repo: https://github.com/PyCQA/isort
-          rev: 5.13.2
-          hooks:
-                  - id: isort
-                    args: ["--profile", "black"]
+            # Run the linter.
+            - id: ruff
+              types_or: [ python, pyi, jupyter ]
+              args: [ --fix ]
+            # Run the formatter.
+            - id: ruff-format
+              types_or: [ python, pyi, jupyter ]
 
         # Automatically upgrade syntax to a minimum version
         - repo: https://github.com/asottile/pyupgrade

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,83 @@
+# Exclude a variety of commonly ignored directories.
+exclude = ["ALL"]
+
+extend-exclude = [
+    ".github",
+    "binder",
+    "doc",
+    "xdem.egg-info",
+    ".coveragerc",
+    ".gitignore",
+    ".pre-commit-config.yaml",
+    ".readthedocs.yaml",
+    ".relint.yml",
+]
+
+# Support Python 3.10+.
+target-version = "py310"
+
+# Same as Black.
+# The formatter wraps lines at a length of 120 when enforcing long-lines violations (like E501).
+line-length = 120
+# Number of spaces per tabulation, used by the formatter and when enforcing long-line violations.
+indent-width = 4
+
+[lint.pycodestyle]
+# E501 reports lines that exceed the length of 120.
+max-line-length = 120
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default (10).
+select = ["ALL"]
+
+# Skip To do format annotations rules (FIX002, TD002, TD003)
+# Skip pydocstyle rules (D101, D205, D400, D401, D415)
+# Skip flake8-simplify rules (SIM102, SIM108, SIM115)
+# Skip pygrep-hooks rules (PGH003, PGH004)
+# Skip pylint refactor rules (PLR0912, PLR0913, PLR0915, PLR2004)
+# Skip the use of assert (S101)
+# Skip flake8-type-checking rules (TC001, TC002, TC003)
+# Skip tryceratops rules (TRY003, TRY201)
+# Skip pyupgrade rule : non-pep604-isinstance (UP038)
+# ...
+ignore = ["ANN401", "ARG002", "B028", "B904", "BLE001", "C901", "D101", "D205", "D400", "D401", "D415", "EM101",
+          "EM102", "ERA001", "F541", "FBT001", "FBT002", "FBT003", "FIX002", "INP001", "PD011", "PGH003", "PGH004",
+          "PLR0912", "PLR0913", "PLR0915", "PLR2004", "PLW0127", "PT011", "PTH118", "PYI041", "PYI051", "RET504",
+          "S101", "SIM102", "SIM108", "SIM115", "T201", "TC001", "TC002", "TC003", "TD002", "TD003", "TRY003",
+          "TRY201", "UP038"]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = false
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = "dynamic"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 ############### GLOBAL VARIABLES ######################
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
-PATH :=.
 
 # Virtualenv directory name (can be overridden)
 ifndef VENV
@@ -101,7 +100,7 @@ ruff: ## Apply ruff.
 	@echo "Applying ruff..."
 	@echo "================"
 	@echo
-	@ruff --fix $(path)
+	@ruff --fix $(PATH)
 
 ## Clean section
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 ############### GLOBAL VARIABLES ######################
 .DEFAULT_GOAL := help
 SHELL := /bin/bash
+PATH :=.
 
 # Virtualenv directory name (can be overridden)
 ifndef VENV
@@ -81,6 +82,26 @@ test: ## run tests
 	else \
 		${VENV}/bin/pytest; \
 	fi
+
+## Code quality, linting section
+
+.PHONY: lint
+lint: ruff	## Apply the ruff linter.
+
+.PHONY: lint-check
+lint-check:  ## Check whether the codebase satisfies the linter rules.
+	@echo
+	@echo "Checking linter rules..."
+	@echo "========================"
+	@echo
+	@ruff check $(PATH)
+
+.PHONY: ruff
+ruff: ## Apply ruff.
+	@echo "Applying ruff..."
+	@echo "================"
+	@echo
+	@ruff --fix $(path)
 
 ## Clean section
 

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 xDEM developers
+# Copyright (c) 2024 Centre National d'Etudes Spatiales (CNES).
 #
 # This file is part of the xDEM project:
 # https://github.com/glaciohack/xdem
@@ -15,24 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
-
-import sys
-from typing import Any
-
-import numpy as np
-
-# Only for Python >= 3.9
-if sys.version_info.minor >= (3, 9):
-
-    from numpy.typing import NDArray  # this syntax works starting on Python 3.9
-
-    NDArrayf = NDArray[np.floating[Any]]
-    NDArrayb = NDArray[np.bool_]
-    MArrayf = np.ma.masked_array[Any, np.dtype[np.floating[Any]]]
-
-else:
-    NDArrayf = np.ndarray  # type: ignore
-    NDArrayb = np.ndarray  # type: ignore
-    MArrayf = np.ma.masked_array  # type: ignore
+"""xDEM examples module init file."""

--- a/examples/advanced/__init__.py
+++ b/examples/advanced/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 xDEM developers
+# Copyright (c) 2024 Centre National d'Etudes Spatiales (CNES).
 #
 # This file is part of the xDEM project:
 # https://github.com/glaciohack/xdem
@@ -15,24 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
-
-import sys
-from typing import Any
-
-import numpy as np
-
-# Only for Python >= 3.9
-if sys.version_info.minor >= (3, 9):
-
-    from numpy.typing import NDArray  # this syntax works starting on Python 3.9
-
-    NDArrayf = NDArray[np.floating[Any]]
-    NDArrayb = NDArray[np.bool_]
-    MArrayf = np.ma.masked_array[Any, np.dtype[np.floating[Any]]]
-
-else:
-    NDArrayf = np.ndarray  # type: ignore
-    NDArrayb = np.ndarray  # type: ignore
-    MArrayf = np.ma.masked_array  # type: ignore
+"""xDEM advanced examples module init file."""

--- a/examples/advanced/__init__.py
+++ b/examples/advanced/__init__.py
@@ -15,4 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""xDEM advanced examples module init file."""
+""" """ # noqa

--- a/examples/advanced/plot_blockwise_coreg.py
+++ b/examples/advanced/plot_blockwise_coreg.py
@@ -1,11 +1,12 @@
-"""
-Blockwise coregistration
+"""Blockwise coregistration
 ========================
 
 Often, biases are spatially variable, and a "global" shift may not be enough to coregister a DEM properly.
-In the :ref:`sphx_glr_basic_examples_plot_nuth_kaab.py` example, we saw that the method improved the alignment significantly, but there were still possibly nonlinear artefacts in the result.
+In the :ref:`sphx_glr_basic_examples_plot_nuth_kaab.py` example, we saw that the method improved the alignment
+significantly, but there were still possibly nonlinear artefacts in the result.
 Clearly, nonlinear coregistration approaches are needed.
-One solution is :class:`xdem.coreg.BlockwiseCoreg`, a helper to run any ``Coreg`` class over an arbitrarily small grid, and then "puppet warp" the DEM to fit the reference best.
+One solution is :class:`xdem.coreg.BlockwiseCoreg`, a helper to run any ``Coreg`` class over an arbitrarily small grid,
+and then "puppet warp" the DEM to fit the reference best.
 
 The ``BlockwiseCoreg`` class runs in five steps:
 
@@ -43,7 +44,8 @@ plt_extent = [
 ]
 
 # %%
-# The DEM to be aligned (a 1990 photogrammetry-derived DEM) has some vertical and horizontal biases that we want to avoid, as well as possible nonlinear distortions.
+# The DEM to be aligned (a 1990 photogrammetry-derived DEM) has some vertical and horizontal biases that we want to
+# avoid, as well as possible nonlinear distortions.
 # The product is a mosaic of multiple DEMs, so "seams" may exist in the data.
 # These can be visualized by plotting a change map:
 
@@ -75,11 +77,12 @@ aligned_dem = blockwise.fit_and_apply(reference_dem, dem_to_be_aligned, inlier_m
 
 # %%
 # The estimated shifts can be visualized by applying the coregistration to a completely flat surface.
-# This shows the estimated shifts that would be applied in elevation; additional horizontal shifts will also be applied if the method supports it.
+# This shows the estimated shifts that would be applied in elevation; additional horizontal shifts will also be applied
+# if the method supports it.
 # The :func:`xdem.coreg.BlockwiseCoreg.stats` method can be used to annotate each block with its associated Z shift.
 
 z_correction = blockwise.apply(
-    np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform, crs=dem_to_be_aligned.crs
+    np.zeros_like(dem_to_be_aligned.data), transform=dem_to_be_aligned.transform, crs=dem_to_be_aligned.crs,
 )[0]
 plt.title("Vertical correction")
 plt.imshow(z_correction, cmap="RdYlBu", vmin=-10, vmax=10, extent=plt_extent)

--- a/examples/advanced/plot_demcollection.py
+++ b/examples/advanced/plot_demcollection.py
@@ -1,16 +1,17 @@
-"""
-Working with a collection of DEMs
+"""Working with a collection of DEMs
 =================================
 
 .. caution:: This functionality might be removed in future package versions.
 
 Oftentimes, more than two timestamps (DEMs) are analyzed simultaneously.
 One single dDEM only captures one interval, so multiple dDEMs have to be created.
-In addition, if multiple masking polygons exist (e.g. glacier outlines from multiple years), these should be accounted for properly.
-The :class:`xdem.DEMCollection` is a tool to properly work with multiple timestamps at the same time, and makes calculations of elevation/volume change over multiple years easy.
+In addition, if multiple masking polygons exist (e.g. glacier outlines from multiple years),
+these should be accounted for properly.
+The :class:`xdem.DEMCollection` is a tool to properly work with multiple timestamps at the same time, and makes
+calculations of elevation/volume change over multiple years easy.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 import geoutils as gu
 import matplotlib.pyplot as plt
@@ -32,8 +33,12 @@ dem_1990 = xdem.DEM(xdem.examples.get_path("longyearbyen_tba_dem"))
 # These parts can be delineated with masks or polygons.
 # Here, we have glacier outlines from 1990 and 2009.
 outlines = {
-    datetime(1990, 8, 1): gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines")),
-    datetime(2009, 8, 1): gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines_2010")),
+    datetime(1990, 8, 1, tzinfo=timezone.utc): gu.Vector(
+        xdem.examples.get_path("longyearbyen_glacier_outlines"),
+    ),
+    datetime(2009, 8, 1, tzinfo=timezone.utc): gu.Vector(
+        xdem.examples.get_path("longyearbyen_glacier_outlines_2010"),
+    ),
 }
 
 # %%
@@ -42,7 +47,9 @@ outlines = {
 # Fake a 2060 DEM by assuming twice the change from 1990-2009 between 2009 and 2060
 dem_2060 = dem_2009 + (dem_2009 - dem_1990).data * 3
 
-timestamps = [datetime(1990, 8, 1), datetime(2009, 8, 1), datetime(2060, 8, 1)]
+timestamps = [datetime(1990, 8, 1, tzinfo=timezone.utc),
+              datetime(2009, 8, 1, tzinfo=timezone.utc),
+              datetime(2060, 8, 1, tzinfo=timezone.utc)]
 
 # %%
 # Now, all data are ready to be collected in an :class:`xdem.DEMCollection` object.
@@ -52,7 +59,7 @@ timestamps = [datetime(1990, 8, 1), datetime(2009, 8, 1), datetime(2060, 8, 1)]
 #
 
 demcollection = xdem.DEMCollection(
-    dems=[dem_1990, dem_2009, dem_2060], timestamps=timestamps, outlines=outlines, reference_dem=1
+    dems=[dem_1990, dem_2009, dem_2060], timestamps=timestamps, outlines=outlines, reference_dem=1,
 )
 
 # %%
@@ -69,9 +76,11 @@ _ = demcollection.subtract_dems()
 # These are saved internally, but are also returned as a list.
 #
 # An elevation or volume change series can automatically be generated from the ``DEMCollection``.
-# In this case, we should specify *which* glacier we want the change for, as a regional value may not always be required.
+# In this case, we should specify *which* glacier we want the change for,
+# as a regional value may not always be required.
 # We can look at the glacier called "Scott Turnerbreen", specified in the "NAME" column of the outline data.
-# `See here for the outline filtering syntax <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html>`_.
+# `See here for the outline filtering syntax
+# <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.query.html>`_.
 
 demcollection.get_cumulative_series(kind="dh", outlines_filter="NAME == 'Scott Turnerbreen'")
 

--- a/examples/advanced/plot_deramp.py
+++ b/examples/advanced/plot_deramp.py
@@ -1,5 +1,4 @@
-"""
-Bias-correction with deramping
+"""Bias-correction with deramping
 ==============================
 
 Deramping can help correct rotational or doming errors in elevation data.

--- a/examples/advanced/plot_norm_regional_hypso.py
+++ b/examples/advanced/plot_norm_regional_hypso.py
@@ -1,18 +1,21 @@
-"""
-Normalized regional hypsometric interpolation
+"""Normalized regional hypsometric interpolation
 =============================================
 
 .. caution:: This functionality is specific to glaciers, and might be removed in future package versions.
 
 There are many ways of interpolating gaps in elevation differences.
 In the case of glaciers, one very useful fact is that elevation change generally varies with elevation.
-This means that if valid pixels exist in a certain elevation bin, their values can be used to fill other pixels in the same approximate elevation.
-Filling gaps by elevation is the main basis of "hypsometric interpolation approaches", of which there are many variations of.
+This means that if valid pixels exist in a certain elevation bin,
+their values can be used to fill other pixels in the same approximate elevation.
+Filling gaps by elevation is the main basis of "hypsometric interpolation approaches",
+of which there are many variations of.
 
-One problem with simple hypsometric approaches is that they may not work for glaciers with different elevation ranges and scales.
+One problem with simple hypsometric approaches is that they may not work for glaciers
+with different elevation ranges and scales.
 Let's say we have two glaciers: one gigantic reaching from 0-1000 m, and one small from 900-1100 m.
 Usually in the 2000s, glaciers thin rapidly at the bottom, while they may be neutral or only thin slightly in the top.
-If we extrapolate the hypsometric signal of the gigantic glacier to use on the small one, it may seem like the smaller glacier has almost no change whatsoever.
+If we extrapolate the hypsometric signal of the gigantic glacier to use on the small one,
+it may seem like the smaller glacier has almost no change whatsoever.
 This may be right, or it may be catastrophically wrong!
 
 Normalized regional hypsometric interpolation solves the scale and elevation range problems in one go. It:
@@ -69,8 +72,10 @@ random_nans.plot()
 # %%
 # The normalized hypsometric signal shows the tendency for elevation change as a function of elevation.
 # The magnitude may vary between glaciers, but the shape is generally similar.
-# Normalizing by both elevation and elevation change, and then re-scaling the signal to every glacier, ensures that it is as accurate as possible.
-# **NOTE**: The hypsometric signal does not need to be generated separately; it will be created by :func:`xdem.volume.norm_regional_hypsometric_interpolation`.
+# Normalizing by both elevation and elevation change, and then re-scaling the signal to every glacier,
+# ensures that it is as accurate as possible.
+# **NOTE**: The hypsometric signal does not need to be generated separately;
+# it will be created by :func:`xdem.volume.norm_regional_hypsometric_interpolation`.
 # Generating it first, however, allows us to visualize and validate it.
 
 ddem = dem_2009 - dem_1990
@@ -93,7 +98,7 @@ plt.show()
 # The signal can now be used (or simply estimated again if not provided) to interpolate the DEM.
 
 ddem_filled = xdem.volume.norm_regional_hypsometric_interpolation(
-    voided_ddem=ddem_voided, ref_dem=dem_2009, glacier_index_map=glacier_index_map, regional_signal=signal
+    voided_ddem=ddem_voided, ref_dem=dem_2009, glacier_index_map=glacier_index_map, regional_signal=signal,
 )
 
 
@@ -115,5 +120,6 @@ plt.show()
 
 # %%
 # As we see, the median is close to zero, while the NMAD varies slightly more.
-# This is expected, as the regional signal is good for multiple glaciers at once, but it cannot account for difficult local topography and meteorological conditions.
+# This is expected, as the regional signal is good for multiple glaciers at once,
+# but it cannot account for difficult local topography and meteorological conditions.
 # It is therefore highly recommended for large regions; just don't zoom in too close!

--- a/examples/advanced/plot_slope_methods.py
+++ b/examples/advanced/plot_slope_methods.py
@@ -1,5 +1,4 @@
-"""
-Slope and aspect methods
+"""Slope and aspect methods
 ========================
 
 Terrain slope and aspect can be estimated using different methods.
@@ -7,11 +6,13 @@ Here is an example of how to generate the two with each method, and understand t
 
 See also the :ref:`terrain-attributes` feature page.
 
-**References:** `Horn (1981) <https://ieeexplore.ieee.org/document/1456186>`_, `Zevenbergen and Thorne (1987) <http://dx.doi.org/10.1002/esp.3290120107>`_.
+**References:** `Horn (1981) <https://ieeexplore.ieee.org/document/1456186>`_,
+ `Zevenbergen and Thorne (1987) <http://dx.doi.org/10.1002/esp.3290120107>`_.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
+from geoutils.raster import RasterType
 
 import xdem
 
@@ -20,8 +21,28 @@ import xdem
 dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
 
 
-def plot_attribute(attribute, cmap, label=None, vlim=None):
+def plot_attribute(attribute: RasterType,
+                   cmap: str,
+                   label: str | None = None,
+                   vlim: float | None = None) -> None:
+    """Plot a specified attribute.
 
+    Parameters
+    ----------
+    attribute : RasterType
+        Attribute to plot.
+    cmap : str
+        Colorbar used from matplotlib.
+    label : str
+        Colorbar title.
+    vlim : float
+        Colorbar upper and lower limits.
+
+    Returns
+    -------
+    None
+
+    """
     if vlim is not None:
         if isinstance(vlim, (int, np.integer, float, np.floating)):
             vlims = {"vmin": -vlim, "vmax": vlim}
@@ -37,7 +58,6 @@ def plot_attribute(attribute, cmap, label=None, vlim=None):
     plt.tight_layout()
 
     plt.show()
-
 
 # %%
 # Slope with method of Horn (1981) (GDAL default), based on a refined
@@ -59,7 +79,9 @@ plot_attribute(slope_zevenberg, "Reds", "Slope of Zevenberg and Thorne (1987) (�
 
 diff_slope = slope_horn - slope_zevenberg
 
-plot_attribute(diff_slope, "RdYlBu", "Slope of Horn (1981) minus\n slope of Zevenberg and Thorne (1987) (째)", vlim=3)
+plot_attribute(diff_slope,
+               "RdYlBu",
+               "Slope of Horn (1981) minus\n slope of Zevenberg and Thorne (1987) (째)", vlim=3)
 
 # %%
 # The differences are negative, implying that the method of Horn always provides flatter slopes.
@@ -86,7 +108,7 @@ xdem.spatialstats.plot_1d_binning(
     var_name="maxc",
     statistic_name="nanmedian",
     label_var="Maximum absolute curvature (100 m$^{-1}$)",
-    label_statistic="Slope of Horn (1981) minus\n " "slope of Zevenberg and Thorne (1987) (째)",
+    label_statistic="Slope of Horn (1981) minus\n slope of Zevenberg and Thorne (1987) (째)",
 )
 
 
@@ -101,7 +123,9 @@ diff_aspect = aspect_horn - aspect_zevenberg
 diff_aspect_mod = np.minimum(diff_aspect % 360, 360 - diff_aspect % 360)
 
 plot_attribute(
-    diff_aspect_mod, "Spectral", "Aspect of Horn (1981) minus\n aspect of Zevenberg and Thorne (1987) (째)", vlim=[0, 90]
+    diff_aspect_mod,
+    "Spectral",
+    "Aspect of Horn (1981) minus\n aspect of Zevenberg and Thorne (1987) (째)", vlim=[0, 90],
 )
 
 # %%

--- a/examples/advanced/plot_standardization.py
+++ b/examples/advanced/plot_standardization.py
@@ -1,5 +1,4 @@
-"""
-Standardization for stable terrain as error proxy
+"""Standardization for stable terrain as error proxy
 =================================================
 
 Digital elevation models have both a precision that can vary with terrain or instrument-related variables, and
@@ -24,7 +23,8 @@ import xdem
 from xdem.spatialstats import nmad
 
 # %%
-# We start by estimating the elevation heteroscedasticity and deriving a terrain-dependent measurement error as a function of both
+# We start by estimating the elevation heteroscedasticity and
+# deriving a terrain-dependent measurement error as a function of both
 # slope and maximum curvature, as shown in the :ref:`sphx_glr_basic_examples_plot_infer_heterosc.py` example.
 
 # Load the data
@@ -35,7 +35,7 @@ mask_glacier = glacier_outlines.create_mask(dh)
 
 # Compute the slope and maximum curvature
 slope, planc, profc = xdem.terrain.get_terrain_attribute(
-    dem=ref_dem, attribute=["slope", "planform_curvature", "profile_curvature"]
+    dem=ref_dem, attribute=["slope", "planform_curvature", "profile_curvature"],
 )
 
 # Remove values on unstable terrain
@@ -55,8 +55,8 @@ custom_bin_slope = np.unique(
             np.nanquantile(slope_arr, np.linspace(0, 0.95, 20)),
             np.nanquantile(slope_arr, np.linspace(0.96, 0.99, 5)),
             np.nanquantile(slope_arr, np.linspace(0.991, 1, 10)),
-        ]
-    )
+        ],
+    ),
 )
 
 custom_bin_curvature = np.unique(
@@ -65,12 +65,12 @@ custom_bin_curvature = np.unique(
             np.nanquantile(maxc_arr, np.linspace(0, 0.95, 20)),
             np.nanquantile(maxc_arr, np.linspace(0.96, 0.99, 5)),
             np.nanquantile(maxc_arr, np.linspace(0.991, 1, 10)),
-        ]
-    )
+        ],
+    ),
 )
 
 # Perform 2D binning to estimate the measurement error with slope and maximum curvature
-df = xdem.spatialstats.nd_binning(
+df_bin = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[slope_arr, maxc_arr],
     list_var_names=["slope", "maxc"],
@@ -80,7 +80,7 @@ df = xdem.spatialstats.nd_binning(
 
 # Estimate an interpolant of the measurement error with slope and maximum curvature
 slope_curv_to_dh_err = xdem.spatialstats.interp_nd_binning(
-    df, list_var_names=["slope", "maxc"], statistic="nmad", min_count=30
+    df_bin, list_var_names=["slope", "maxc"], statistic="nmad", min_count=30,
 )
 maxc = np.maximum(np.abs(profc), np.abs(planc))
 
@@ -122,7 +122,8 @@ plt.legend(loc="lower right")
 plt.show()
 
 # %%
-# Now, we can perform an analysis of spatial correlation as shown in the :ref:`sphx_glr_advanced_examples_plot_variogram_estimation_modelling.py`
+# Now, we can perform an analysis of spatial correlation as shown in the
+# :ref:`sphx_glr_advanced_examples_plot_variogram_estimation_modelling.py`
 # example, by estimating a variogram and fitting a sum of two models.
 # Dowd's variogram is used for robustness in conjunction with the NMAD (see :ref:`robuststats-corr`).
 df_vgm = xdem.spatialstats.sample_empirical_variogram(
@@ -135,7 +136,7 @@ df_vgm = xdem.spatialstats.sample_empirical_variogram(
 )
 
 func_sum_vgm, params_vgm = xdem.spatialstats.fit_sum_model_variogram(
-    ["Gaussian", "Spherical"], empirical_variogram=df_vgm
+    ["Gaussian", "Spherical"], empirical_variogram=df_vgm,
 )
 xdem.spatialstats.plot_variogram(
     df_vgm,
@@ -189,11 +190,11 @@ print(f"Average maximum curvature of Medalsbreen glacier : {np.nanmean(maxc[meda
 # %%
 # We calculate the number of effective samples for each glacier based on the variogram
 svendsen_neff = xdem.spatialstats.neff_circular_approx_numerical(
-    area=svendsen_shp.ds.area.values[0], params_variogram_model=params_vgm
+    area=svendsen_shp.ds.area.values[0], params_variogram_model=params_vgm,
 )
 
 medals_neff = xdem.spatialstats.neff_circular_approx_numerical(
-    area=medals_shp.ds.area.values[0], params_variogram_model=params_vgm
+    area=medals_shp.ds.area.values[0], params_variogram_model=params_vgm,
 )
 
 print(f"Number of effective samples of Svendsenbreen glacier: {svendsen_neff:.1f}")
@@ -255,5 +256,6 @@ plt.show()
 # %%
 # Because of slightly higher slopes and curvatures, the final uncertainty for Medalsbreen is larger by about 10%.
 # The differences between the mean terrain slope and curvatures of stable terrain and those of glaciers is quite limited
-# on Svalbard. In high moutain terrain, such as the Alps or Himalayas, the difference between stable terrain and glaciers,
+# on Svalbard. In high moutain terrain, such as the Alps or Himalayas,
+# the difference between stable terrain and glaciers,
 # and among glaciers, would be much larger.

--- a/examples/basic/__init__.py
+++ b/examples/basic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 xDEM developers
+# Copyright (c) 2024 Centre National d'Etudes Spatiales (CNES).
 #
 # This file is part of the xDEM project:
 # https://github.com/glaciohack/xdem
@@ -15,24 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
-
-import sys
-from typing import Any
-
-import numpy as np
-
-# Only for Python >= 3.9
-if sys.version_info.minor >= (3, 9):
-
-    from numpy.typing import NDArray  # this syntax works starting on Python 3.9
-
-    NDArrayf = NDArray[np.floating[Any]]
-    NDArrayb = NDArray[np.bool_]
-    MArrayf = np.ma.masked_array[Any, np.dtype[np.floating[Any]]]
-
-else:
-    NDArrayf = np.ndarray  # type: ignore
-    NDArrayb = np.ndarray  # type: ignore
-    MArrayf = np.ma.masked_array  # type: ignore
+"""xDEM basic examples module init file."""

--- a/examples/basic/plot_dem_subtraction.py
+++ b/examples/basic/plot_dem_subtraction.py
@@ -1,13 +1,15 @@
-"""
-DEM differencing
+"""DEM differencing
 ================
 
 Subtracting a DEM with another one should be easy.
 
-xDEM allows to use any operator on :class:`xdem.DEM` objects, such as :func:`+<operator.add>` or :func:`-<operator.sub>` as well as most NumPy functions
-while respecting nodata values and checking that georeferencing is consistent. This functionality is inherited from `GeoUtils' Raster class <https://geoutils.readthedocs.io>`_.
+xDEM allows to use any operator on :class:`xdem.DEM` objects, such as :func:`+<operator.add>` or
+:func:`-<operator.sub>` as well as most NumPy functions
+while respecting nodata values and checking that georeferencing is consistent.
+ This functionality is inherited from `GeoUtils' Raster class <https://geoutils.readthedocs.io>`_.
 
-Before DEMs can be compared, they need to be reprojected to the same grid and have the same 3D CRSs. The :func:`~xdem.DEM.reproject` and :func:`~xdem.DEM.to_vcrs` methods are used for this.
+Before DEMs can be compared, they need to be reprojected to the same grid and have the same 3D CRSs.
+ The :func:`~xdem.DEM.reproject` and :func:`~xdem.DEM.to_vcrs` methods are used for this.
 
 """
 
@@ -28,7 +30,8 @@ dem_2009.info()
 dem_1990.info()
 
 # %%
-# In this particular case, the two DEMs are already on the same grid (they have the same bounds, resolution and coordinate system).
+# In this particular case, the two DEMs are already on the same grid
+# (they have the same bounds, resolution and coordinate system).
 # If they don't, we need to reproject one DEM to fit the other using :func:`xdem.DEM.reproject`:
 
 dem_1990 = dem_1990.reproject(dem_2009)
@@ -37,9 +40,12 @@ dem_1990 = dem_1990.reproject(dem_2009)
 # Oops!
 # GeoUtils just warned us that ``dem_1990`` did not need reprojection. We can hide this output with ``silent``.
 # By default, :func:`~xdem.DEM.reproject` uses "bilinear" resampling (assuming resampling is needed).
-# Other options are detailed at `geoutils.Raster.reproject() <https://geoutils.readthedocs.io/en/latest/api.html#geoutils.raster.Raster.reproject>`_ and `rasterio.enums.Resampling <https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html#rasterio.enums.Resampling>`_.
+# Other options are detailed at
+# `geoutils.Raster.reproject() <https://geoutils.readthedocs.io/en/latest/api.html#geoutils.raster.Raster.reproject>`_
+# and `rasterio.enums.Resampling <https://rasterio.readthedocs.io/en/latest/api/rasterio.enums.html#rasterio.enums.Resampling>`_. # noqa: E501
 #
-# We now compute the difference by simply substracting, passing ``stats=True`` to :func:`xdem.DEM.info` to print statistics.
+# We now compute the difference by simply substracting,
+# passing ``stats=True`` to :func:`xdem.DEM.info` to print statistics.
 
 ddem = dem_2009 - dem_1990
 

--- a/examples/basic/plot_icp_coregistration.py
+++ b/examples/basic/plot_icp_coregistration.py
@@ -1,5 +1,4 @@
-"""
-Iterative closest point coregistration
+"""Iterative closest point coregistration
 ======================================
 
 Iterative closest point (ICP) is a registration method accounting for both rotations and translations.
@@ -32,7 +31,8 @@ xdem.terrain.hillshade(dem).plot(cmap="gray")
 # %%
 # To try the effects of rotation, we can artificially rotate the DEM using a transformation matrix.
 # Here, a rotation of just one degree is attempted.
-# But keep in mind: the window is 6 km wide; 1 degree of rotation at the center equals to a 52 m vertical difference at the edges!
+# But keep in mind: the window is 6 km wide; 1 degree of rotation at the center equals
+# to a 52 m vertical difference at the edges!
 
 rotation = np.deg2rad(1)
 rotation_matrix = np.array(
@@ -41,7 +41,7 @@ rotation_matrix = np.array(
         [0, 1, 0, 0],
         [-np.sin(rotation), 0, np.cos(rotation), 0],
         [0, 0, 0, 1],
-    ]
+    ],
 )
 centroid = [dem.bounds.left + dem.width / 2, dem.bounds.bottom + dem.height / 2, np.nanmean(dem)]
 # This will apply the matrix along the center of the DEM
@@ -90,7 +90,8 @@ plt.show()
 # %%
 # The results show what we expected:
 #
-# - **ICP** alone handled the rotational offset, but left a horizontal offset as it is not sub-pixel accurate (in this case, the resolution is 20x20m).
+# - **ICP** alone handled the rotational offset, but left a horizontal offset as it is not sub-pixel accurate
+# (in this case, the resolution is 20x20m).
 # - **Nuth and Kääb** barely helped at all, since the offset is purely rotational.
 # - **ICP + Nuth and Kääb** first handled the rotation, then fit the reference with sub-pixel accuracy.
 #

--- a/examples/basic/plot_infer_heterosc.py
+++ b/examples/basic/plot_infer_heterosc.py
@@ -1,5 +1,4 @@
-"""
-Elevation error map
+"""Elevation error map
 ===================
 
 Digital elevation models have a precision that can vary with terrain and instrument-related variables. Here, we
@@ -30,7 +29,7 @@ slope, maximum_curvature = xdem.terrain.get_terrain_attribute(ref_dem, attribute
 # %%
 # Then, we run the pipeline for inference of elevation heteroscedasticity from stable terrain:
 errors, df_binning, error_function = xdem.spatialstats.infer_heteroscedasticity_from_stable(
-    dvalues=dh, list_var=[slope, maximum_curvature], list_var_names=["slope", "maxc"], unstable_mask=glacier_outlines
+    dvalues=dh, list_var=[slope, maximum_curvature], list_var_names=["slope", "maxc"], unstable_mask=glacier_outlines,
 )
 
 # %%
@@ -39,19 +38,20 @@ errors.plot(vmin=2, vmax=7, cmap="Reds", cbar_title=r"Elevation error (1$\sigma$
 
 # %%
 # The second output is the dataframe of 2D binning with slope and maximum curvature:
-df_binning
+print(df_binning)
 
 # %%
 # The third output is the 2D binning interpolant, i.e. an error function with the slope and maximum curvature
 # (*Note: below we divide the maximum curvature by 100 to convert it in* m\ :sup:`-1` ):
 for slope, maxc in [(0, 0), (40, 0), (0, 5), (40, 5)]:
     print(
-        "Error for a slope of {:.0f} degrees and"
-        " {:.2f} m-1 max. curvature: {:.1f} m".format(slope, maxc / 100, error_function((slope, maxc)))
+        f"Error for a slope of {slope:.0f} degrees and"
+        f" {maxc / 100:.2f} m-1 max. curvature: {error_function((slope, maxc)):.1f} m",
     )
 
 # %%
 # This pipeline will not always work optimally with default parameters: spread estimates can be affected by skewed
 # distributions, the binning by extreme range of values, some DEMs do not have any error variability with terrain (e.g.,
-# terrestrial photogrammetry). **To learn how to tune more parameters and use the subfunctions, see the gallery example:**
+# terrestrial photogrammetry).
+# **To learn how to tune more parameters and use the subfunctions, see the gallery example:**
 # :ref:`sphx_glr_advanced_examples_plot_heterosc_estimation_modelling.py`!

--- a/examples/basic/plot_infer_spatial_correlation.py
+++ b/examples/basic/plot_infer_spatial_correlation.py
@@ -1,12 +1,12 @@
-"""
-Spatial correlation of errors
+"""Spatial correlation of errors
 =============================
 
 Digital elevation models have errors that are spatially correlated due to instrument or processing effects. Here, we
 rely on a non-stationary spatial statistics framework to estimate and model spatial correlations in elevation error.
 We use a sum of variogram forms to model this correlation, with stable terrain as an error proxy for moving terrain.
 
-**References:** `Rolstad et al. (2009) <http://dx.doi.org/10.3189/002214309789470950>`_, `Hugonnet et al. (2022) <https://doi.org/10.1109/jstars.2022.3188922>`_.
+**References:** `Rolstad et al. (2009) <http://dx.doi.org/10.3189/002214309789470950>`_,
+`Hugonnet et al. (2022) <https://doi.org/10.1109/jstars.2022.3188922>`_.
 """
 
 import geoutils as gu
@@ -30,7 +30,7 @@ glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlin
     df_model_params,
     spatial_corr_function,
 ) = xdem.spatialstats.infer_spatial_correlation_from_stable(
-    dvalues=dh, list_models=["Gaussian", "Spherical"], unstable_mask=glacier_outlines, random_state=42
+    dvalues=dh, list_models=["Gaussian", "Spherical"], unstable_mask=glacier_outlines, random_state=42,
 )
 
 # %%
@@ -40,20 +40,18 @@ glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlin
 # "experimental" variance value of the variogram in that bin, the ``count`` the number of pairwise samples, and
 # ``err_exp`` the 1-sigma error of the "experimental" variance, if more than one variogram is estimated with the
 # ``n_variograms`` parameter.
-df_empirical_variogram
+print(df_empirical_variogram)
 
 # %%
 # The second output is the dataframe of optimized model parameters (``range``, ``sill``, and possibly ``smoothness``)
 # for a sum of gaussian and spherical models:
-df_model_params
+print(df_model_params)
 
 # %%
 # The third output is the spatial correlation function with spatial lags, derived from the variogram:
 for spatial_lag in [0, 100, 1000, 10000, 30000]:
     print(
-        "Errors are correlated at {:.1f}% for a {:,.0f} m spatial lag".format(
-            spatial_corr_function(spatial_lag) * 100, spatial_lag
-        )
+    f"Errors are correlated at {spatial_corr_function(spatial_lag) * 100:.1f}% for a {spatial_lag:,.0f} m spatial lag",
     )
 
 # %%

--- a/examples/basic/plot_logging_configuration.py
+++ b/examples/basic/plot_logging_configuration.py
@@ -1,5 +1,4 @@
-"""
-Configuring verbosity level
+"""Configuring verbosity level
 ===========================
 
 This example demonstrates how to configure verbosity level, or logging, using a coregistration method.

--- a/examples/basic/plot_nuth_kaab.py
+++ b/examples/basic/plot_nuth_kaab.py
@@ -1,5 +1,4 @@
-"""
-Nuth and Kääb coregistration
+"""Nuth and Kääb coregistration
 ============================
 
 The Nuth and Kääb coregistration corrects horizontal and vertical shifts, and is especially performant for precise
@@ -26,7 +25,8 @@ glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlin
 inlier_mask = ~glacier_outlines.create_mask(reference_dem)
 
 # %%
-# The DEM to be aligned (a 1990 photogrammetry-derived DEM) has some vertical and horizontal biases that we want to reduce.
+# The DEM to be aligned (a 1990 photogrammetry-derived DEM)
+# has some vertical and horizontal biases that we want to reduce.
 # These can be visualized by plotting a change map:
 
 diff_before = reference_dem - dem_to_be_aligned
@@ -64,4 +64,5 @@ print(f"Error after: median = {med_after:.2f} - NMAD = {nmad_after:.2f} m")
 # %%
 # In the plot above, one may notice a positive (blue) tendency toward the east.
 # The 1990 DEM is a mosaic, and likely has a "seam" near there.
-# :ref:`sphx_glr_advanced_examples_plot_blockwise_coreg.py` tackles this issue, using a nonlinear coregistration approach.
+# :ref:`sphx_glr_advanced_examples_plot_blockwise_coreg.py` tackles this issue,
+# using a nonlinear coregistration approach.

--- a/examples/basic/plot_spatial_error_propagation.py
+++ b/examples/basic/plot_spatial_error_propagation.py
@@ -1,5 +1,4 @@
-"""
-Spatial propagation of elevation errors
+"""Spatial propagation of elevation errors
 =======================================
 
 Propagating elevation errors spatially accounting for heteroscedasticity and spatial correlation is complex. It
@@ -7,7 +6,8 @@ requires computing the pairwise correlations between all points of an area of in
 other operation), which is computationally intensive. Here, we rely on published formulations to perform
 computationally-efficient spatial propagation for the mean of elevation (or elevation differences) in an area.
 
-**References:** `Rolstad et al. (2009) <http://dx.doi.org/10.3189/002214309789470950>`_, `Hugonnet et al. (2022) <https://doi.org/10.1109/jstars.2022.3188922>`_.
+**References:** `Rolstad et al. (2009) <http://dx.doi.org/10.3189/002214309789470950>`_,
+`Hugonnet et al. (2022) <https://doi.org/10.1109/jstars.2022.3188922>`_.
 """
 
 import geoutils as gu
@@ -20,7 +20,8 @@ import xdem
 
 # %%
 # We load the same data, and perform the same calculations on heteroscedasticity and spatial correlations of errors as
-# in the :ref:`sphx_glr_basic_examples_plot_infer_heterosc.py` and :ref:`sphx_glr_basic_examples_plot_infer_spatial_correlation.py`
+# in the :ref:`sphx_glr_basic_examples_plot_infer_heterosc.py` and
+# :ref:`sphx_glr_basic_examples_plot_infer_spatial_correlation.py`
 # examples.
 
 dh = xdem.DEM(xdem.examples.get_path("longyearbyen_ddem"))
@@ -28,7 +29,7 @@ ref_dem = xdem.DEM(xdem.examples.get_path("longyearbyen_ref_dem"))
 glacier_outlines = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines"))
 slope, maximum_curvature = xdem.terrain.get_terrain_attribute(ref_dem, attribute=["slope", "maximum_curvature"])
 errors, df_binning, error_function = xdem.spatialstats.infer_heteroscedasticity_from_stable(
-    dvalues=dh, list_var=[slope, maximum_curvature], list_var_names=["slope", "maxc"], unstable_mask=glacier_outlines
+    dvalues=dh, list_var=[slope, maximum_curvature], list_var_names=["slope", "maxc"], unstable_mask=glacier_outlines,
 )
 
 # %%
@@ -36,7 +37,7 @@ errors, df_binning, error_function = xdem.spatialstats.infer_heteroscedasticity_
 # as it removes the variance variability due to heteroscedasticity.
 zscores = dh / errors
 emp_variogram, params_variogram_model, spatial_corr_function = xdem.spatialstats.infer_spatial_correlation_from_stable(
-    dvalues=zscores, list_models=["Gaussian", "Spherical"], unstable_mask=glacier_outlines, random_state=42
+    dvalues=zscores, list_models=["Gaussian", "Spherical"], unstable_mask=glacier_outlines, random_state=42,
 )
 
 # %%
@@ -48,7 +49,7 @@ areas = [
     glacier_outlines.ds[glacier_outlines.ds["NAME"] == "Medalsbreen"],
 ]
 stderr_glaciers = xdem.spatialstats.spatial_error_propagation(
-    areas=areas, errors=errors, params_variogram_model=params_variogram_model
+    areas=areas, errors=errors, params_variogram_model=params_variogram_model,
 )
 
 for glacier_name, stderr_gla in [("Brombreen", stderr_glaciers[0]), ("Medalsbreen", stderr_glaciers[1])]:
@@ -60,7 +61,7 @@ for glacier_name, stderr_gla in [("Brombreen", stderr_glaciers[0]), ("Medalsbree
 # sizes, but is less accurate to estimate the standard error of a certain area shape.
 areas = 10 ** np.linspace(1, 12)
 stderrs = xdem.spatialstats.spatial_error_propagation(
-    areas=areas, errors=errors, params_variogram_model=params_variogram_model
+    areas=areas, errors=errors, params_variogram_model=params_variogram_model,
 )
 plt.plot(areas / 10**6, stderrs)
 plt.xlabel("Averaging area (km²)")
@@ -72,7 +73,7 @@ plt.vlines(
     colors="red",
     linestyles="dashed",
     label="Disk area with radius the\n1st correlation range of {:,.0f} meters".format(
-        params_variogram_model["range"].values[0]
+        params_variogram_model["range"].values[0],
     ),
 )
 plt.vlines(
@@ -82,7 +83,7 @@ plt.vlines(
     colors="blue",
     linestyles="dashed",
     label="Disk area with radius the\n2nd correlation range of {:,.0f} meters".format(
-        params_variogram_model["range"].values[1]
+        params_variogram_model["range"].values[1],
     ),
 )
 plt.xscale("log")

--- a/examples/basic/plot_terrain_attributes.py
+++ b/examples/basic/plot_terrain_attributes.py
@@ -1,5 +1,4 @@
-"""
-Terrain attributes
+"""Terrain attributes
 ==================
 
 Terrain attributes generated from a DEM have a multitude of uses for analytic and visual purposes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,10 @@ build-backend = "setuptools.build_meta"
 version_file = "xdem/_version.py"
 fallback_version = "0.0.1"
 
-[tool.black]
-target_version = ['py310']
+#[tool.black]
+#target_version = ['py310']
+
+
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules -W error::UserWarning"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""This file now only serves for backward-compatibility for routines explicitly calling python setup.py"""
+"""The file now only serves for backward-compatibility for routines explicitly calling python setup.py"""
 
 from setuptools import setup
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 xDEM developers
+# Copyright (c) 2024 Centre National d'Etudes Spatiales (CNES).
 #
 # This file is part of the xDEM project:
 # https://github.com/glaciohack/xdem
@@ -15,24 +15,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import annotations
-
-import sys
-from typing import Any
-
-import numpy as np
-
-# Only for Python >= 3.9
-if sys.version_info.minor >= (3, 9):
-
-    from numpy.typing import NDArray  # this syntax works starting on Python 3.9
-
-    NDArrayf = NDArray[np.floating[Any]]
-    NDArrayb = NDArray[np.bool_]
-    MArrayf = np.ma.masked_array[Any, np.dtype[np.floating[Any]]]
-
-else:
-    NDArrayf = np.ndarray  # type: ignore
-    NDArrayb = np.ndarray  # type: ignore
-    MArrayf = np.ma.masked_array  # type: ignore
+"""xDEM tests module init file."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Union
+"""Functions to test configuration."""
+
+from collections.abc import Callable
 
 import geoutils as gu
 import numpy as np
@@ -11,10 +13,9 @@ from xdem._typing import NDArrayf
 
 @pytest.fixture(scope="session")  # type: ignore
 def raster_to_rda() -> Callable[[RasterType], rd.rdarray]:
+    """Allows to convert geoutils.Raster to richDEM rdarray through decorator."""
     def _raster_to_rda(rst: RasterType) -> rd.rdarray:
-        """
-        Convert geoutils.Raster to richDEM rdarray.
-        """
+        """Convert geoutils.Raster to richDEM rdarray."""
         arr = rst.data.filled(rst.nodata).squeeze()
         rda = rd.rdarray(arr, no_data=rst.nodata)
         rda.geotransform = rst.transform.to_gdal()
@@ -25,10 +26,9 @@ def raster_to_rda() -> Callable[[RasterType], rd.rdarray]:
 
 @pytest.fixture(scope="session")  # type: ignore
 def get_terrainattr_richdem(raster_to_rda: Callable[[RasterType], rd.rdarray]) -> Callable[[RasterType, str], NDArrayf]:
+    """Allows to get terrain attribute for DEM opened with geoutils.Raster using RichDEM through decorator."""
     def _get_terrainattr_richdem(rst: RasterType, attribute: str = "slope_radians") -> NDArrayf:
-        """
-        Derive terrain attribute for DEM opened with geoutils.Raster using RichDEM.
-        """
+        """Derive terrain attribute for DEM opened with geoutils.Raster using RichDEM."""
         rda = raster_to_rda(rst)
         terrattr = rd.TerrainAttribute(rda, attrib=attribute)
         terrattr[terrattr == terrattr.no_data] = np.nan
@@ -39,24 +39,23 @@ def get_terrainattr_richdem(raster_to_rda: Callable[[RasterType], rd.rdarray]) -
 
 @pytest.fixture(scope="session")  # type: ignore
 def get_terrain_attribute_richdem(
-    get_terrainattr_richdem: Callable[[RasterType, str], NDArrayf]
-) -> Callable[[RasterType, Union[str, list[str]], bool, float, float, float], Union[RasterType, list[RasterType]]]:
+    get_terrainattr_richdem: Callable[[RasterType, str], NDArrayf],
+) -> Callable[[RasterType, str | list[str], bool, float, float, float], RasterType | list[RasterType]]:
+    """Allows to get one or multiple terrain attributes from a DEM using RichDEM through decorator."""
     def _get_terrain_attribute_richdem(
         dem: RasterType,
-        attribute: Union[str, List[str]],
+        attribute: str | list[str],
         degrees: bool = True,
         hillshade_altitude: float = 45.0,
         hillshade_azimuth: float = 315.0,
         hillshade_z_factor: float = 1.0,
-    ) -> Union[RasterType, List[RasterType]]:
-        """
-        Derive one or multiple terrain attributes from a DEM using RichDEM.
-        """
+    ) -> RasterType | list[RasterType]:
+        """Derive one or multiple terrain attributes from a DEM using RichDEM."""
         if isinstance(attribute, str):
             attribute = [attribute]
 
         if not isinstance(dem, gu.Raster):
-            raise ValueError("DEM must be a geoutils.Raster object.")
+            raise TypeError("DEM must be a geoutils.Raster object.")
 
         terrain_attributes = {}
 

--- a/tests/test_coreg/__init__.py
+++ b/tests/test_coreg/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of the xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""xDEM test_coreg module init file."""

--- a/tests/test_coreg/test_base.py
+++ b/tests/test_coreg/test_base.py
@@ -132,7 +132,7 @@ class TestCoregClass:
         corr_copy = corr.copy()
 
         # Assign some attributes and .metadata after copying, respecting the CoregDict type class
-        corr.meta["outputs"]["affine"] = {"shift_z": 30}
+        corr._meta["outputs"]["affine"] = {"shift_z": 30} # noqa: SLF001
         # Make sure these don't appear in the copy
         assert corr_copy.meta != corr.meta
 
@@ -171,7 +171,7 @@ class TestCoregClass:
 
         # Define a class with a subsample and random_state in the .metadata
         coreg = Coreg(meta={"subsample": subsample, "random_state": 42})
-        subsample_mask = coreg.get_subsample_on_valid_mask(valid_mask=valid_mask)
+        subsample_mask = coreg._get_subsample_on_valid_mask(valid_mask=valid_mask) # noqa: SLF001
 
         # Check that it returns a same-shaped array that is boolean
         assert np.shape(valid_mask) == np.shape(subsample_mask)
@@ -626,15 +626,15 @@ class TestCoregPipeline:
         """Test the pipeline copy."""
         # Create a pipeline, add some .metadata, and copy it
         pipeline = coreg_class() + coreg_class()
-        pipeline.pipeline[0].meta["outputs"]["affine"] = {"shift_z": 1}
+        pipeline.pipeline[0]._meta["outputs"]["affine"] = {"shift_z": 1} # noqa: SLF001
 
         pipeline_copy = pipeline.copy()
 
         # Add some more .metadata after copying (this should not be transferred)
-        pipeline_copy.pipeline[0].meta["outputs"]["affine"].update({"shift_y": 0.5 * 30})
+        pipeline_copy.pipeline[0]._meta["outputs"]["affine"].update({"shift_y": 0.5 * 30}) # noqa: SLF001
 
         assert pipeline.pipeline[0].meta != pipeline_copy.pipeline[0].meta
-        assert pipeline_copy.pipeline[0].meta["outputs"]["affine"]["shift_z"]
+        assert pipeline_copy.pipeline[0]._meta["outputs"]["affine"]["shift_z"] # noqa: SLF001
 
     def test_pipeline(self) -> None:
         """Test the pipeline from two vertical shift correction approaches."""

--- a/tests/test_coreg/test_biascorr.py
+++ b/tests/test_coreg/test_biascorr.py
@@ -73,10 +73,10 @@ class TestBiasCorr:
         )
         assert bcorr.meta["inputs"]["fitorbin"]["bias_var_names"] is None
 
-        # Check that the is_affine attribute is set correctly
-        assert not bcorr.is_affine
+        # Check that the _is_affine attribute is set correctly
+        assert not bcorr._is_affine # noqa: SLF001
         assert bcorr.meta["inputs"]["fitorbin"]["fit_or_bin"] == "fit"
-        assert bcorr.needs_vars is True
+        assert bcorr._needs_vars is True # noqa: SLF001
 
         # Or with default bin arguments
         bcorr2 = biascorr.BiasCorr(fit_or_bin="bin")
@@ -416,7 +416,7 @@ class TestBiasCorr:
             dirbias.meta["inputs"]["fitorbin"]["fit_optimizer"] == biascorr.fit_workflows["nfreq_sumsin"]["optimizer"]
         )
         assert dirbias.meta["inputs"]["specific"]["angle"] == 45
-        assert dirbias.needs_vars is False
+        assert dirbias._needs_vars is False # noqa: SLF001
 
         # Check that variable names are defined during instantiation
         assert dirbias.meta["inputs"]["fitorbin"]["bias_var_names"] == ["angle"]
@@ -503,7 +503,7 @@ class TestBiasCorr:
         assert deramp.meta["inputs"]["fitorbin"]["fit_func"] == polynomial_2d
         assert deramp.meta["inputs"]["fitorbin"]["fit_optimizer"] == scipy.optimize.curve_fit
         assert deramp.meta["inputs"]["specific"]["poly_order"] == 2
-        assert deramp.needs_vars is False
+        assert deramp._needs_vars is False # noqa: SLF001
 
         # Check that variable names are defined during instantiation
         assert deramp.meta["inputs"]["fitorbin"]["bias_var_names"] == ["xx", "yy"]
@@ -558,7 +558,7 @@ class TestBiasCorr:
         assert tb.meta["inputs"]["fitorbin"]["bin_sizes"] == 100
         assert tb.meta["inputs"]["fitorbin"]["bin_statistic"] == np.nanmedian
         assert tb.meta["inputs"]["specific"]["terrain_attribute"] == "maximum_curvature"
-        assert tb.needs_vars is False
+        assert tb._needs_vars is False # noqa: SLF001
 
         assert tb.meta["inputs"]["fitorbin"]["bias_var_names"] == ["maximum_curvature"]
 

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -60,7 +60,7 @@ class TestdDEM:
 
         ddem.interpolate(method="regional_hypsometric", reference_elevation=self.dem_2009, mask=self.outlines_1990)
 
-        assert ddem._filled_data is not None
+        assert ddem.filled_data is not None
         assert isinstance(ddem.filled_data, np.ndarray)
 
         assert ddem.filled_data.shape == ddem.data.shape

--- a/tests/test_ddem.py
+++ b/tests/test_ddem.py
@@ -60,7 +60,7 @@ class TestdDEM:
 
         ddem.interpolate(method="regional_hypsometric", reference_elevation=self.dem_2009, mask=self.outlines_1990)
 
-        assert ddem.filled_data is not None
+        assert ddem._filled_data is not None # noqa: SLF001
         assert isinstance(ddem.filled_data, np.ndarray)
 
         assert ddem.filled_data.shape == ddem.data.shape

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -124,7 +124,7 @@ class TestDEM:
         assert dem.transform == transform
         assert dem.crs == crs
         assert dem.nodata == nodata
-        assert dem.vcrs == xdem.vcrs.vcrs_from_user_input(vcrs_input=vcrs)
+        assert dem.vcrs == xdem.vcrs._vcrs_from_user_input(vcrs_input=vcrs) # noqa: SLF001
 
     def test_from_array__vcrs(self) -> None:
         """Test that overridden from_array rightly sets the vertical CRS."""
@@ -277,7 +277,7 @@ class TestDEM:
         assert median_after - median_before == pytest.approx(-32, rel=0.1)
 
         # Check that the results are consistent with the operation done independently
-        ccrs_dest = xdem.vcrs.build_ccrs_from_crs_and_vcrs(dem.crs, xdem.vcrs.vcrs_from_user_input("EGM96"))
+        ccrs_dest = xdem.vcrs._build_ccrs_from_crs_and_vcrs(dem.crs, xdem.vcrs.vcrs_from_user_input("EGM96")) # noqa: SLF001
         transformer = Transformer.from_crs(crs_from=ccrs_init, crs_to=ccrs_dest, always_xy=True)
 
         xx, yy = dem.coords()

--- a/tests/test_demcollection.py
+++ b/tests/test_demcollection.py
@@ -2,6 +2,7 @@
 
 import datetime
 import warnings
+from datetime import timezone
 
 import geoutils as gu
 import numpy as np
@@ -16,8 +17,10 @@ class TestDEMCollection:
     outlines_2010 = gu.Vector(xdem.examples.get_path("longyearbyen_glacier_outlines_2010"))
 
     def test_init(self) -> None:
-
-        timestamps = [datetime.datetime(1990, 8, 1), datetime.datetime(2009, 8, 1), datetime.datetime(2060, 8, 1)]
+        """Test that the DEMs of the collection are consistent."""
+        timestamps = [datetime.datetime(1990, 8, 1, tzinfo=timezone.utc),
+                      datetime.datetime(2009, 8, 1, tzinfo=timezone.utc),
+                      datetime.datetime(2060, 8, 1, tzinfo=timezone.utc)]
 
         scott_1990 = gu.Vector(self.outlines_1990.ds.loc[self.outlines_1990.ds["NAME"] == "Scott Turnerbreen"])
         scott_2010 = gu.Vector(self.outlines_2010.ds.loc[self.outlines_2010.ds["NAME"] == "Scott Turnerbreen"])
@@ -33,7 +36,7 @@ class TestDEMCollection:
         dems = xdem.DEMCollection(
             [self.dem_1990, self.dem_2009, dem_2060],
             timestamps=timestamps,
-            outlines=dict(zip(timestamps[:2], [self.outlines_1990, self.outlines_2010])),
+            outlines=dict(zip(timestamps[:2], [self.outlines_1990, self.outlines_2010], strict=False)),
             reference_dem=1,
         )
 
@@ -81,8 +84,8 @@ class TestDEMCollection:
 
     def test_dem_datetimes(self) -> None:
         """Try to create the DEMCollection without the timestamps argument (instead relying on datetime attributes)."""
-        self.dem_1990.datetime = datetime.datetime(1990, 8, 1)
-        self.dem_2009.datetime = datetime.datetime(2009, 8, 1)
+        self.dem_1990.datetime = datetime.datetime(1990, 8, 1, tzinfo=timezone.utc)
+        self.dem_2009.datetime = datetime.datetime(2009, 8, 1, tzinfo=timezone.utc)
 
         dems = xdem.DEMCollection([self.dem_1990, self.dem_2009])
 
@@ -90,10 +93,10 @@ class TestDEMCollection:
 
     def test_ddem_interpolation(self) -> None:
         """Test that dDEM interpolation works as it should."""
-
         # Create a DEMCollection object
         dems = xdem.DEMCollection(
-            [self.dem_2009, self.dem_1990], timestamps=[datetime.datetime(year, 8, 1) for year in (2009, 1990)]
+            [self.dem_2009, self.dem_1990],
+            timestamps=[datetime.datetime(year, 8, 1, tzinfo=timezone.utc) for year in (2009, 1990)],
         )
 
         # Create dDEMs

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,7 +13,6 @@ from xdem._typing import NDArrayf
 
 def load_examples() -> tuple[Raster, Raster, Vector, Raster]:
     """Load example files to try coregistration methods with."""
-
     ref_dem = Raster(examples.get_path("longyearbyen_ref_dem"))
     tba_dem = Raster(examples.get_path("longyearbyen_tba_dem"))
     glacier_mask = Vector(examples.get_path("longyearbyen_glacier_outlines"))
@@ -48,7 +47,6 @@ class TestExamples:
     )  # type: ignore
     def test_array_content(self, rst_and_truevals: tuple[Raster, NDArrayf]) -> None:
         """Let's ensure the data arrays in the examples are always the same by checking randomly some values"""
-
         rst = rst_and_truevals[0]
         truevals = rst_and_truevals[1]
         rng = np.random.default_rng(42)
@@ -60,7 +58,6 @@ class TestExamples:
     @pytest.mark.parametrize("rst_and_truenodata", [(ref_dem, 0), (tba_dem, 0), (ddem, 0)])  # type: ignore
     def test_array_nodata(self, rst_and_truenodata: tuple[Raster, int]) -> None:
         """Let's also check that the data arrays have always the same number of not finite values"""
-
         rst = rst_and_truenodata[0]
         truenodata = rst_and_truenodata[1]
         mask = gu.raster.get_array_and_mask(rst)[1]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -18,7 +18,6 @@ class TestFilters:
 
     def test_gauss(self) -> None:
         """Test applying the various Gaussian filters on DEMs with/without NaNs"""
-
         # Test applying scipy's Gaussian filter
         # smoothing should not yield values below.above original DEM
         dem_array = self.dem_1990.data
@@ -67,7 +66,6 @@ class TestFilters:
 
     def test_dist_filter(self) -> None:
         """Test that distance_filter works"""
-
         # Calculate dDEM
         ddem = self.dem_2009.data - self.dem_1990.data
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -1,6 +1,4 @@
-"""
-Functions to test the fitting tools.
-"""
+"""Functions to test the fitting tools."""
 
 import platform
 import warnings
@@ -24,7 +22,7 @@ class TestRobustFitting:
         ],
     )  # type: ignore
     def test_robust_norder_polynomial_fit(self, pkg_estimator: str) -> None:
-
+        """Test the robustness of the polynomial fitted."""
         # Define x vector
         x = np.linspace(-50, 50, 10000)
         # Define exact polynomial
@@ -45,13 +43,13 @@ class TestRobustFitting:
             )
 
         # Check coefficients are constrained
-        assert deg == 3 or deg == 4
+        assert deg in {3, 4}
         error_margins = [100, 5, 2, 1]
         for i in range(4):
             assert coefs[i] == pytest.approx(true_coefs[i], abs=error_margins[i])
 
     def test_robust_norder_polynomial_fit_noise_and_outliers(self) -> None:
-
+        """Test the robustness of the polynomial fitted after adding noise and outliers."""
         # Ignore sklearn convergence warnings
         warnings.filterwarnings("ignore", category=UserWarning, message="lbfgs failed to converge")
 
@@ -70,7 +68,7 @@ class TestRobustFitting:
 
         # Run with the "Linear" estimator
         coefs, deg = xdem.fit.robust_norder_polynomial_fit(
-            x, y, estimator_name="Linear", linear_pkg="scipy", loss="soft_l1", method="trf", f_scale=0.5
+            x, y, estimator_name="Linear", linear_pkg="scipy", loss="soft_l1", method="trf", f_scale=0.5,
         )
 
         # TODO: understand why this is not robust since moving from least_squares() to curve_fit(), while the
@@ -86,13 +84,13 @@ class TestRobustFitting:
 
         # The sklearn Linear solution with MSE cost function will not be robust
         coefs2, deg2 = xdem.fit.robust_norder_polynomial_fit(
-            x, y, estimator_name="Linear", linear_pkg="sklearn", cost_func=mean_squared_error, margin_improvement=50
+            x, y, estimator_name="Linear", linear_pkg="sklearn", cost_func=mean_squared_error, margin_improvement=50,
         )
         # It won't find the right degree because of the outliers and noise
         assert deg2 != 3
         # Using the median absolute error should improve the fit
         coefs3, deg3 = xdem.fit.robust_norder_polynomial_fit(
-            x, y, estimator_name="Linear", linear_pkg="sklearn", cost_func=median_absolute_error, margin_improvement=50
+            x, y, estimator_name="Linear", linear_pkg="sklearn", cost_func=median_absolute_error, margin_improvement=50,
         )
         # Will find the right degree, but won't find the right coefficients because of the outliers and noise
         assert deg3 == 3
@@ -119,7 +117,7 @@ class TestRobustFitting:
             assert coefs6[i + 1] == pytest.approx(true_coefs[i + 1], abs=1)
 
     def test_robust_nfreq_sumsin_fit(self) -> None:
-
+        """Test the robustness of the estimated sum of sinusoid fitted."""
         # Define X vector
         x = np.linspace(0, 10, 1000)
         # Define exact sum of sinusoid signal
@@ -146,11 +144,11 @@ class TestRobustFitting:
         # Check that using custom arguments does not trigger an error
         bounds = [(1, 7), (1, 10), (0, 2 * np.pi), (1, 7), (0.1, 4), (0, 2 * np.pi)]
         coefs, deg = xdem.fit.robust_nfreq_sumsin_fit(
-            x, y, bounds_amp_wave_phase=bounds, max_nb_frequency=2, hop_length=0.01, random_state=42, niter=1
+            x, y, bounds_amp_wave_phase=bounds, max_nb_frequency=2, hop_length=0.01, random_state=42, niter=1,
         )
 
     def test_robust_nfreq_simsin_fit_noise_and_outliers(self) -> None:
-
+        """Test the robustness of the estimated sum of sinusoid fitted after adding noise and outliers."""
         # Check robustness to outliers
         rng = np.random.default_rng(42)
         # Define X vector

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 
 import pytest
 import yaml  # type: ignore
@@ -16,13 +17,12 @@ import xdem.misc
 class TestMisc:
     def test_environment_files(self) -> None:
         """Check that environment yml files are properly written: all dependencies of env are also in dev-env"""
-
-        fn_env = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "environment.yml"))
-        fn_devenv = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "dev-environment.yml"))
+        fn_env = Path(os.path.join(Path(__file__).parent, "..", "environment.yml")).resolve()
+        fn_devenv = Path(os.path.join(Path(__file__).parent, "..", "dev-environment.yml")).resolve()
 
         # Load the yml as dictionaries
-        yaml_env = yaml.safe_load(open(fn_env))
-        yaml_devenv = yaml.safe_load(open(fn_devenv))
+        yaml_env = yaml.safe_load(Path(fn_env).open())
+        yaml_devenv = yaml.safe_load(Path(fn_devenv).open())
 
         # Extract the dependencies values
         conda_dep_env = yaml_env["dependencies"]
@@ -48,8 +48,7 @@ class TestMisc:
     @pytest.mark.parametrize("deprecation_increment", [-1, 0, 1, None])  # type: ignore
     @pytest.mark.parametrize("details", [None, "It was completely useless!", "dunnowhy"])  # type: ignore
     def test_deprecate(self, deprecation_increment: int | None, details: str | None) -> None:
-        """
-        Test the deprecation warnings/errors.
+        """Test the deprecation warnings/errors.
 
         If the removal_version is larger than the current, it should warn.
         If the removal_version is smaller or equal, it should raise an error.
@@ -57,7 +56,6 @@ class TestMisc:
         :param deprecation_increment: The version number relative to the current version.
         :param details: An optional explanation for the description.
         """
-
         current_version = Version(Version(xdem.__version__).base_version)
 
         # Set the removal version to be the current version plus the increment (e.g. 0.0.5 + 1 -> 0.0.6)
@@ -84,7 +82,7 @@ class TestMisc:
             return 1
 
         # Example of why Version needs to be used below
-        assert not "0.0.10" > "0.0.8"
+        # assert not "0.0.10" > "0.0.8"environment yml files
         assert Version("0.0.10") > Version("0.0.8")
 
         # If True, a warning is expected. If False, a ValueError is expected.
@@ -116,8 +114,8 @@ class TestMisc:
             with pytest.raises(ValueError, match=re.escape(text)):
                 useless_func()
 
-    def test_diff_environment_yml(self, capsys) -> None:  # type: ignore
-
+    def test_diff_environment_yml(self, capsys) -> None:  # noqa: ANN001
+        """Check the differences between a synthetic environment and the environment from the yml files."""
         # Test with synthetic environment
         env = {"dependencies": ["python==3.9", "numpy", "pandas"]}
         devenv = {"dependencies": ["python==3.9", "numpy", "pandas", "opencv"]}

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -351,7 +351,7 @@ class TestBinning:
         df_binning = df_binning[df_binning.nd == 3]
         # Convert the intervals from string due to saving to file
         for var in ["slope", "elevation", "aspect"]:
-            df_binning[var] = [xdem.spatialstats.pandas_str_to_interval(x) for x in df_binning[var]]
+            df_binning[var] = [xdem.spatialstats._pandas_str_to_interval(x) for x in df_binning[var]] # noqa: SLF001
 
         # Take 1000 random points in the array
         rng = np.random.default_rng(42)
@@ -438,7 +438,7 @@ class TestBinning:
             dvalues=self.diff, list_var=[self.slope, self.maximum_curv], unstable_mask=self.outlines,
         )
 
-        df_binning_2, err_fun_2 = xdem.spatialstats.estimate_model_heteroscedasticity(
+        df_binning_2, err_fun_2 = xdem.spatialstats._estimate_model_heteroscedasticity( # noqa: SLF001
             dvalues=self.diff[~self.mask],
             list_var=[self.slope[~self.mask], self.maximum_curv[~self.mask]],
             list_var_names=["var1", "var2"],
@@ -455,7 +455,7 @@ class TestBinning:
         assert np.array_equal(errors_1_arr, errors_2_arr, equal_nan=True)
 
         # Save for use in TestVariogram
-        errors_1.save(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors_1.save(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif")) # noqa: SLF001
 
         # Check that errors are raised with wrong input
         with pytest.raises(ValueError, match="The values must be a Raster or NumPy array, or a list of those."):
@@ -580,7 +580,7 @@ class TestVariogram:
         shape = values.shape
 
         keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
-        runs, samples, ratio_subsample = xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(
+        runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters( # noqa: SLF001
             **keyword_arguments,
         )
 
@@ -714,7 +714,7 @@ class TestVariogram:
 
         # Run the function
         keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
-        runs, samples, ratio_subsample = xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(
+        runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters( # noqa: SLF001
             **keyword_arguments,
         )
 
@@ -740,7 +740,7 @@ class TestVariogram:
         keyword_arguments = {"subsample": 3, "extent": (0, 1, 0, 1), "shape": (10, 10)}
 
         with pytest.raises(ValueError, match="The number of subsamples needs to be at least 10."):
-            xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(**keyword_arguments)
+            xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(**keyword_arguments) # noqa: SLF001
 
     def test_multirange_fit_performance(self) -> None:
         """Verify that the fitting works with artificial dataset"""
@@ -781,7 +781,7 @@ class TestVariogram:
             ValueError,
             match='The dataframe with variogram parameters must contain the columns "model", "range" and "psill".',
         ):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["spherical"], "range": [100]}),
             )
 
@@ -793,31 +793,31 @@ class TestVariogram:
             + ", ".join(list_supported_models)
             + ".",
         ):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["Supraluminal"], "range": [100], "psill": [1]}),
             )
 
         # Check with wrong range format
         with pytest.raises(ValueError, match="The variogram ranges must be float or integer."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["spherical"], "range": ["a"], "psill": [1]}),
             )
 
         # Check with negative range
         with pytest.raises(ValueError, match="The variogram ranges must have non-zero, positive values."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["spherical"], "range": [-1], "psill": [1]}),
             )
 
         # Check with wrong partial sill format
         with pytest.raises(ValueError, match="The variogram partial sills must be float or integer."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": ["a"]}),
             )
 
         # Check with negative partial sill
         with pytest.raises(ValueError, match="The variogram partial sills must have non-zero, positive values."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": [-1]}),
             )
 
@@ -827,19 +827,19 @@ class TestVariogram:
             match='The dataframe with variogram parameters must contain the column "smooth" '
             "for the smoothness factor when using Matern or Stable models.",
         ):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1]}),
             )
 
         # Check with wrong smoothness format
         with pytest.raises(ValueError, match="The variogram smoothness parameter must be float or integer."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": ["a"]}),
             )
 
         # Check with negative smoothness
         with pytest.raises(ValueError, match="The variogram smoothness parameter must have non-zero, positive values."):
-            xdem.spatialstats.check_validity_params_variogram(
+            xdem.spatialstats._check_validity_params_variogram( # noqa: SLF001
                 pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": [-1]}),
             )
 
@@ -852,13 +852,13 @@ class TestVariogram:
         diff_on_stable.set_mask(self.mask)
 
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif")) # noqa: SLF001
 
         # Standardize the differences
         zscores = diff_on_stable / errors
 
         # Run wrapper estimate and model function
-        emp_vgm_1, params_model_vgm_1, _ = xdem.spatialstats.estimate_model_spatial_correlation(
+        emp_vgm_1, params_model_vgm_1, _ = xdem.spatialstats._estimate_model_spatial_correlation( # noqa: SLF001
             dvalues=zscores, list_models=["Gau", "Sph"], subsample=10, random_state=42,
         )
 
@@ -903,7 +903,7 @@ class TestVariogram:
         )
         # Save the modelled variogram for later used in TestNeffEstimation
         params_model_vgm_5.to_csv(
-            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False,
+            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False, # noqa: SLF001
         )
 
         # Check that errors are raised with wrong input
@@ -1179,11 +1179,11 @@ class TestNeffEstimation:
     def test_spatial_error_propagation(self) -> None:
         """Test that the spatial error propagation wrapper function runs properly"""
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif")) # noqa: SLF001
 
         # Load the spatial correlation from TestVariogram
         params_variogram_model = pd.read_csv(
-            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None,
+            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None, # noqa: SLF001
         )
 
         # Run the function with vector areas
@@ -1216,8 +1216,8 @@ class TestSubSampling:
     def test_circular_masking(self) -> None:
         """Test that the circular masking works as intended"""
         # using default (center should be [2,2], radius 2)
-        circ = xdem.spatialstats.create_circular_mask((5, 5))
-        circ2 = xdem.spatialstats.create_circular_mask((5, 5), center=(2, 2), radius=2)
+        circ = xdem.spatialstats._create_circular_mask((5, 5)) # noqa: SLF001
+        circ2 = xdem.spatialstats._create_circular_mask((5, 5), center=(2, 2), radius=2) # noqa: SLF001
 
         # check default center and radius are derived properly
         assert np.array_equal(circ, circ2)
@@ -1230,29 +1230,29 @@ class TestSubSampling:
 
         # check distance is not a multiple of pixels (more accurate subsampling)
         # will create a 1-pixel mask around the center
-        circ3 = xdem.spatialstats.create_circular_mask((5, 5), center=(1, 1), radius=1)
+        circ3 = xdem.spatialstats._create_circular_mask((5, 5), center=(1, 1), radius=1) # noqa: SLF001
 
         eq_circ3 = np.zeros((5, 5), dtype=bool)
         eq_circ3[1, 1] = True
         assert np.array_equal(circ3, eq_circ3)
 
         # will create a square mask (<1.5 pixel) around the center
-        circ4 = xdem.spatialstats.create_circular_mask((5, 5), center=(1, 1), radius=1.5)
+        circ4 = xdem.spatialstats._create_circular_mask((5, 5), center=(1, 1), radius=1.5) # noqa: SLF001
         # should not be the same as radius = 1
         assert not np.array_equal(circ3, circ4)
 
     def test_ring_masking(self) -> None:
         """Test that the ring masking works as intended"""
         # by default, the mask is only an outside circle (ring of size 0)
-        ring1 = xdem.spatialstats.create_ring_mask((5, 5))
-        circ1 = xdem.spatialstats.create_circular_mask((5, 5))
+        ring1 = xdem.spatialstats._create_ring_mask((5, 5)) # noqa: SLF001
+        circ1 = xdem.spatialstats._create_circular_mask((5, 5)) # noqa: SLF001
 
         assert np.array_equal(ring1, circ1)
 
         # test rings with different inner radius
-        ring2 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=1, out_radius=2)
-        ring3 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=0, out_radius=2)
-        ring4 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=1.5, out_radius=2)
+        ring2 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=1, out_radius=2) # noqa: SLF001
+        ring3 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=0, out_radius=2) # noqa: SLF001
+        ring4 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=1.5, out_radius=2) # noqa: SLF001
 
         assert np.logical_and(~np.array_equal(ring2, ring3), ~np.array_equal(ring3, ring4))
 

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -27,7 +27,6 @@ PLOT = False
 
 def load_ref_and_diff() -> tuple[Raster, Raster, NDArrayf, Vector]:
     """Load example files to try coregistration methods with."""
-
     reference_raster = Raster(examples.get_path("longyearbyen_ref_dem"))
     outlines = Vector(examples.get_path("longyearbyen_glacier_outlines"))
 
@@ -44,7 +43,6 @@ class TestStats:
 
     def test_nmad(self) -> None:
         """Test NMAD functionality runs on any type of input"""
-
         # Check that the NMAD is computed the same with a raster, masked array or NaN array
         nmad_raster = nmad(self.diff)
         nmad_ma = nmad(self.diff.data)
@@ -66,69 +64,68 @@ class TestBinning:
 
     # Derive terrain attributes
     slope, aspect, maximum_curv = xdem.terrain.get_terrain_attribute(
-        ref, attribute=["slope", "aspect", "maximum_curvature"]
+        ref, attribute=["slope", "aspect", "maximum_curvature"],
     )
 
     def test_nd_binning(self) -> None:
         """Check that the nd_binning function works adequately and save dataframes to files for later tests"""
-
         # Subsampler
         indices = gu.raster.subsample_array(
-            self.diff.data.flatten(), subsample=10000, return_indices=True, random_state=42
+            self.diff.data.flatten(), subsample=10000, return_indices=True, random_state=42,
         )
 
         # 1D binning, by default will create 10 bins
-        df = xdem.spatialstats.nd_binning(
+        df_binning = xdem.spatialstats.nd_binning(
             values=self.diff.data.flatten()[indices],
             list_var=[self.slope.data.flatten()[indices]],
             list_var_names=["slope"],
         )
 
         # Check length matches
-        assert df.shape[0] == 10
+        assert df_binning.shape[0] == 10
         # Check bin edges match the minimum and maximum of binning variable
-        assert np.nanmin(self.slope.data.flatten()[indices]) == np.min(pd.IntervalIndex(df.slope).left)
-        assert np.nanmax(self.slope.data.flatten()[indices]) == np.max(pd.IntervalIndex(df.slope).right)
+        assert np.nanmin(self.slope.data.flatten()[indices]) == np.min(pd.IntervalIndex(df_binning.slope).left)
+        assert np.nanmax(self.slope.data.flatten()[indices]) == np.max(pd.IntervalIndex(df_binning.slope).right)
 
         # NMAD should go up quite a bit with slope, more than 8 m between the two extreme bins
-        assert df.nmad.values[-1] - df.nmad.values[0] > 8
+        assert df_binning.nmad.values[-1] - df_binning.nmad.values[0] > 8
 
         # 1D binning with 20 bins
-        df = xdem.spatialstats.nd_binning(
+        df_binning = xdem.spatialstats.nd_binning(
             values=self.diff.data.flatten()[indices],
             list_var=[self.slope.data.flatten()[indices]],
             list_var_names=["slope"],
             list_var_bins=20,
         )
         # Check length matches
-        assert df.shape[0] == 20
+        assert df_binning.shape[0] == 20
 
         # Define function for custom stat
         def percentile_80(a: NDArrayf) -> np.floating[Any]:
             return np.nanpercentile(a, 80)
 
         # Check the function runs with custom functions
-        df = xdem.spatialstats.nd_binning(
+        df_binning = xdem.spatialstats.nd_binning(
             values=self.diff.data.flatten()[indices],
             list_var=[self.slope.data.flatten()[indices]],
             list_var_names=["slope"],
             statistics=[percentile_80],
         )
         # Check that the count is added automatically by the function when not user-defined
-        assert "count" in df.columns.values
+        assert "count" in df_binning.columns.values
 
         # 2D binning
-        df = xdem.spatialstats.nd_binning(
+        df_binning = xdem.spatialstats.nd_binning(
             values=self.diff.data.flatten()[indices],
             list_var=[self.slope.data.flatten()[indices], self.ref.data.flatten()[indices]],
             list_var_names=["slope", "elevation"],
         )
 
         # Dataframe should contain two 1D binning of length 10 and one 2D binning of length 100
-        assert df.shape[0] == (10 + 10 + 100)
+        assert df_binning.shape[0] == (10 + 10 + 100)
 
         # 3D binning
-        df = xdem.spatialstats.nd_binning(
+        df_binning = xdem.spatialstats.nd_binning(
             values=self.diff.data.flatten()[indices],
             list_var=[
                 self.slope.data.flatten()[indices],
@@ -141,37 +138,39 @@ class TestBinning:
 
         # Dataframe should contain three 1D binning of length 10 and three 2D binning of length 100 and one 2D binning
         # of length 1000
-        assert df.shape[0] == (4**3 + 3 * 4**2 + 3 * 4)
+        assert df_binning.shape[0] == (4**3 + 3 * 4**2 + 3 * 4)
 
         # Save for later use
-        df.to_csv(os.path.join(examples._EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index=False)
+        df_binning.to_csv(os.path.join(examples.EXAMPLES_DIRECTORY,"df_3d_binning_slope_elevation_aspect.csv"),
+                          index=False)
 
     def test_interp_nd_binning_artificial_data(self) -> None:
         """Check that the N-dimensional interpolation works correctly using artificial data"""
-
         # Check the function works with a classic input (see example)
-        df = pd.DataFrame(
+        df_binning = pd.DataFrame(
             {
                 "var1": [1, 2, 3, 1, 2, 3, 1, 2, 3],
                 "var2": [1, 1, 1, 2, 2, 2, 3, 3, 3],
                 "statistic": [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            }
+            },
         )
         arr = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9]).reshape((3, 3))
         fun = xdem.spatialstats.interp_nd_binning(
-            df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None
+            df_binning, list_var_names=["var1", "var2"], statistic="statistic", min_count=None,
         )
 
         # Check that the dimensions are rightly ordered
-        assert fun((1, 3)) == df[np.logical_and(df["var1"] == 1, df["var2"] == 3)]["statistic"].values[0]
-        assert fun((3, 1)) == df[np.logical_and(df["var1"] == 3, df["var2"] == 1)]["statistic"].values[0]
+        assert fun((1, 3)) == df_binning[np.logical_and(df_binning["var1"] == 1,
+                                                        df_binning["var2"] == 3)]["statistic"].values[0]
+        assert fun((3, 1)) == df_binning[np.logical_and(df_binning["var1"] == 3,
+                                                        df_binning["var2"] == 1)]["statistic"].values[0]
 
         # Check interpolation falls right on values for points (1, 1), (1, 2) etc...
         for i in range(3):
             for j in range(3):
-                x = df["var1"][3 * i + j]
-                y = df["var2"][3 * i + j]
-                stat = df["statistic"][3 * i + j]
+                x = df_binning["var1"][3 * i + j]
+                y = df_binning["var2"][3 * i + j]
+                stat = df_binning["statistic"][3 * i + j]
                 assert fun((x, y)) == stat
 
         # Check bilinear interpolation inside the grid
@@ -254,34 +253,34 @@ class TestBinning:
         vec2 = np.arange(1, 4)
         vec3 = np.arange(1, 5)
         x, y, z = np.meshgrid(vec1, vec2, vec3)
-        df = pd.DataFrame(
-            {"var1": x.ravel(), "var2": y.ravel(), "var3": z.ravel(), "statistic": np.arange(len(x.ravel()))}
+        df_binning = pd.DataFrame(
+            {"var1": x.ravel(), "var2": y.ravel(), "var3": z.ravel(), "statistic": np.arange(len(x.ravel()))},
         )
         fun = xdem.spatialstats.interp_nd_binning(
-            df, list_var_names=["var1", "var2", "var3"], statistic="statistic", min_count=None
+            df_binning, list_var_names=["var1", "var2", "var3"], statistic="statistic", min_count=None,
         )
         for i in vec1:
             for j in vec2:
                 for k in vec3:
                     assert (
                         fun((i, j, k))
-                        == df[np.logical_and.reduce((df["var1"] == i, df["var2"] == j, df["var3"] == k))][
-                            "statistic"
-                        ].values[0]
+                        == df_binning[np.logical_and.reduce((df_binning["var1"] == i,
+                                                             df_binning["var2"] == j,
+                                                             df_binning["var3"] == k))]["statistic"].values[0]
                     )
 
         # Check that the linear extrapolation respects nearest neighbour and doesn't go negative
 
         # The following example used to give a negative value
-        df = pd.DataFrame(
+        df_binning = pd.DataFrame(
             {
                 "var1": [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4],
                 "var2": [0, 0, 0, 0, 5, 5, 5, 5, 5.5, 5.5, 5.5, 5.5, 6, 6, 6, 6],
                 "statistic": [0, 0, 0, 0, 1, 1, 1, 1, np.nan, 1, 1, np.nan, np.nan, 0, 0, np.nan],
-            }
+            },
         )
         fun = xdem.spatialstats.interp_nd_binning(
-            df, list_var_names=["var1", "var2"], statistic="statistic", min_count=None
+            df_binning, list_var_names=["var1", "var2"], statistic="statistic", min_count=None,
         )
 
         # Check it is now positive or equal to zero
@@ -289,14 +288,13 @@ class TestBinning:
 
     def test_interp_nd_binning_realdata(self) -> None:
         """Check that the function works well with outputs from the nd_binning function"""
-
         # Read nd_binning output
-        df = pd.read_csv(
-            os.path.join(examples._EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None
+        df_binning = pd.read_csv(
+            os.path.join(examples.EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None,
         )
 
         # First, in 1D
-        fun = xdem.spatialstats.interp_nd_binning(df, list_var_names="slope")
+        fun = xdem.spatialstats.interp_nd_binning(df_binning, list_var_names="slope")
 
         # Check a value is returned inside the grid
         assert np.isfinite(fun(([15],)))
@@ -306,10 +304,10 @@ class TestBinning:
         assert all(np.isfinite(fun(([-5, 50],))))
 
         # Check when the first passed binning variable contains NaNs because of other binning variable
-        fun = xdem.spatialstats.interp_nd_binning(df, list_var_names="elevation")
+        fun = xdem.spatialstats.interp_nd_binning(df_binning, list_var_names="elevation")
 
         # Then, in 2D
-        fun = xdem.spatialstats.interp_nd_binning(df, list_var_names=["slope", "elevation"])
+        fun = xdem.spatialstats.interp_nd_binning(df_binning, list_var_names=["slope", "elevation"])
 
         # Check a value is returned inside the grid
         assert np.isfinite(fun(([15], [1000])))
@@ -319,7 +317,7 @@ class TestBinning:
         assert all(np.isfinite(fun(([-5, 50], [-500, 3000]))))
 
         # Then in 3D
-        fun = xdem.spatialstats.interp_nd_binning(df, list_var_names=["slope", "elevation", "aspect"])
+        fun = xdem.spatialstats.interp_nd_binning(df_binning, list_var_names=["slope", "elevation", "aspect"])
 
         # Check a value is returned inside the grid
         assert np.isfinite(fun(([15], [1000], [np.pi])))
@@ -330,15 +328,14 @@ class TestBinning:
 
     def test_get_perbin_nd_binning(self) -> None:
         """Test the get per-bin function."""
-
         # Read nd_binning output
-        df = pd.read_csv(
-            os.path.join(examples._EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None
+        df_binning = pd.read_csv(
+            os.path.join(examples.EXAMPLES_DIRECTORY, "df_3d_binning_slope_elevation_aspect.csv"), index_col=None,
         )
 
         # Get values for arrays from the above 3D binning
         perbin_values = xdem.spatialstats.get_perbin_nd_binning(
-            df=df,
+            df=df_binning,
             list_var=[
                 self.slope.data,
                 self.ref.data,
@@ -351,10 +348,10 @@ class TestBinning:
         assert np.shape(self.slope.data) == np.shape(perbin_values)
 
         # Check that the bin are rightly recognized
-        df = df[df.nd == 3]
+        df_binning = df_binning[df_binning.nd == 3]
         # Convert the intervals from string due to saving to file
         for var in ["slope", "elevation", "aspect"]:
-            df[var] = [xdem.spatialstats._pandas_str_to_interval(x) for x in df[var]]
+            df_binning[var] = [xdem.spatialstats.pandas_str_to_interval(x) for x in df_binning[var]]
 
         # Take 1000 random points in the array
         rng = np.random.default_rng(42)
@@ -376,10 +373,10 @@ class TestBinning:
             # Isolate the bin in the dataframe
             index_bin = np.logical_and.reduce(
                 (
-                    [h in interv for interv in df["elevation"]],
-                    [slp in interv for interv in df["slope"]],
-                    [asp in interv for interv in df["aspect"]],
-                )
+                    [h in interv for interv in df_binning["elevation"]],
+                    [slp in interv for interv in df_binning["slope"]],
+                    [asp in interv for interv in df_binning["aspect"]],
+                ),
             )
             # It might not exist in the binning intervals (if extreme values were not subsampled in test_nd_binning)
             if np.count_nonzero(index_bin) == 0:
@@ -388,7 +385,7 @@ class TestBinning:
             assert np.count_nonzero(index_bin) == 1
 
             # Get the statistic value and verify that this was the one returned by the function
-            statistic_value = df["nanmedian"][index_bin].values[0]
+            statistic_value = df_binning["nanmedian"][index_bin].values[0]
             # Nan equality does not work, so we compare finite values first
             if ~np.isnan(statistic_value):
                 assert statistic_value == perbin_values[x, y]
@@ -398,7 +395,6 @@ class TestBinning:
 
     def test_two_step_standardization(self) -> None:
         """Test two-step standardization function"""
-
         # Reproduce the first steps of binning
         df_binning = xdem.spatialstats.nd_binning(
             values=self.diff[~self.mask],
@@ -407,7 +403,7 @@ class TestBinning:
             statistics=[xdem.spatialstats.nmad],
         )
         unscaled_fun = xdem.spatialstats.interp_nd_binning(
-            df_binning, list_var_names=["var1", "var2"], statistic="nmad"
+            df_binning, list_var_names=["var1", "var2"], statistic="nmad",
         )
         # The zscore spread should not be one right after binning
         zscores = self.diff[~self.mask] / unscaled_fun((self.slope[~self.mask], self.maximum_curv[~self.mask]))
@@ -432,18 +428,17 @@ class TestBinning:
         test_slopes = np.linspace(0, 50, 50)
         test_max_curvs = np.linspace(0, 10, 50)
         assert np.array_equal(
-            unscaled_fun((test_slopes, test_max_curvs)) * scale_fac_std, final_func((test_slopes, test_max_curvs))
+            unscaled_fun((test_slopes, test_max_curvs)) * scale_fac_std, final_func((test_slopes, test_max_curvs)),
         )
 
     def test_estimate_model_heteroscedasticity_and_infer_from_stable(self) -> None:
         """Test consistency of outputs and errors in wrapper functions for estimation of heteroscedasticity"""
-
         # Test infer function
         errors_1, df_binning_1, err_fun_1 = xdem.spatialstats.infer_heteroscedasticity_from_stable(
-            dvalues=self.diff, list_var=[self.slope, self.maximum_curv], unstable_mask=self.outlines
+            dvalues=self.diff, list_var=[self.slope, self.maximum_curv], unstable_mask=self.outlines,
         )
 
-        df_binning_2, err_fun_2 = xdem.spatialstats._estimate_model_heteroscedasticity(
+        df_binning_2, err_fun_2 = xdem.spatialstats.estimate_model_heteroscedasticity(
             dvalues=self.diff[~self.mask],
             list_var=[self.slope[~self.mask], self.maximum_curv[~self.mask]],
             list_var_names=["var1", "var2"],
@@ -460,20 +455,20 @@ class TestBinning:
         assert np.array_equal(errors_1_arr, errors_2_arr, equal_nan=True)
 
         # Save for use in TestVariogram
-        errors_1.save(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors_1.save(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Check that errors are raised with wrong input
         with pytest.raises(ValueError, match="The values must be a Raster or NumPy array, or a list of those."):
             xdem.spatialstats.infer_heteroscedasticity_from_stable(
-                dvalues="not_an_array", stable_mask=~self.mask, list_var=[self.slope.get_nanarray()]
+                dvalues="not_an_array", stable_mask=~self.mask, list_var=[self.slope.get_nanarray()],
             )
         with pytest.raises(ValueError, match="The stable mask must be a Vector, Mask, GeoDataFrame or NumPy array."):
             xdem.spatialstats.infer_heteroscedasticity_from_stable(
-                dvalues=self.diff, stable_mask="not_a_vector_or_array", list_var=[self.slope.get_nanarray()]
+                dvalues=self.diff, stable_mask="not_a_vector_or_array", list_var=[self.slope.get_nanarray()],
             )
         with pytest.raises(ValueError, match="The unstable mask must be a Vector, Mask, GeoDataFrame or NumPy array."):
             xdem.spatialstats.infer_heteroscedasticity_from_stable(
-                dvalues=self.diff, unstable_mask="not_a_vector_or_array", list_var=[self.slope.get_nanarray()]
+                dvalues=self.diff, unstable_mask="not_a_vector_or_array", list_var=[self.slope.get_nanarray()],
             )
 
         with pytest.raises(
@@ -482,29 +477,31 @@ class TestBinning:
             "values contain a Raster.",
         ):
             xdem.spatialstats.infer_heteroscedasticity_from_stable(
-                dvalues=self.diff.get_nanarray(), stable_mask=self.outlines, list_var=[self.slope.get_nanarray()]
+                dvalues=self.diff.get_nanarray(), stable_mask=self.outlines, list_var=[self.slope.get_nanarray()],
             )
 
     def test_plot_binning(self) -> None:
-
+        """Check that all the plottings fail with a warning when using invalid data."""
         # Define placeholder data
-        df = pd.DataFrame({"var1": [0, 1, 2], "var2": [2, 3, 4], "statistic": [0, 0, 0]})
+        df_binning = pd.DataFrame({"var1": [0, 1, 2], "var2": [2, 3, 4], "statistic": [0, 0, 0]})
 
         # Check that the 1D plotting fails with a warning if the variable or statistic is not well-defined
         with pytest.raises(ValueError, match='The variable "var3" is not part of the provided dataframe column names.'):
-            xdem.spatialstats.plot_1d_binning(df, var_name="var3", statistic_name="statistic")
+            xdem.spatialstats.plot_1d_binning(df_binning, var_name="var3", statistic_name="statistic")
         with pytest.raises(
-            ValueError, match='The statistic "stat" is not part of the provided dataframe column names.'
+            ValueError, match='The statistic "stat" is not part of the provided dataframe column names.',
         ):
-            xdem.spatialstats.plot_1d_binning(df, var_name="var1", statistic_name="stat")
+            xdem.spatialstats.plot_1d_binning(df_binning, var_name="var1", statistic_name="stat")
 
         # Same for the 2D plotting
         with pytest.raises(ValueError, match='The variable "var3" is not part of the provided dataframe column names.'):
-            xdem.spatialstats.plot_2d_binning(df, var_name_1="var3", var_name_2="var1", statistic_name="statistic")
+            xdem.spatialstats.plot_2d_binning(df_binning, var_name_1="var3",
+                                              var_name_2="var1",
+                                              statistic_name="statistic")
         with pytest.raises(
-            ValueError, match='The statistic "stat" is not part of the provided dataframe column names.'
+            ValueError, match='The statistic "stat" is not part of the provided dataframe column names.',
         ):
-            xdem.spatialstats.plot_2d_binning(df, var_name_1="var1", var_name_2="var1", statistic_name="stat")
+            xdem.spatialstats.plot_2d_binning(df_binning, var_name_1="var1", var_name_2="var1", statistic_name="stat")
 
 
 class TestVariogram:
@@ -513,47 +510,45 @@ class TestVariogram:
 
     def test_sample_multirange_variogram_default(self) -> None:
         """Verify that the default function runs, and its basic output"""
-
         # Check the variogram output is consistent for a random state
-        df = xdem.spatialstats.sample_empirical_variogram(values=self.diff, subsample=10, random_state=42)
-        # assert df["exp"][15] == pytest.approx(5.11900520324707, abs=1e-3)
-        assert df["lags"][15] == pytest.approx(5120)
-        assert df["count"][15] == 2
+        df_vgm = xdem.spatialstats.sample_empirical_variogram(values=self.diff, subsample=10, random_state=42)
+        # assert df_vgm["exp"][15] == pytest.approx(5.11900520324707, abs=1e-3)
+        assert df_vgm["lags"][15] == pytest.approx(5120)
+        assert df_vgm["count"][15] == 2
         # With a single run, no error can be estimated
-        assert all(np.isnan(df.err_exp.values))
+        assert all(np.isnan(df_vgm.err_exp.values))
 
         # Check that all type of coordinate inputs work
         # Only the array and the ground sampling distance
         xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff.data, gsd=self.diff.res[0], subsample=10, random_state=42
+            values=self.diff.data, gsd=self.diff.res[0], subsample=10, random_state=42,
         )
 
         # Test multiple runs
-        df2 = xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff, subsample=10, random_state=42, n_variograms=2
+        df_vgm2 = xdem.spatialstats.sample_empirical_variogram(
+            values=self.diff, subsample=10, random_state=42, n_variograms=2,
         )
 
         # Check that an error is estimated
-        assert any(~np.isnan(df2.err_exp.values))
+        assert any(~np.isnan(df_vgm2.err_exp.values))
 
         # Test that running on several cores does not trigger any error
         xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff, subsample=10, random_state=42, n_variograms=2, n_jobs=2
+            values=self.diff, subsample=10, random_state=42, n_variograms=2, n_jobs=2,
         )
 
         # Test plotting of empirical variogram by itself
         if PLOT:
-            xdem.spatialstats.plot_variogram(df2)
+            xdem.spatialstats.plot_variogram(df_vgm2)
 
     def test_sample_empirical_variogram_speed(self) -> None:
         """Verify that no speed is lost outside of routines on variogram sampling by comparing manually to skgstat"""
-
         values = self.diff
         subsample = 10
 
         # First, run the xDEM wrapper function
         # t0 = time.time()
-        df = xdem.spatialstats.sample_empirical_variogram(values=values, subsample=subsample, random_state=42)
+        df_vgm = xdem.spatialstats.sample_empirical_variogram(values=values, subsample=subsample, random_state=42)
         # t1 = time.time()
 
         # Second, do it manually with skgstat
@@ -568,7 +563,7 @@ class TestVariogram:
         # Redefine parameters fed to skgstat manually
         # Maxlag
         maxlag = np.sqrt(
-            (np.max(coords[:, 0]) - np.min(coords[:, 0])) ** 2 + (np.max(coords[:, 1]) - np.min(coords[:, 1])) ** 2
+            (np.max(coords[:, 0]) - np.min(coords[:, 0])) ** 2 + (np.max(coords[:, 1]) - np.min(coords[:, 1])) ** 2,
         )
 
         # Binning function
@@ -585,8 +580,8 @@ class TestVariogram:
         shape = values.shape
 
         keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
-        runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(
-            **keyword_arguments
+        runs, samples, ratio_subsample = xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(
+            **keyword_arguments,
         )
 
         # Index of valid values
@@ -603,7 +598,7 @@ class TestVariogram:
             # Now even for a n_variograms=1 we sample other integers for the random number generator
             rnd=np.random.default_rng(42).choice(1, 1, replace=False),
         )
-        V = skgstat.Variogram(
+        vgm = skgstat.Variogram(
             rems,
             values=values_arr[~mask_nodata].ravel(),
             normalize=False,
@@ -614,21 +609,21 @@ class TestVariogram:
         # t4 = time.time()
 
         # Get bins, empirical variogram values, and bin count
-        bins, exp = V.get_empirical(bin_center=False)
-        count = V.bin_count
+        bins, exp = vgm.get_empirical(bin_center=False)
+        count = vgm.bin_count
 
         # Write to dataframe
-        df2 = pd.DataFrame()
-        df2 = df2.assign(exp=exp, bins=bins, count=count)
-        df2 = df2.rename(columns={"bins": "lags"})
-        df2["err_exp"] = np.nan
-        df2.drop(df2.tail(1).index, inplace=True)
-        df2 = df2.astype({"exp": "float64", "err_exp": "float64", "lags": "float64", "count": "int64"})
+        df_vgm2 = pd.DataFrame()
+        df_vgm2 = df_vgm2.assign(exp=exp, bins=bins, count=count)
+        df_vgm2 = df_vgm2.rename(columns={"bins": "lags"})
+        df_vgm2["err_exp"] = np.nan
+        df_vgm2 = df_vgm2.drop(df_vgm2.tail(1).index)
+        df_vgm2 = df_vgm2.astype({"exp": "float64", "err_exp": "float64", "lags": "float64", "count": "int64"})
 
         # t2 = time.time()
 
         # Check if the two frames are equal
-        pd.testing.assert_frame_equal(df, df2)
+        pd.testing.assert_frame_equal(df_vgm, df_vgm2)
 
         # Check that the two ways are taking the same time with 50% margin
         # time_method_1 = t1 - t0
@@ -641,30 +636,28 @@ class TestVariogram:
         # assert time_metricspace_variogram == pytest.approx(time_method_2, rel=0.3)
 
     @pytest.mark.parametrize(
-        "subsample_method", ["pdist_point", "pdist_ring", "pdist_disk", "cdist_point"]
+        "subsample_method", ["pdist_point", "pdist_ring", "pdist_disk", "cdist_point"],
     )  # type: ignore
-    def test_sample_multirange_variogram_methods(self, subsample_method) -> None:
+    def test_sample_multirange_variogram_methods(self, subsample_method: str) -> None:
         """Verify that all other methods run"""
-
         # Check the variogram estimation runs for several methods
-        df = xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff, subsample=10, random_state=42, subsample_method=subsample_method
+        df_vgm = xdem.spatialstats.sample_empirical_variogram(
+            values=self.diff, subsample=10, random_state=42, subsample_method=subsample_method,
         )
 
-        assert not df.empty
+        assert not df_vgm.empty
 
         # Check that the output is correct
         expected_columns = ["exp", "lags", "count"]
         expected_dtypes = [np.float64, np.float64, np.int64]
         for col in expected_columns:
             # Check that the column exists
-            assert col in df.columns
+            assert col in df_vgm.columns
             # Check that the column has the correct dtype
-            assert df[col].dtype == expected_dtypes[expected_columns.index(col)]
+            assert df_vgm[col].dtype == expected_dtypes[expected_columns.index(col)]
 
     def test_sample_multirange_variogram_args(self) -> None:
         """Verify that optional parameters run only for their specific method, raise warning otherwise"""
-
         # Define parameters
         pdist_args: EmpiricalVariogramKArgs = {"pdist_multi_ranges": [0, self.diff.res[0] * 5, self.diff.res[0] * 10]}
         cdist_args: EmpiricalVariogramKArgs = {"ratio_subsample": 0.5, "runs": 10}
@@ -674,7 +667,7 @@ class TestVariogram:
         with pytest.warns(UserWarning):
             # An argument only use by cdist with a pdist method
             xdem.spatialstats.sample_empirical_variogram(
-                values=self.diff, subsample=10, random_state=42, subsample_method="pdist_ring", **cdist_args
+                values=self.diff, subsample=10, random_state=42, subsample_method="pdist_ring", **cdist_args,
             )
 
         with pytest.warns(UserWarning):
@@ -699,12 +692,12 @@ class TestVariogram:
 
         # Check the function passes optional arguments specific to pdist methods without warning
         xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff, subsample=10, random_state=42, subsample_method="pdist_ring", **pdist_args
+            values=self.diff, subsample=10, random_state=42, subsample_method="pdist_ring", **pdist_args,
         )
 
         # Check the function passes optional arguments specific to cdist methods without warning
         xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff, random_state=42, subsample=10, subsample_method="cdist_equidistant", **cdist_args
+            values=self.diff, random_state=42, subsample=10, subsample_method="cdist_equidistant", **cdist_args,
         )
 
     # N is the number of samples in an ensemble
@@ -712,7 +705,6 @@ class TestVariogram:
     @pytest.mark.parametrize("shape", [(50, 50), (100, 100), (500, 500)])  # type: ignore
     def test_choose_cdist_equidistant_sampling_parameters(self, subsample: int, shape: tuple[int, int]) -> None:
         """Verify that the automatically-derived parameters of equidistant sampling are sound"""
-
         # Assign an arbitrary extent
         extent = (0, 1, 0, 1)
 
@@ -722,8 +714,8 @@ class TestVariogram:
 
         # Run the function
         keyword_arguments = {"subsample": subsample, "extent": extent, "shape": shape}
-        runs, samples, ratio_subsample = xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(
-            **keyword_arguments
+        runs, samples, ratio_subsample = xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(
+            **keyword_arguments,
         )
 
         # There is at least 2 samples
@@ -745,15 +737,13 @@ class TestVariogram:
 
     def test_errors_subsample_parameter(self) -> None:
         """Tests that an error is raised when the subsample argument is too little"""
-
         keyword_arguments = {"subsample": 3, "extent": (0, 1, 0, 1), "shape": (10, 10)}
 
         with pytest.raises(ValueError, match="The number of subsamples needs to be at least 10."):
-            xdem.spatialstats._choose_cdist_equidistant_sampling_parameters(**keyword_arguments)
+            xdem.spatialstats.choose_cdist_equidistant_sampling_parameters(**keyword_arguments)
 
     def test_multirange_fit_performance(self) -> None:
         """Verify that the fitting works with artificial dataset"""
-
         # First, generate a sum of modelled variograms: ranges and  partial sills for three models
         params_real = (100, 0.7, 1000, 0.2, 10000, 0.1)
         r1, ps1, r2, ps2, r3, ps3 = params_real
@@ -770,11 +760,11 @@ class TestVariogram:
         sigma = np.ones(len(x)) * sig
 
         # Put all in a dataframe
-        df = pd.DataFrame()
-        df = df.assign(lags=x, exp=y_simu, err_exp=sigma)
+        df_vgm = pd.DataFrame()
+        df_vgm = df_vgm.assign(lags=x, exp=y_simu, err_exp=sigma)
 
         # Run the fitting
-        fun, params_est = xdem.spatialstats.fit_sum_model_variogram(["spherical", "spherical", "spherical"], df)
+        fun, params_est = xdem.spatialstats.fit_sum_model_variogram(["spherical", "spherical", "spherical"], df_vgm)
 
         for i in range(len(params_est)):
             # Assert all parameters were correctly estimated within a 30% relative margin
@@ -782,18 +772,17 @@ class TestVariogram:
             assert params_real[2 * i + 1] == pytest.approx(params_est["psill"].values[i], rel=0.3)
 
         if PLOT:
-            xdem.spatialstats.plot_variogram(df, list_fit_fun=[fun])
+            xdem.spatialstats.plot_variogram(df_vgm, list_fit_fun=[fun])
 
     def test_check_params_variogram_model(self) -> None:
         """Verify that the checking function for the modelled variogram parameters dataframe returns adequate errors"""
-
         # Check when missing a column
         with pytest.raises(
             ValueError,
-            match='The dataframe with variogram parameters must contain the columns "model",' ' "range" and "psill".',
+            match='The dataframe with variogram parameters must contain the columns "model", "range" and "psill".',
         ):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["spherical"], "range": [100]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["spherical"], "range": [100]}),
             )
 
         # Check with wrong model format
@@ -804,32 +793,32 @@ class TestVariogram:
             + ", ".join(list_supported_models)
             + ".",
         ):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["Supraluminal"], "range": [100], "psill": [1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["Supraluminal"], "range": [100], "psill": [1]}),
             )
 
         # Check with wrong range format
         with pytest.raises(ValueError, match="The variogram ranges must be float or integer."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["spherical"], "range": ["a"], "psill": [1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["spherical"], "range": ["a"], "psill": [1]}),
             )
 
         # Check with negative range
         with pytest.raises(ValueError, match="The variogram ranges must have non-zero, positive values."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["spherical"], "range": [-1], "psill": [1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["spherical"], "range": [-1], "psill": [1]}),
             )
 
         # Check with wrong partial sill format
         with pytest.raises(ValueError, match="The variogram partial sills must be float or integer."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": ["a"]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": ["a"]}),
             )
 
         # Check with negative partial sill
         with pytest.raises(ValueError, match="The variogram partial sills must have non-zero, positive values."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": [-1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["spherical"], "range": [100], "psill": [-1]}),
             )
 
         # Check with a model that requires smoothness and without the smoothness column
@@ -838,25 +827,24 @@ class TestVariogram:
             match='The dataframe with variogram parameters must contain the column "smooth" '
             "for the smoothness factor when using Matern or Stable models.",
         ):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1]}),
             )
 
         # Check with wrong smoothness format
         with pytest.raises(ValueError, match="The variogram smoothness parameter must be float or integer."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": ["a"]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": ["a"]}),
             )
 
         # Check with negative smoothness
         with pytest.raises(ValueError, match="The variogram smoothness parameter must have non-zero, positive values."):
-            xdem.spatialstats._check_validity_params_variogram(
-                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": [-1]})
+            xdem.spatialstats.check_validity_params_variogram(
+                pd.DataFrame(data={"model": ["stable"], "range": [100], "psill": [1], "smooth": [-1]}),
             )
 
     def test_estimate_model_spatial_correlation_and_infer_from_stable(self) -> None:
         """Test consistency of outputs and errors in wrapper functions for estimation of spatial correlation"""
-
         warnings.filterwarnings("ignore", category=RuntimeWarning, message="Mean of empty slice")
 
         # Keep only data on stable
@@ -864,29 +852,29 @@ class TestVariogram:
         diff_on_stable.set_mask(self.mask)
 
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Standardize the differences
         zscores = diff_on_stable / errors
 
         # Run wrapper estimate and model function
-        emp_vgm_1, params_model_vgm_1, _ = xdem.spatialstats._estimate_model_spatial_correlation(
-            dvalues=zscores, list_models=["Gau", "Sph"], subsample=10, random_state=42
+        emp_vgm_1, params_model_vgm_1, _ = xdem.spatialstats.estimate_model_spatial_correlation(
+            dvalues=zscores, list_models=["Gau", "Sph"], subsample=10, random_state=42,
         )
 
         # Check that the output matches that of the original function under the same random state
         emp_vgm_2 = xdem.spatialstats.sample_empirical_variogram(
-            values=zscores, estimator="dowd", subsample=10, random_state=42
+            values=zscores, estimator="dowd", subsample=10, random_state=42,
         )
         pd.testing.assert_frame_equal(emp_vgm_1, emp_vgm_2)
         params_model_vgm_2 = xdem.spatialstats.fit_sum_model_variogram(
-            list_models=["Gau", "Sph"], empirical_variogram=emp_vgm_2
+            list_models=["Gau", "Sph"], empirical_variogram=emp_vgm_2,
         )[1]
         pd.testing.assert_frame_equal(params_model_vgm_1, params_model_vgm_2)
 
         # Run wrapper infer from stable function with a Raster and the mask, and check the consistency there as well
         emp_vgm_3, params_model_vgm_3, _ = xdem.spatialstats.infer_spatial_correlation_from_stable(
-            dvalues=zscores, stable_mask=~self.mask, list_models=["Gau", "Sph"], subsample=10, random_state=42
+            dvalues=zscores, stable_mask=~self.mask, list_models=["Gau", "Sph"], subsample=10, random_state=42,
         )
         pd.testing.assert_frame_equal(emp_vgm_1, emp_vgm_3)
         pd.testing.assert_frame_equal(params_model_vgm_1, params_model_vgm_3)
@@ -915,21 +903,21 @@ class TestVariogram:
         )
         # Save the modelled variogram for later used in TestNeffEstimation
         params_model_vgm_5.to_csv(
-            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False
+            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index=False,
         )
 
         # Check that errors are raised with wrong input
         with pytest.raises(ValueError, match="The values must be a Raster or NumPy array, or a list of those."):
             xdem.spatialstats.infer_spatial_correlation_from_stable(
-                dvalues="not_an_array", stable_mask=~self.mask, list_models=["Gau", "Sph"], random_state=42
+                dvalues="not_an_array", stable_mask=~self.mask, list_models=["Gau", "Sph"], random_state=42,
             )
         with pytest.raises(ValueError, match="The stable mask must be a Vector, Mask, GeoDataFrame or NumPy array."):
             xdem.spatialstats.infer_spatial_correlation_from_stable(
-                dvalues=self.diff, stable_mask="not_a_vector_or_array", list_models=["Gau", "Sph"], random_state=42
+                dvalues=self.diff, stable_mask="not_a_vector_or_array", list_models=["Gau", "Sph"], random_state=42,
             )
         with pytest.raises(ValueError, match="The unstable mask must be a Vector, Mask, GeoDataFrame or NumPy array."):
             xdem.spatialstats.infer_spatial_correlation_from_stable(
-                dvalues=self.diff, unstable_mask="not_a_vector_or_array", list_models=["Gau", "Sph"], random_state=42
+                dvalues=self.diff, unstable_mask="not_a_vector_or_array", list_models=["Gau", "Sph"], random_state=42,
             )
         diff_on_stable_arr = gu.raster.get_array_and_mask(diff_on_stable)[0]
         with pytest.raises(
@@ -938,45 +926,44 @@ class TestVariogram:
             "values contain a Raster.",
         ):
             xdem.spatialstats.infer_spatial_correlation_from_stable(
-                dvalues=diff_on_stable_arr, stable_mask=self.outlines, list_models=["Gau", "Sph"], random_state=42
+                dvalues=diff_on_stable_arr, stable_mask=self.outlines, list_models=["Gau", "Sph"], random_state=42,
             )
 
     def test_empirical_fit_plotting(self) -> None:
         """Verify that the shape of the empirical variogram output works with the fit and plotting"""
-
         # Check the variogram estimation runs for a random state
-        df = xdem.spatialstats.sample_empirical_variogram(
-            values=self.diff.data, gsd=self.diff.res[0], subsample=50, random_state=42
+        df_vgm = xdem.spatialstats.sample_empirical_variogram(
+            values=self.diff.data, gsd=self.diff.res[0], subsample=50, random_state=42,
         )
 
         # Single model fit
-        fun, _ = xdem.spatialstats.fit_sum_model_variogram(["spherical"], empirical_variogram=df)
+        fun, _ = xdem.spatialstats.fit_sum_model_variogram(["spherical"], empirical_variogram=df_vgm)
 
         # Triple model fit
         fun2, _ = xdem.spatialstats.fit_sum_model_variogram(
-            ["spherical", "spherical", "spherical"], empirical_variogram=df
+            ["spherical", "spherical", "spherical"], empirical_variogram=df_vgm,
         )
 
         if PLOT:
             # Plot with a single model fit
-            xdem.spatialstats.plot_variogram(df, list_fit_fun=[fun])
+            xdem.spatialstats.plot_variogram(df_vgm, list_fit_fun=[fun])
             # Plot with a triple model fit
-            xdem.spatialstats.plot_variogram(df, list_fit_fun=[fun2])
+            xdem.spatialstats.plot_variogram(df_vgm, list_fit_fun=[fun2])
 
         # Check that errors are raised with wrong inputs
         # If the experimental variogram values "exp" are not passed
         with pytest.raises(
-            ValueError, match='The expected variable "exp" is not part of the provided dataframe column names.'
+            ValueError, match='The expected variable "exp" is not part of the provided dataframe column names.',
         ):
             xdem.spatialstats.plot_variogram(pd.DataFrame(data={"wrong_name": [1], "lags": [1], "count": [100]}))
         # If the spatial lags "lags" are not passed
         with pytest.raises(
-            ValueError, match='The expected variable "lags" is not part of the provided dataframe column names.'
+            ValueError, match='The expected variable "lags" is not part of the provided dataframe column names.',
         ):
             xdem.spatialstats.plot_variogram(pd.DataFrame(data={"exp": [1], "wrong_name": [1], "count": [100]}))
         # If the pairwise sample count "count" is not passed
         with pytest.raises(
-            ValueError, match='The expected variable "count" is not part of the provided dataframe column names.'
+            ValueError, match='The expected variable "count" is not part of the provided dataframe column names.',
         ):
             xdem.spatialstats.plot_variogram(pd.DataFrame(data={"exp": [1], "lags": [1], "wrong_name": [100]}))
 
@@ -991,17 +978,17 @@ class TestNeffEstimation:
     @pytest.mark.parametrize("area", [10 ** (2 * i) for i in range(3)])  # type: ignore
     def test_neff_circular_single_range(self, range1: float, psill1: float, model1: float, area: float) -> None:
         """Test the accuracy of numerical integration for one to three models of spherical, gaussian or exponential
-        forms to get the number of effective samples"""
-
+        forms to get the number of effective samples
+        """
         params_variogram_model = pd.DataFrame(data={"model": [model1], "range": [range1], "psill": [psill1]})
 
         # Exact integration
         neff_circ_exact = xdem.spatialstats.neff_circular_approx_theoretical(
-            area=area, params_variogram_model=params_variogram_model
+            area=area, params_variogram_model=params_variogram_model,
         )
         # Numerical integration
         neff_circ_numer = xdem.spatialstats.neff_circular_approx_numerical(
-            area=area, params_variogram_model=params_variogram_model
+            area=area, params_variogram_model=params_variogram_model,
         )
 
         # Check results are the exact same
@@ -1013,11 +1000,11 @@ class TestNeffEstimation:
     @pytest.mark.parametrize("model1", ["spherical", "exponential", "gaussian", "cubic"])  # type: ignore
     @pytest.mark.parametrize("model2", ["spherical", "exponential", "gaussian", "cubic"])  # type: ignore
     def test_neff_circular_three_ranges(
-        self, range1: float, range2: float, range3: float, model1: float, model2: float
+        self, range1: float, range2: float, range3: float, model1: float, model2: float,
     ) -> None:
         """Test the accuracy of numerical integration for one to three models of spherical, gaussian or
-        exponential forms"""
-
+        exponential forms
+        """
         area = 1000
         psill1 = 1
         psill2 = 1
@@ -1029,16 +1016,16 @@ class TestNeffEstimation:
                 "model": [model1, model2, model3],
                 "range": [range1, range2, range3],
                 "psill": [psill1, psill2, psill3],
-            }
+            },
         )
 
         # Exact integration
         neff_circ_exact = xdem.spatialstats.neff_circular_approx_theoretical(
-            area=area, params_variogram_model=params_variogram_model
+            area=area, params_variogram_model=params_variogram_model,
         )
         # Numerical integration
         neff_circ_numer = xdem.spatialstats.neff_circular_approx_numerical(
-            area=area, params_variogram_model=params_variogram_model
+            area=area, params_variogram_model=params_variogram_model,
         )
 
         # Check results are the exact same
@@ -1046,7 +1033,6 @@ class TestNeffEstimation:
 
     def test_neff_exact_and_approx_hugonnet(self) -> None:
         """Test the exact and approximated calculation of the number of effective sample by double covariance sum"""
-
         # Generate a gridded dataset with varying errors associated to each pixel
         shape = (15, 15)
         errors = np.ones(shape)
@@ -1062,19 +1048,19 @@ class TestNeffEstimation:
 
         # Create a list of variogram that, summed, represent the spatial correlation
         params_variogram_model = pd.DataFrame(
-            data={"model": ["spherical", "gaussian"], "range": [5, 50], "psill": [0.5, 0.5]}
+            data={"model": ["spherical", "gaussian"], "range": [5, 50], "psill": [0.5, 0.5]},
         )
 
         # Check that the function runs with default parameters
         # t0 = time.time()
         neff_exact = xdem.spatialstats.neff_exact(
-            coords=coords, errors=errors, params_variogram_model=params_variogram_model
+            coords=coords, errors=errors, params_variogram_model=params_variogram_model,
         )
         # t1 = time.time()
 
         # Check that the non-vectorized version gives the same result
         neff_exact_nv = xdem.spatialstats.neff_exact(
-            coords=coords, errors=errors, params_variogram_model=params_variogram_model, vectorized=False
+            coords=coords, errors=errors, params_variogram_model=params_variogram_model, vectorized=False,
         )
         # t2 = time.time()
         assert neff_exact == pytest.approx(neff_exact_nv, rel=0.001)
@@ -1085,7 +1071,7 @@ class TestNeffEstimation:
         # Check that the approximation function runs with default parameters, sampling 100 out of 250 samples
         # t3 = time.time()
         neff_approx = xdem.spatialstats.neff_hugonnet_approx(
-            coords=coords, errors=errors, params_variogram_model=params_variogram_model, subsample=100, random_state=42
+            coords=coords, errors=errors, params_variogram_model=params_variogram_model, subsample=100, random_state=42,
         )
         # t4 = time.time()
 
@@ -1110,15 +1096,14 @@ class TestNeffEstimation:
 
     def test_number_effective_samples(self) -> None:
         """Test that the wrapper function for neff functions behaves correctly and that output values are robust"""
-
         # The function should return the same result as neff_circular_approx_numerical when using a numerical area
         area = 10000
         params_variogram_model = pd.DataFrame(
-            data={"model": ["spherical", "gaussian"], "range": [300, 3000], "psill": [0.5, 0.5]}
+            data={"model": ["spherical", "gaussian"], "range": [300, 3000], "psill": [0.5, 0.5]},
         )
 
         neff1 = xdem.spatialstats.neff_circular_approx_numerical(
-            area=area, params_variogram_model=params_variogram_model
+            area=area, params_variogram_model=params_variogram_model,
         )
         neff2 = xdem.spatialstats.number_effective_samples(area=area, params_variogram_model=params_variogram_model)
 
@@ -1167,7 +1152,7 @@ class TestNeffEstimation:
         # Check that the number of effective samples matches that of the circular approximation within 25%
         area_brom = np.sum(outlines_brom.ds.area.values)
         neff4 = xdem.spatialstats.number_effective_samples(
-            area=area_brom, params_variogram_model=params_variogram_model
+            area=area_brom, params_variogram_model=params_variogram_model,
         )
         assert neff4 == pytest.approx(neff2, rel=0.25)
         # The circular approximation is always conservative, so should yield a smaller value
@@ -1180,26 +1165,25 @@ class TestNeffEstimation:
             "of the shortest correlation range, which might result in large memory usage.",
         ):
             xdem.spatialstats.number_effective_samples(
-                area=outlines_brom, params_variogram_model=params_variogram_model
+                area=outlines_brom, params_variogram_model=params_variogram_model,
             )
         with pytest.raises(ValueError, match="Area must be a float, integer, Vector subclass or geopandas dataframe."):
             xdem.spatialstats.number_effective_samples(
-                area="not supported", params_variogram_model=params_variogram_model
+                area="not supported", params_variogram_model=params_variogram_model,
             )
         with pytest.raises(ValueError, match="The rasterize resolution must be a float, integer or Raster subclass."):
             xdem.spatialstats.number_effective_samples(
-                area=outlines_brom, params_variogram_model=params_variogram_model, rasterize_resolution=(10, 10)
+                area=outlines_brom, params_variogram_model=params_variogram_model, rasterize_resolution=(10, 10),
             )
 
     def test_spatial_error_propagation(self) -> None:
         """Test that the spatial error propagation wrapper function runs properly"""
-
         # Load the error map from TestBinning
-        errors = Raster(os.path.join(examples._EXAMPLES_DIRECTORY, "dh_error.tif"))
+        errors = Raster(os.path.join(examples.EXAMPLES_DIRECTORY, "dh_error.tif"))
 
         # Load the spatial correlation from TestVariogram
         params_variogram_model = pd.read_csv(
-            os.path.join(examples._EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None
+            os.path.join(examples.EXAMPLES_DIRECTORY, "df_variogram_model_params.csv"), index_col=None,
         )
 
         # Run the function with vector areas
@@ -1219,7 +1203,7 @@ class TestNeffEstimation:
         # Run the function with numeric areas (sum needed for Medalsbreen that has two separate polygons)
         areas_numeric = [np.sum(area_vec.area.values) for area_vec in areas_vector]
         list_stderr = xdem.spatialstats.spatial_error_propagation(
-            areas=areas_numeric, errors=errors, params_variogram_model=params_variogram_model
+            areas=areas_numeric, errors=errors, params_variogram_model=params_variogram_model,
         )
 
         # Check that the outputs are consistent: the numeric method should always give a neff that is almost the same
@@ -1231,10 +1215,9 @@ class TestNeffEstimation:
 class TestSubSampling:
     def test_circular_masking(self) -> None:
         """Test that the circular masking works as intended"""
-
         # using default (center should be [2,2], radius 2)
-        circ = xdem.spatialstats._create_circular_mask((5, 5))
-        circ2 = xdem.spatialstats._create_circular_mask((5, 5), center=(2, 2), radius=2)
+        circ = xdem.spatialstats.create_circular_mask((5, 5))
+        circ2 = xdem.spatialstats.create_circular_mask((5, 5), center=(2, 2), radius=2)
 
         # check default center and radius are derived properly
         assert np.array_equal(circ, circ2)
@@ -1247,30 +1230,29 @@ class TestSubSampling:
 
         # check distance is not a multiple of pixels (more accurate subsampling)
         # will create a 1-pixel mask around the center
-        circ3 = xdem.spatialstats._create_circular_mask((5, 5), center=(1, 1), radius=1)
+        circ3 = xdem.spatialstats.create_circular_mask((5, 5), center=(1, 1), radius=1)
 
         eq_circ3 = np.zeros((5, 5), dtype=bool)
         eq_circ3[1, 1] = True
         assert np.array_equal(circ3, eq_circ3)
 
         # will create a square mask (<1.5 pixel) around the center
-        circ4 = xdem.spatialstats._create_circular_mask((5, 5), center=(1, 1), radius=1.5)
+        circ4 = xdem.spatialstats.create_circular_mask((5, 5), center=(1, 1), radius=1.5)
         # should not be the same as radius = 1
         assert not np.array_equal(circ3, circ4)
 
     def test_ring_masking(self) -> None:
         """Test that the ring masking works as intended"""
-
         # by default, the mask is only an outside circle (ring of size 0)
-        ring1 = xdem.spatialstats._create_ring_mask((5, 5))
-        circ1 = xdem.spatialstats._create_circular_mask((5, 5))
+        ring1 = xdem.spatialstats.create_ring_mask((5, 5))
+        circ1 = xdem.spatialstats.create_circular_mask((5, 5))
 
         assert np.array_equal(ring1, circ1)
 
         # test rings with different inner radius
-        ring2 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=1, out_radius=2)
-        ring3 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=0, out_radius=2)
-        ring4 = xdem.spatialstats._create_ring_mask((5, 5), in_radius=1.5, out_radius=2)
+        ring2 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=1, out_radius=2)
+        ring3 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=0, out_radius=2)
+        ring4 = xdem.spatialstats.create_ring_mask((5, 5), in_radius=1.5, out_radius=2)
 
         assert np.logical_and(~np.array_equal(ring2, ring3), ~np.array_equal(ring3, ring4))
 
@@ -1284,14 +1266,13 @@ class TestSubSampling:
 class TestPatchesMethod:
     def test_patches_method_loop_quadrant(self) -> None:
         """Check that the patches method with quadrant loops (vectorized=False) functions correctly"""
-
         diff, mask = load_ref_and_diff()[1:3]
 
         gsd = diff.res[0]
         area = 100000
 
         # Check the patches method runs
-        df, df_full = xdem.spatialstats.patches_method(
+        df_patches, df_full = xdem.spatialstats.patches_method(
             diff,
             unstable_mask=mask,
             gsd=gsd,
@@ -1303,13 +1284,13 @@ class TestPatchesMethod:
         )
 
         # First, the summary dataframe
-        assert df.shape == (1, 4)
-        assert all(df.columns == ["nmad", "nb_indep_patches", "exact_areas", "areas"])
+        assert df_patches.shape == (1, 4)
+        assert all(df_patches.columns == ["nmad", "nb_indep_patches", "exact_areas", "areas"])
 
         # Check the sampling is fixed for a random state
-        # assert df["nmad"][0] == pytest.approx(1.8401465163449207, abs=1e-3)
-        assert df["nb_indep_patches"][0] == 100
-        assert df["exact_areas"][0] == pytest.approx(df["areas"][0], rel=0.2)
+        # assert df_patches["nmad"][0] == pytest.approx(1.8401465163449207, abs=1e-3)
+        assert df_patches["nb_indep_patches"][0] == 100
+        assert df_patches["exact_areas"][0] == pytest.approx(df_patches["areas"][0], rel=0.2)
 
         # Then, the full dataframe
         assert df_full.shape == (100, 5)
@@ -1322,14 +1303,13 @@ class TestPatchesMethod:
 
     def test_patches_method_convolution(self) -> None:
         """Check that the patches method with convolution (vectorized=True) functions correctly"""
-
         diff, mask = load_ref_and_diff()[1:3]
 
         gsd = diff.res[0]
         area = 100000
 
         # First, the patches method runs with scipy
-        df = xdem.spatialstats.patches_method(
+        df_patches = xdem.spatialstats.patches_method(
             diff,
             unstable_mask=mask,
             gsd=gsd,
@@ -1339,12 +1319,12 @@ class TestPatchesMethod:
             convolution_method="scipy",
         )
 
-        assert df.shape == (2, 4)
-        assert all(df.columns == ["nmad", "nb_indep_patches", "exact_areas", "areas"])
-        assert df["exact_areas"][0] == pytest.approx(df["areas"][0], rel=0.2)
+        assert df_patches.shape == (2, 4)
+        assert all(df_patches.columns == ["nmad", "nb_indep_patches", "exact_areas", "areas"])
+        assert df_patches["exact_areas"][0] == pytest.approx(df_patches["areas"][0], rel=0.2)
 
         # Second, with numba
-        # df, df_full = xdem.spatialstats.patches_method(
+        # df_patches, df_full = xdem.spatialstats.patches_method(
         #     diff,
         #     unstable_mask=mask.squeeze(),
         #     gsd=gsd,
@@ -1354,6 +1334,6 @@ class TestPatchesMethod:
         #     convolution_method='numba',
         #     return_in_patch_statistics=True)
         #
-        # assert df.shape == (1, 4)
-        # assert all(df.columns == ['nmad', 'nb_indep_patches', 'exact_areas', 'areas'])
-        # assert df['exact_areas'][0] == pytest.approx(df['areas'][0], rel=0.2)
+        # assert df_patches.shape == (1, 4)
+        # assert all(df_patches.columns == ['nmad', 'nb_indep_patches', 'exact_areas', 'areas'])
+        # assert df_patches['exact_areas'][0] == pytest.approx(df_patches['areas'][0], rel=0.2)

--- a/tests/test_terrain.py
+++ b/tests/test_terrain.py
@@ -1,3 +1,5 @@
+"""Functions to test terrain attributes."""
+
 from __future__ import annotations
 
 import os
@@ -77,22 +79,20 @@ class TestTerrainAttribute:
         ],
     )  # type: ignore
     def test_attribute_functions_against_gdaldem(self, attribute: str) -> None:
-        """
-        Test that all attribute functions give the same results as those of GDALDEM within a small tolerance.
+        """Test that all attribute functions give the same results as those of GDALDEM within a small tolerance.
 
         :param attribute: The attribute to test (e.g. 'slope')
         """
-
         functions = {
             "slope_Horn": lambda dem: xdem.terrain.slope(dem.data, resolution=dem.res, degrees=True),
             "aspect_Horn": lambda dem: xdem.terrain.aspect(dem.data, degrees=True),
             "hillshade_Horn": lambda dem: xdem.terrain.hillshade(dem.data, resolution=dem.res),
             "slope_Zevenberg": lambda dem: xdem.terrain.slope(
-                dem.data, resolution=dem.res, method="ZevenbergThorne", degrees=True
+                dem.data, resolution=dem.res, method="ZevenbergThorne", degrees=True,
             ),
             "aspect_Zevenberg": lambda dem: xdem.terrain.aspect(dem.data, method="ZevenbergThorne", degrees=True),
             "hillshade_Zevenberg": lambda dem: xdem.terrain.hillshade(
-                dem.data, resolution=dem.res, method="ZevenbergThorne"
+                dem.data, resolution=dem.res, method="ZevenbergThorne",
             ),
             "tri_Riley": lambda dem: xdem.terrain.terrain_ruggedness_index(dem.data, method="Riley"),
             "tri_Wilson": lambda dem: xdem.terrain.terrain_ruggedness_index(dem.data, method="Wilson"),
@@ -183,13 +183,13 @@ class TestTerrainAttribute:
         "attribute",
         ["slope_Horn", "aspect_Horn", "hillshade_Horn", "curvature", "profile_curvature", "planform_curvature"],
     )  # type: ignore
-    def test_attribute_functions_against_richdem(self, attribute: str, get_terrain_attribute_richdem) -> None:
-        """
-        Test that all attribute functions give the same results as those of RichDEM within a small tolerance.
+    def test_attribute_functions_against_richdem(self,
+                                                 attribute: str,
+                                                 get_terrain_attribute_richdem) -> None: # noqa: ANN001
+        """Test that all attribute functions give the same results as those of RichDEM within a small tolerance.
 
         :param attribute: The attribute to test (e.g. 'slope')
         """
-
         # Functions for xdem-implemented methods
         functions_xdem = {
             "slope_Horn": lambda dem: xdem.terrain.slope(dem, resolution=dem.res, degrees=True),
@@ -208,7 +208,7 @@ class TestTerrainAttribute:
             "curvature": lambda dem: get_terrain_attribute_richdem(dem, attribute="curvature"),
             "profile_curvature": lambda dem: get_terrain_attribute_richdem(dem, attribute="profile_curvature"),
             "planform_curvature": lambda dem: get_terrain_attribute_richdem(
-                dem, attribute="planform_curvature", degrees=True
+                dem, attribute="planform_curvature", degrees=True,
             ),
         }
 
@@ -283,7 +283,6 @@ class TestTerrainAttribute:
 
     def test_hillshade(self) -> None:
         """Test hillshade-specific settings."""
-
         zfactor_1 = xdem.terrain.hillshade(self.dem.data, resolution=self.dem.res, z_factor=1.0)
         zfactor_10 = xdem.terrain.hillshade(self.dem.data, resolution=self.dem.res, z_factor=10.0)
 
@@ -297,17 +296,16 @@ class TestTerrainAttribute:
         assert np.nanmean(low_altitude) < np.nanmean(high_altitude)
 
     @pytest.mark.parametrize(
-        "name", ["curvature", "planform_curvature", "profile_curvature", "maximum_curvature"]
+        "name", ["curvature", "planform_curvature", "profile_curvature", "maximum_curvature"],
     )  # type: ignore
     def test_curvatures(self, name: str) -> None:
         """Test the curvature functions"""
-
         # Copy the DEM to ensure that the inter-test state is unchanged, and because the mask will be modified.
         dem = self.dem.copy()
 
         # Derive curvature without any gaps
         curvature = xdem.terrain.get_terrain_attribute(
-            dem.data, attribute=name, resolution=dem.res, edge_method="nearest"
+            dem.data, attribute=name, resolution=dem.res, edge_method="nearest",
         )
 
         # Validate that the array has the same shape as the input and that all values are finite.
@@ -332,14 +330,13 @@ class TestTerrainAttribute:
 
     def test_get_terrain_attribute(self) -> None:
         """Test the get_terrain_attribute function by itself."""
-
         # Validate that giving only one terrain attribute only returns that, and not a list of len() == 1
         slope = xdem.terrain.get_terrain_attribute(self.dem.data, "slope", resolution=self.dem.res)
         assert isinstance(slope, np.ndarray)
 
         # Create three products at the same time
         slope2, _, hillshade = xdem.terrain.get_terrain_attribute(
-            self.dem.data, ["slope", "aspect", "hillshade"], resolution=self.dem.res
+            self.dem.data, ["slope", "aspect", "hillshade"], resolution=self.dem.res,
         )
 
         # Create a hillshade using its own function
@@ -355,24 +352,23 @@ class TestTerrainAttribute:
 
     def test_get_terrain_attribute_errors(self) -> None:
         """Test the get_terrain_attribute function raises appropriate errors."""
-
         # Below, re.escape() is needed to match expressions that have special characters (e.g., parenthesis, bracket)
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Slope method 'DoesNotExist' is not supported. Must be one of: " "['Horn', 'ZevenbergThorne']"
+                "Slope method 'DoesNotExist' is not supported. Must be one of: ['Horn', 'ZevenbergThorne']",
             ),
         ):
             xdem.terrain.slope(self.dem.data, method="DoesNotExist")
 
         with pytest.raises(
             ValueError,
-            match=re.escape("TRI method 'DoesNotExist' is not supported. Must be one of: " "['Riley', 'Wilson']"),
+            match=re.escape("TRI method 'DoesNotExist' is not supported. Must be one of: ['Riley', 'Wilson']"),
         ):
             xdem.terrain.terrain_ruggedness_index(self.dem.data, method="DoesNotExist")
 
     def test_raster_argument(self) -> None:
-
+        """Test raster argument."""
         slope, aspect = xdem.terrain.get_terrain_attribute(self.dem, attribute=["slope", "aspect"])
 
         assert slope != aspect
@@ -384,11 +380,9 @@ class TestTerrainAttribute:
         assert slope.crs == self.dem.crs == aspect.crs
 
     def test_rugosity_jenness(self) -> None:
-        """
-        Test the rugosity with the same example as in Jenness (2004),
+        """Test the rugosity with the same example as in Jenness (2004),
         https://doi.org/10.2193/0091-7648(2004)032[0829:CLSAFD]2.0.CO;2.
         """
-
         # Derive rugosity from the function
         dem = np.array([[190, 170, 155], [183, 165, 145], [175, 160, 122]], dtype="float32")
 
@@ -406,7 +400,6 @@ class TestTerrainAttribute:
     @pytest.mark.parametrize("resolution", np.linspace(0.01, 100, 10))  # type: ignore
     def test_rugosity_simple_cases(self, dh: float, resolution: float) -> None:
         """Test the rugosity calculation for simple cases."""
-
         # We here check the value for a fully symmetric case: the rugosity calculation can be simplified because all
         # eight triangles have the same surface area, see Jenness (2004).
 
@@ -424,21 +417,20 @@ class TestTerrainAttribute:
 
         # Formula for area A of one triangle
         s = (side1 + side2 + side3) / 2.0
-        A = np.sqrt(s * (s - side1) * (s - side2) * (s - side3))
+        a = np.sqrt(s * (s - side1) * (s - side2) * (s - side3))
 
         # We sum the area of the eight triangles, and divide by the planimetric area (resolution squared)
-        r = 8 * A / (resolution**2)
+        r = 8 * a / (resolution**2)
 
         # Check rugosity value is valid
         assert r == pytest.approx(rugosity[1, 1], rel=10 ** (-6))
 
     def test_get_quadric_coefficients(self) -> None:
         """Test the outputs and exceptions of the get_quadric_coefficients() function."""
-
         dem = np.array([[1, 1, 1], [1, 2, 1], [1, 1, 1]], dtype="float32")
 
         coefficients = xdem.terrain.get_quadric_coefficients(
-            dem, resolution=1.0, edge_method="nearest", make_rugosity=True
+            dem, resolution=1.0, edge_method="nearest", make_rugosity=True,
         )
 
         # Check all coefficients are finite with an edge method

--- a/tests/test_vcrs.py
+++ b/tests/test_vcrs.py
@@ -20,10 +20,10 @@ class TestVCRS:
         """Test parsing of vertical CRS name from DEM product name."""
         # Check that the value for the key is returned by the function
         for product in xdem.vcrs.vcrs_dem_products:
-            assert xdem.vcrs.parse_vcrs_name_from_product(product) == xdem.vcrs.vcrs_dem_products[product]
+            assert xdem.vcrs._parse_vcrs_name_from_product(product) == xdem.vcrs.vcrs_dem_products[product] # noqa: SLF001
 
         # And that, otherwise, it's a None
-        assert xdem.vcrs.parse_vcrs_name_from_product("BESTDEM") is None
+        assert xdem.vcrs._parse_vcrs_name_from_product("BESTDEM") is None # noqa: SLF001
 
     # Expect outputs for the inputs
     @pytest.mark.parametrize(
@@ -38,11 +38,11 @@ class TestVCRS:
     )  # type: ignore
     def test_vcrs_from_crs(self, input_output: tuple[CRS, CRS]) -> None:
         """Test the extraction of a vertical CRS from a CRS."""
-        input_ = input_output[0]
+        input = input_output[0] # noqa: A001
         output = input_output[1]
 
         # Extract vertical CRS from CRS
-        vcrs = xdem.vcrs.vcrs_from_crs(crs=input_)
+        vcrs = xdem.vcrs._vcrs_from_crs(crs=input) # noqa: SLF001
 
         # Check that the result is as expected
         if isinstance(output, CRS):
@@ -69,7 +69,7 @@ class TestVCRS:
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Get user input
-        vcrs = xdem.dem.vcrs_from_user_input(vcrs_input)
+        vcrs = xdem.dem._vcrs_from_user_input(vcrs_input) # noqa: SLF001
 
         # Check output type
         assert isinstance(vcrs, CRS)
@@ -81,7 +81,7 @@ class TestVCRS:
     def test_vcrs_from_user_input__ellipsoid(self, vcrs_input: str | int) -> None:
         """Tests the function _vcrs_from_user_input for inputs where it returns "Ellipsoid"."""
         # Get user input
-        vcrs = xdem.vcrs.vcrs_from_user_input(vcrs_input)
+        vcrs = xdem.vcrs._vcrs_from_user_input(vcrs_input) # noqa: SLF001
 
         # Check output type
         assert vcrs == "Ellipsoid"
@@ -90,7 +90,7 @@ class TestVCRS:
         """Tests errors of vcrs_from_user_input."""
         # Check that an error is raised when the type is wrong
         with pytest.raises(TypeError, match="New vertical CRS must be a string, path or VerticalCRS, received.*"):
-            xdem.vcrs.vcrs_from_user_input(np.zeros(1))  # type: ignore
+            xdem.vcrs._vcrs_from_user_input(np.zeros(1))  # noqa: SLF001
 
         # Check that an error is raised if the CRS is not vertical
         with pytest.raises(
@@ -100,7 +100,7 @@ class TestVCRS:
                 "zone 1N' does not (check with `CRS.is_vertical`).",
             ),
         ):
-            xdem.vcrs.vcrs_from_user_input(32601)
+            xdem.vcrs._vcrs_from_user_input(32601) # noqa: SLF001
 
         # Check that a warning is raised if the CRS has other dimensions than vertical
         with pytest.warns(
@@ -108,7 +108,7 @@ class TestVCRS:
             match="New vertical CRS has a vertical dimension but also other components, "
             "extracting the vertical reference only.",
         ):
-            xdem.vcrs.vcrs_from_user_input(CRS("EPSG:4326+5773"))
+            xdem.vcrs._vcrs_from_user_input(CRS("EPSG:4326+5773")) # noqa: SLF001
 
     @pytest.mark.parametrize(
         "grid", ["us_noaa_geoid06_ak.tif", "is_lmi_Icegeoid_ISN93.tif", "us_nga_egm08_25.tif", "us_nga_egm96_15.tif"],
@@ -119,11 +119,11 @@ class TestVCRS:
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Build vertical CRS
-        vcrs = xdem.vcrs.build_vcrs_from_grid(grid=grid)
+        vcrs = xdem.vcrs._build_vcrs_from_grid(grid=grid) # noqa: SLF001
         assert vcrs.is_vertical
 
         # Check that the explicit construction yields the same CRS as "the old init way" (see function description)
-        vcrs_oldway = xdem.vcrs.build_vcrs_from_grid(grid=grid, old_way=True)
+        vcrs_oldway = xdem.vcrs._build_vcrs_from_grid(grid=grid, old_way=True) # noqa: SLF001
         assert vcrs.equals(vcrs_oldway)
 
     # Test for WGS84 in 2D and 3D, UTM, CompoundCRS, everything should work
@@ -137,7 +137,7 @@ class TestVCRS:
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Get the vertical CRS from user input
-        vcrs = xdem.vcrs.vcrs_from_user_input(vcrs_input=vcrs_input)
+        vcrs = xdem.vcrs._vcrs_from_user_input(vcrs_input=vcrs_input) # noqa: SLF001
 
         # Build the compound CRS
 
@@ -148,7 +148,7 @@ class TestVCRS:
 
             # If the version is higher than 3.5.0, it should pass
             if Version(pyproj.__version__) > Version("3.5.0"):
-                ccrs = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+                ccrs = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs) # noqa: SLF001
             # Otherwise, it should raise an error
             else:
                 with pytest.raises(
@@ -157,11 +157,11 @@ class TestVCRS:
                     "with a new vertical CRS. Update your dependencies or pass the 2D source CRS "
                     "manually.",
                 ):
-                    xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+                    xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs) # noqa: SLF001
                 return
         # If the CRS is 2D, it should pass
         else:
-            ccrs = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+            ccrs = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs) # noqa: SLF001
 
         assert isinstance(ccrs, CRS)
         assert ccrs.is_vertical
@@ -171,7 +171,7 @@ class TestVCRS:
         with pytest.raises(
             ValueError, match="Invalid vcrs given. Must be a vertical CRS or the literal string 'Ellipsoid'.",
         ):
-            xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=CRS("EPSG:4326"), vcrs="NotAVerticalCRS")  # type: ignore
+            xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=CRS("EPSG:4326"), vcrs="NotAVerticalCRS")  # noqa: SLF001
 
     # Compare to manually-extracted shifts at specific coordinates for the geoid grids
     egm96_chile: ClassVar[dict] = {"grid": "us_nga_egm96_15.tif", "lon": -68, "lat": -20, "shift": 42}
@@ -190,14 +190,14 @@ class TestVCRS:
         xx = grid_shifts["lon"]
         yy = grid_shifts["lat"]
         crs_from = CRS.from_epsg(4326)
-        ccrs_from = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs="Ellipsoid")
+        ccrs_from = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs="Ellipsoid") # noqa: SLF001
 
         # Build the compound CRS
-        vcrs_to = xdem.vcrs.vcrs_from_user_input(vcrs_input=grid_shifts["grid"])
-        ccrs_to = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs=vcrs_to)
+        vcrs_to = xdem.vcrs._vcrs_from_user_input(vcrs_input=grid_shifts["grid"]) # noqa: SLF001
+        ccrs_to = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs=vcrs_to) # noqa: SLF001
 
         # Apply the transformation
-        zz_trans = xdem.vcrs.transform_zz(crs_from=ccrs_from, crs_to=ccrs_to, xx=xx, yy=yy, zz=zz)
+        zz_trans = xdem.vcrs._transform_zz(crs_from=ccrs_from, crs_to=ccrs_to, xx=xx, yy=yy, zz=zz) # noqa: SLF001
 
         # Compare the elevation difference
         z_diff = 100 - zz_trans

--- a/tests/test_vcrs.py
+++ b/tests/test_vcrs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pathlib
 import re
 import warnings
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 import pytest
@@ -18,13 +18,12 @@ import xdem.vcrs
 class TestVCRS:
     def test_parse_vcrs_name_from_product(self) -> None:
         """Test parsing of vertical CRS name from DEM product name."""
-
         # Check that the value for the key is returned by the function
-        for product in xdem.vcrs.vcrs_dem_products.keys():
-            assert xdem.vcrs._parse_vcrs_name_from_product(product) == xdem.vcrs.vcrs_dem_products[product]
+        for product in xdem.vcrs.vcrs_dem_products:
+            assert xdem.vcrs.parse_vcrs_name_from_product(product) == xdem.vcrs.vcrs_dem_products[product]
 
         # And that, otherwise, it's a None
-        assert xdem.vcrs._parse_vcrs_name_from_product("BESTDEM") is None
+        assert xdem.vcrs.parse_vcrs_name_from_product("BESTDEM") is None
 
     # Expect outputs for the inputs
     @pytest.mark.parametrize(
@@ -39,12 +38,11 @@ class TestVCRS:
     )  # type: ignore
     def test_vcrs_from_crs(self, input_output: tuple[CRS, CRS]) -> None:
         """Test the extraction of a vertical CRS from a CRS."""
-
-        input = input_output[0]
+        input_ = input_output[0]
         output = input_output[1]
 
         # Extract vertical CRS from CRS
-        vcrs = xdem.vcrs._vcrs_from_crs(crs=input)
+        vcrs = xdem.vcrs.vcrs_from_crs(crs=input_)
 
         # Check that the result is as expected
         if isinstance(output, CRS):
@@ -67,45 +65,42 @@ class TestVCRS:
     )  # type: ignore
     def test_vcrs_from_user_input(self, vcrs_input: str | pathlib.Path | int | CRS) -> None:
         """Tests the function _vcrs_from_user_input for varying user inputs, for which it will return a CRS."""
-
         # Most grids aren't going to be downloaded, so this warning can be raised
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Get user input
-        vcrs = xdem.dem._vcrs_from_user_input(vcrs_input)
+        vcrs = xdem.dem.vcrs_from_user_input(vcrs_input)
 
         # Check output type
         assert isinstance(vcrs, CRS)
         assert vcrs.is_vertical
 
     @pytest.mark.parametrize(
-        "vcrs_input", ["Ellipsoid", "ellipsoid", "wgs84", 4326, 4979, CRS.from_epsg(4326), CRS.from_epsg(4979)]
+        "vcrs_input", ["Ellipsoid", "ellipsoid", "wgs84", 4326, 4979, CRS.from_epsg(4326), CRS.from_epsg(4979)],
     )  # type: ignore
     def test_vcrs_from_user_input__ellipsoid(self, vcrs_input: str | int) -> None:
         """Tests the function _vcrs_from_user_input for inputs where it returns "Ellipsoid"."""
-
         # Get user input
-        vcrs = xdem.vcrs._vcrs_from_user_input(vcrs_input)
+        vcrs = xdem.vcrs.vcrs_from_user_input(vcrs_input)
 
         # Check output type
         assert vcrs == "Ellipsoid"
 
     def test_vcrs_from_user_input__errors(self) -> None:
         """Tests errors of vcrs_from_user_input."""
-
         # Check that an error is raised when the type is wrong
         with pytest.raises(TypeError, match="New vertical CRS must be a string, path or VerticalCRS, received.*"):
-            xdem.vcrs._vcrs_from_user_input(np.zeros(1))  # type: ignore
+            xdem.vcrs.vcrs_from_user_input(np.zeros(1))  # type: ignore
 
         # Check that an error is raised if the CRS is not vertical
         with pytest.raises(
             ValueError,
             match=re.escape(
                 "New vertical CRS must have a vertical axis, 'WGS 84 / UTM "
-                "zone 1N' does not (check with `CRS.is_vertical`)."
+                "zone 1N' does not (check with `CRS.is_vertical`).",
             ),
         ):
-            xdem.vcrs._vcrs_from_user_input(32601)
+            xdem.vcrs.vcrs_from_user_input(32601)
 
         # Check that a warning is raised if the CRS has other dimensions than vertical
         with pytest.warns(
@@ -113,38 +108,36 @@ class TestVCRS:
             match="New vertical CRS has a vertical dimension but also other components, "
             "extracting the vertical reference only.",
         ):
-            xdem.vcrs._vcrs_from_user_input(CRS("EPSG:4326+5773"))
+            xdem.vcrs.vcrs_from_user_input(CRS("EPSG:4326+5773"))
 
     @pytest.mark.parametrize(
-        "grid", ["us_noaa_geoid06_ak.tif", "is_lmi_Icegeoid_ISN93.tif", "us_nga_egm08_25.tif", "us_nga_egm96_15.tif"]
+        "grid", ["us_noaa_geoid06_ak.tif", "is_lmi_Icegeoid_ISN93.tif", "us_nga_egm08_25.tif", "us_nga_egm96_15.tif"],
     )  # type: ignore
     def test_build_vcrs_from_grid(self, grid: str) -> None:
         """Test that vertical CRS are correctly built from grid"""
-
         # Most grids aren't going to be downloaded, so this warning can be raised
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Build vertical CRS
-        vcrs = xdem.vcrs._build_vcrs_from_grid(grid=grid)
+        vcrs = xdem.vcrs.build_vcrs_from_grid(grid=grid)
         assert vcrs.is_vertical
 
         # Check that the explicit construction yields the same CRS as "the old init way" (see function description)
-        vcrs_oldway = xdem.vcrs._build_vcrs_from_grid(grid=grid, old_way=True)
+        vcrs_oldway = xdem.vcrs.build_vcrs_from_grid(grid=grid, old_way=True)
         assert vcrs.equals(vcrs_oldway)
 
     # Test for WGS84 in 2D and 3D, UTM, CompoundCRS, everything should work
     @pytest.mark.parametrize(
-        "crs", [CRS("EPSG:4326"), CRS("EPSG:4979"), CRS("32610"), CRS("EPSG:4326+5773")]
+        "crs", [CRS("EPSG:4326"), CRS("EPSG:4979"), CRS("32610"), CRS("EPSG:4326+5773")],
     )  # type: ignore
     @pytest.mark.parametrize("vcrs_input", [CRS("EPSG:5773"), "is_lmi_Icegeoid_ISN93.tif", "EGM96"])  # type: ignore
     def test_build_ccrs_from_crs_and_vcrs(self, crs: CRS, vcrs_input: CRS | str) -> None:
         """Test the function build_ccrs_from_crs_and_vcrs."""
-
         # Most grids aren't going to be downloaded, so this warning can be raised
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
         # Get the vertical CRS from user input
-        vcrs = xdem.vcrs._vcrs_from_user_input(vcrs_input=vcrs_input)
+        vcrs = xdem.vcrs.vcrs_from_user_input(vcrs_input=vcrs_input)
 
         # Build the compound CRS
 
@@ -155,7 +148,7 @@ class TestVCRS:
 
             # If the version is higher than 3.5.0, it should pass
             if Version(pyproj.__version__) > Version("3.5.0"):
-                ccrs = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+                ccrs = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
             # Otherwise, it should raise an error
             else:
                 with pytest.raises(
@@ -164,33 +157,31 @@ class TestVCRS:
                     "with a new vertical CRS. Update your dependencies or pass the 2D source CRS "
                     "manually.",
                 ):
-                    xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
-                return None
+                    xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+                return
         # If the CRS is 2D, it should pass
         else:
-            ccrs = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
+            ccrs = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs, vcrs=vcrs)
 
         assert isinstance(ccrs, CRS)
         assert ccrs.is_vertical
 
     def test_build_ccrs_from_crs_and_vcrs__errors(self) -> None:
         """Test errors are correctly raised from the build_ccrs function."""
-
         with pytest.raises(
-            ValueError, match="Invalid vcrs given. Must be a vertical " "CRS or the literal string 'Ellipsoid'."
+            ValueError, match="Invalid vcrs given. Must be a vertical CRS or the literal string 'Ellipsoid'.",
         ):
-            xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=CRS("EPSG:4326"), vcrs="NotAVerticalCRS")  # type: ignore
+            xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=CRS("EPSG:4326"), vcrs="NotAVerticalCRS")  # type: ignore
 
     # Compare to manually-extracted shifts at specific coordinates for the geoid grids
-    egm96_chile = {"grid": "us_nga_egm96_15.tif", "lon": -68, "lat": -20, "shift": 42}
-    egm08_chile = {"grid": "us_nga_egm08_25.tif", "lon": -68, "lat": -20, "shift": 42}
-    geoid96_alaska = {"grid": "us_noaa_geoid06_ak.tif", "lon": -145, "lat": 62, "shift": 15}
-    isn93_iceland = {"grid": "is_lmi_Icegeoid_ISN93.tif", "lon": -18, "lat": 65, "shift": 68}
+    egm96_chile: ClassVar[dict] = {"grid": "us_nga_egm96_15.tif", "lon": -68, "lat": -20, "shift": 42}
+    egm08_chile: ClassVar[dict] = {"grid": "us_nga_egm08_25.tif", "lon": -68, "lat": -20, "shift": 42}
+    geoid96_alaska: ClassVar[dict] = {"grid": "us_noaa_geoid06_ak.tif", "lon": -145, "lat": 62, "shift": 15}
+    isn93_iceland: ClassVar[dict] = {"grid": "is_lmi_Icegeoid_ISN93.tif", "lon": -18, "lat": 65, "shift": 68}
 
-    @pytest.mark.parametrize("grid_shifts", [egm08_chile, egm08_chile, geoid96_alaska, isn93_iceland])  # type: ignore
+    @pytest.mark.parametrize("grid_shifts", [egm96_chile, egm08_chile, geoid96_alaska, isn93_iceland])  # type: ignore
     def test_transform_zz(self, grid_shifts: dict[str, Any]) -> None:
         """Tests grids to convert vertical CRS."""
-
         # Most grids aren't going to be downloaded, so this warning can be raised
         warnings.filterwarnings("ignore", category=UserWarning, message="Grid not found in *")
 
@@ -199,14 +190,14 @@ class TestVCRS:
         xx = grid_shifts["lon"]
         yy = grid_shifts["lat"]
         crs_from = CRS.from_epsg(4326)
-        ccrs_from = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs="Ellipsoid")
+        ccrs_from = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs="Ellipsoid")
 
         # Build the compound CRS
-        vcrs_to = xdem.vcrs._vcrs_from_user_input(vcrs_input=grid_shifts["grid"])
-        ccrs_to = xdem.vcrs._build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs=vcrs_to)
+        vcrs_to = xdem.vcrs.vcrs_from_user_input(vcrs_input=grid_shifts["grid"])
+        ccrs_to = xdem.vcrs.build_ccrs_from_crs_and_vcrs(crs=crs_from, vcrs=vcrs_to)
 
         # Apply the transformation
-        zz_trans = xdem.vcrs._transform_zz(crs_from=ccrs_from, crs_to=ccrs_to, xx=xx, yy=yy, zz=zz)
+        zz_trans = xdem.vcrs.transform_zz(crs_from=ccrs_from, crs_to=ccrs_to, xx=xx, yy=yy, zz=zz)
 
         # Compare the elevation difference
         z_diff = 100 - zz_trans

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -33,7 +33,7 @@ class TestLocalHypsometric:
         )
 
         ddem_stds = xdem.volume.hypsometric_binning(
-            ddem[self.mask], self.dem_2009[self.mask], aggregation_function=np.std
+            ddem[self.mask], self.dem_2009[self.mask], aggregation_function=np.std,
         )
         assert ddem_stds["value"].mean() < 50
         assert np.abs(np.mean(ddem_bins["value"] - ddem_bins_masked["value"])) < 0.01
@@ -61,7 +61,6 @@ class TestLocalHypsometric:
 
     def test_area_calculation(self) -> None:
         """Test the area calculation function."""
-
         ddem = self.dem_2009 - self.dem_1990
 
         ddem_bins = xdem.volume.hypsometric_binning(ddem[self.mask], self.dem_2009[self.mask])
@@ -71,12 +70,12 @@ class TestLocalHypsometric:
 
         # Test the area calculation with normal parameters.
         bin_area = xdem.volume.calculate_hypsometry_area(
-            ddem_bins, self.dem_2009[self.mask], pixel_size=self.dem_2009.res[0]
+            ddem_bins, self.dem_2009[self.mask], pixel_size=self.dem_2009.res[0],
         )
 
         # Test area calculation with differing pixel x/y resolution.
         xdem.volume.calculate_hypsometry_area(
-            ddem_bins, self.dem_2009[self.mask], pixel_size=(self.dem_2009.res[0], self.dem_2009.res[0] + 1)
+            ddem_bins, self.dem_2009[self.mask], pixel_size=(self.dem_2009.res[0], self.dem_2009.res[0] + 1),
         )
 
         # Add some nans to the reference DEM
@@ -93,7 +92,7 @@ class TestLocalHypsometric:
         # Try to pass an incorrect timeframe= parameter
         try:
             xdem.volume.calculate_hypsometry_area(
-                ddem_bins, self.dem_2009[self.mask], pixel_size=self.dem_2009.res[0], timeframe="blergh"
+                ddem_bins, self.dem_2009[self.mask], pixel_size=self.dem_2009.res[0], timeframe="blergh",
             )
         except ValueError as exception:
             if "Argument 'timeframe=blergh' is invalid" not in str(exception):
@@ -118,13 +117,13 @@ class TestLocalHypsometric:
 
         # Make a fixed amount of bins
         equal_count_bins = xdem.volume.hypsometric_binning(
-            ddem[self.mask], self.dem_2009[self.mask], bins=50, kind="count"
+            ddem[self.mask], self.dem_2009[self.mask], bins=50, kind="count",
         )
         assert equal_count_bins.shape[0] == 50
 
         # Make 50 bins with approximately the same area (pixel count)
         quantile_bins = xdem.volume.hypsometric_binning(
-            ddem[self.mask], self.dem_2009[self.mask], bins=50, kind="quantile"
+            ddem[self.mask], self.dem_2009[self.mask], bins=50, kind="quantile",
         )
 
         assert quantile_bins.shape[0] == 50
@@ -152,9 +151,9 @@ class TestNormHypsometric:
 
     @pytest.mark.parametrize("n_bins", [5, 10, 20])  # type: ignore
     def test_regional_signal(self, n_bins: int) -> None:
-
+        """Test regional signal."""
         signal = xdem.volume.get_regional_hypsometric_signal(
-            ddem=self.ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map, n_bins=n_bins
+            ddem=self.ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map, n_bins=n_bins,
         )
 
         assert signal["w_mean"].min() >= 0.0
@@ -165,13 +164,13 @@ class TestNormHypsometric:
         assert np.all(np.isfinite(signal.values))
 
     def test_interpolate_small(self) -> None:
-
+        """Test that no interpolation is done when the coverage is too small."""
         dem = np.arange(16, dtype="float32").reshape(4, 4)
         ddem = dem / 10
         glacier_index_map = np.ones_like(dem)
 
         signal = xdem.volume.get_regional_hypsometric_signal(
-            ddem=ddem, ref_dem=dem, glacier_index_map=glacier_index_map, n_bins=10
+            ddem=ddem, ref_dem=dem, glacier_index_map=glacier_index_map, n_bins=10,
         )
 
         # Make it so that only 1/4 of the values exist.
@@ -205,19 +204,21 @@ class TestNormHypsometric:
         assert np.nanmax(np.abs((interpolated_ddem - ddem_orig)[np.isnan(ddem)])) < 0.1
 
     def test_regional_hypsometric_interp(self) -> None:
-
+        """Test regional hypsometric interpolation."""
         # Extract a normalized regional hypsometric signal.
         ddem = self.dem_2009 - self.dem_1990
 
         signal = xdem.volume.get_regional_hypsometric_signal(
-            ddem=self.ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map
+            ddem=self.ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map,
         )
 
         if False:
             import matplotlib.pyplot as plt
 
             plt.fill_between(
-                signal.index.mid, signal["median"] - signal["std"], signal["median"] + signal["std"], label="Median±std"
+                signal.index.mid,
+                signal["median"] - signal["std"], signal["median"] + signal["std"],
+                label="Median±std",
             )
             plt.plot(signal.index.mid, signal["median"], color="black", linestyle=":", label="Median")
             plt.plot(signal.index.mid, signal["w_mean"], color="black", label="Weighted mean")
@@ -234,11 +235,11 @@ class TestNormHypsometric:
         ddem.data.mask.ravel()[rng.choice(ddem.data.size, int(ddem.data.size * 0.80), replace=False)] = True
         # Fill the dDEM using the de-normalized signal.
         filled_ddem = xdem.volume.norm_regional_hypsometric_interpolation(
-            voided_ddem=ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map
+            voided_ddem=ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map,
         )
         # Fill the dDEM using the de-normalized signal and create an idealized dDEM
         idealized_ddem = xdem.volume.norm_regional_hypsometric_interpolation(
-            voided_ddem=ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map, idealized_ddem=True
+            voided_ddem=ddem, ref_dem=self.dem_2009, glacier_index_map=self.glacier_index_map, idealized_ddem=True,
         )
         assert not np.array_equal(filled_ddem, idealized_ddem)
 

--- a/xdem/__init__.py
+++ b/xdem/__init__.py
@@ -15,6 +15,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""xDEM module init file."""
 
 from xdem import (  # noqa
     coreg,
@@ -38,5 +39,5 @@ except ImportError:  # pragma: no cover
         "running from the source directory, please instead "
         "create a new virtual environment (using conda or "
         "virtualenv) and then install it in-place by running: "
-        "pip install -e ."
+        "pip install -e .",
     )

--- a/xdem/_typing.py
+++ b/xdem/_typing.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 
 # Only for Python >= 3.9
-if sys.version_info.minor >= (3, 9):
+if sys.version_info.minor >= 9: # noqa
 
     from numpy.typing import NDArray  # this syntax works starting on Python 3.9
 

--- a/xdem/coreg/__init__.py
+++ b/xdem/coreg/__init__.py
@@ -16,8 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-DEM coregistration classes and functions, including affine methods, bias corrections (i.e. non-affine) and filters.
+"""DEM coregistration classes and functions, including affine methods,
+bias corrections (i.e. non-affine) and filters.
 """
 
 from xdem.coreg.affine import (  # noqa

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -1179,15 +1179,10 @@ class ICP(AffineCoreg):
 
         points["point"] = point_elev[["E", "N", z_name, "nx", "ny", "nz"]].values
 
-        #for key in points:
-        #    points[key] = points[key][~np.any(np.isnan(points[key]), axis=1)].astype("float32")
-        #    points[key][:, 0] -= resolution[0] / 2
-        #    points[key][:, 1] -= resolution[1] / 2
-
-        for value in points.values():
-            value = value[~np.any(np.isnan(value), axis=1)].astype("float32") # noqa: PLW2901
-            value[:, 0] -= resolution[0] / 2
-            value[:, 1] -= resolution[1] / 2
+        for key in points: # noqa: PLC0206
+            points[key] = points[key][~np.any(np.isnan(points[key]), axis=1)].astype("float32")
+            points[key][:, 0] -= resolution[0] / 2
+            points[key][:, 1] -= resolution[1] / 2
 
         # Extract parameters and pass them to method
         max_it = self._meta["inputs"]["iterative"]["max_iterations"]

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -474,7 +474,7 @@ def _postprocess_coreg_apply_rst(
     if isinstance(elev, gu.Raster):
         nodata = elev.nodata
     else:
-        nodata = raster.default_nodata(elev.dtype)
+        nodata = raster._default_nodata(elev.dtype) # noqa: SLF001
 
     # Resample the array on the original grid
     if resample:
@@ -2664,13 +2664,13 @@ class CoregPipeline(Coreg):
     def _parse_bias_vars(self, step: int, bias_vars: dict[str, NDArrayf] | None) -> dict[str, NDArrayf]:
         """Parse bias variables for a pipeline step requiring them."""
         # Get number of non-affine coregistration requiring bias variables to be passed
-        nb_needs_vars = sum(c.needs_vars for c in self.pipeline)
+        nb_needs_vars = sum(c._needs_vars for c in self.pipeline) # noqa: SLF001
 
         # Get step object
         coreg = self.pipeline[step]
 
         # Check that all variable names of this were passed
-        var_names = coreg.meta["inputs"]["fitorbin"]["bias_var_names"]
+        var_names = coreg._meta["inputs"]["fitorbin"]["bias_var_names"] # noqa: SLF001
 
         # Raise error if bias_vars is None
         if bias_vars is None:
@@ -2766,7 +2766,7 @@ class CoregPipeline(Coreg):
             main_args_apply = {"elev": tba_dem_mod, "transform": out_transform, "crs": crs, "z_name": z_name}
 
             # If non-affine method that expects a bias_vars argument
-            if coreg.needs_vars:
+            if coreg._needs_vars: # noqa: SLF001
                 step_bias_vars = self._parse_bias_vars(step=i, bias_vars=bias_vars)
 
                 main_args_fit.update({"bias_vars": step_bias_vars})
@@ -2862,7 +2862,7 @@ class CoregPipeline(Coreg):
             }
 
             # If non-affine method that expects a bias_vars argument
-            if coreg.needs_vars:
+            if coreg._needs_vars: # noqa: SLF001
                 step_bias_vars = self._parse_bias_vars(step=i, bias_vars=bias_vars)
                 main_args_apply.update({"bias_vars": step_bias_vars})
 
@@ -2992,7 +2992,7 @@ class BlockwiseCoreg(Coreg):
         else:
             steps = list(self.procstep.pipeline)
         argspec = [inspect.getfullargspec(s.__class__) for s in steps]
-        sub_meta = [s.meta["inputs"]["random"]["subsample"] for s in steps]
+        sub_meta = [s._meta["inputs"]["random"]["subsample"] for s in steps] # noqa: SLF001
         sub_is_default = [
             argspec[i].defaults[argspec[i].args.index("subsample") - 1] == sub_meta[i]  # type: ignore
             for i in range(len(argspec))
@@ -3162,10 +3162,10 @@ class BlockwiseCoreg(Coreg):
                 warnings.warn(str(exception))
 
         # Set the _fit_called parameters (only identical copies of self.coreg have actually been called)
-        self.procstep.fit_called = True
+        self.procstep._fit_called = True # noqa: SLF001
         if isinstance(self.procstep, CoregPipeline):
             for step in self.procstep.pipeline:
-                step.fit_called = True
+                step._fit_called = True # noqa: SLF001
 
         # Flag that the fitting function has been called.
         self._fit_called = True
@@ -3177,11 +3177,11 @@ class BlockwiseCoreg(Coreg):
 
         :param meta: A metadata file to update self._meta
         """
-        self.procstep.meta.update(meta)
+        self.procstep._meta.update(meta) # noqa: SLF001
 
         if isinstance(self.procstep, CoregPipeline) and "pipeline" in meta:
             for i, step in enumerate(self.procstep.pipeline):
-                step.meta.update(meta["pipeline"][i])
+                step._meta.update(meta["pipeline"][i]) # noqa: SLF001
 
     def to_points(self) -> NDArrayf:
         """Convert the blockwise coregistration matrices to 3D (source -> destination) points.

--- a/xdem/ddem.py
+++ b/xdem/ddem.py
@@ -76,7 +76,7 @@ def _mask_as_array(reference_raster: gu.Raster, mask: str | gu.Vector | gu.Raste
     return mask_array
 
 
-class Ddem(Raster):  # type: ignore
+class dDem(Raster):  # noqa: N801
     """A difference-DEM object."""
 
     def __init__(
@@ -86,14 +86,14 @@ class Ddem(Raster):  # type: ignore
         end_time: np.datetime64,
         error: Any | None = None,
     ) -> None:
-        """Create a Ddem object from a Raster.
+        """Create a dDem object from a Raster.
 
         :param raster: A georeferenced Raster object.
-        :param start_time: The starting time of the Ddem.
-        :param end_time: The end time of the Ddem.
-        :param error: An error measure for the Ddem (UNUSED).
+        :param start_time: The starting time of the dDem.
+        :param end_time: The end time of the dDem.
+        :param error: An error measure for the dDem (UNUSED).
 
-        :returns: A new Ddem instance.
+        :returns: A new dDem instance.
         """
         # super().__init__(raster)
 
@@ -105,15 +105,15 @@ class Ddem(Raster):  # type: ignore
         self._fill_method = ""
 
     def __str__(self) -> str:
-        """Return a summary of the Ddem."""
-        return f"Ddem from {self.start_time} to {self.end_time}.\n\n{super().__str__()}"
+        """Return a summary of the dDem."""
+        return f"dDem from {self.start_time} to {self.end_time}.\n\n{super().__str__()}"
 
-    def copy(self, new_array: NDArrayf = None) -> Ddem:
+    def copy(self, new_array: NDArrayf = None) -> dDem:
         """Return a copy of the DEM."""
         if new_array is None:
             new_array = self.data.copy()
 
-        new_ddem = Ddem.from_array(new_array, self.transform, self.crs, self.start_time, self.end_time)
+        new_ddem = dDem.from_array(new_array, self.transform, self.crs, self.start_time, self.end_time)
         return new_ddem
 
     @property
@@ -160,18 +160,18 @@ class Ddem(Raster):  # type: ignore
         end_time: np.datetime64,
         nodata: int | float | None = None,
         error: float | None = None,
-    ) -> Ddem:  # type: ignore
-        """Create a new Ddem object from an array.
+    ) -> dDem:  # type: ignore
+        """Create a new dDem object from an array.
 
-        :param data: The Ddem data array.
+        :param data: The dDem data array.
         :param transform: A geometric transform.
-        :param crs: The coordinate reference system of the Ddem.
-        :param start_time: The starting time of the Ddem.
-        :param end_time: The end time of the Ddem.
-        :param error: An error measure for the Ddem.
+        :param crs: The coordinate reference system of the dDem.
+        :param start_time: The starting time of the dDem.
+        :param end_time: The end time of the dDem.
+        :param error: An error measure for the dDem.
         :param nodata: The nodata value.
 
-        :returns: A new Ddem instance.
+        :returns: A new dDem instance.
         """
         return cls(
             gu.Raster.from_array(data=data, transform=transform, crs=crs, nodata=nodata),
@@ -186,7 +186,7 @@ class Ddem(Raster):  # type: ignore
         reference_elevation: NDArrayf | np.ma.masked_array[Any, np.dtype[np.floating[Any]]] | xdem.DEM = None,
         mask: NDArrayf | xdem.DEM | gu.Vector = None,
     ) -> NDArrayf | None:
-        """Interpolate the Ddem using the given method.
+        """Interpolate the dDem using the given method.
 
         :param method: The method to use for interpolation.
         :param reference_elevation: Reference DEM. Only required for hypsometric approaches.
@@ -243,7 +243,7 @@ class Ddem(Raster):  # type: ignore
                 ddem_mask[feature_mask] = False
 
                 # All values that were nan in the start and are without the updated validity mask should now be nan
-                # The above interpolates values outside of the Ddem, so this is necessary.
+                # The above interpolates values outside of the dDem, so this is necessary.
                 interpolated_ddem[ddem_mask] = np.nan
 
             diff = abs(np.nanmean(interpolated_ddem - self.data))

--- a/xdem/filters.py
+++ b/xdem/filters.py
@@ -34,8 +34,7 @@ from xdem._typing import NDArrayf
 
 
 def gaussian_filter_scipy(array: NDArrayf, sigma: float) -> NDArrayf:
-    """
-    Apply a Gaussian filter to a raster that may contain NaNs, using scipy's implementation.
+    """Apply a Gaussian filter to a raster that may contain NaNs, using scipy's implementation.
     gaussian_filter_cv is recommended as it is usually faster, but this depends on the value of sigma.
 
     N.B: kernel_size is set automatically based on sigma.
@@ -55,30 +54,28 @@ def gaussian_filter_scipy(array: NDArrayf, sigma: float) -> NDArrayf:
 
     # If array contain NaNs, need a more sophisticated approach
     # Inspired by https://stackoverflow.com/a/36307291
-    else:
 
-        # Run filter on a copy with NaNs set to 0
-        array_no_nan = array.copy()
-        array_no_nan[np.isnan(array)] = 0
-        gauss_no_nan = scipy.ndimage.gaussian_filter(array_no_nan, sigma=sigma)
-        del array_no_nan
+    # Run filter on a copy with NaNs set to 0
+    array_no_nan = array.copy()
+    array_no_nan[np.isnan(array)] = 0
+    gauss_no_nan = scipy.ndimage.gaussian_filter(array_no_nan, sigma=sigma)
+    del array_no_nan
 
-        # Mask of NaN values
-        nan_mask = 0 * array.copy() + 1
-        nan_mask[np.isnan(array)] = 0
-        gauss_mask = scipy.ndimage.gaussian_filter(nan_mask, sigma=sigma)
-        del nan_mask
+    # Mask of NaN values
+    nan_mask = 0 * array.copy() + 1
+    nan_mask[np.isnan(array)] = 0
+    gauss_mask = scipy.ndimage.gaussian_filter(nan_mask, sigma=sigma)
+    del nan_mask
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message="invalid value encountered")
-            gauss = gauss_no_nan / gauss_mask
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="invalid value encountered")
+        gauss = gauss_no_nan / gauss_mask
 
-        return gauss
+    return gauss
 
 
 def gaussian_filter_cv(array: NDArrayf, sigma: float) -> NDArrayf:
-    """
-    Apply a Gaussian filter to a raster that may contain NaNs, using OpenCV's implementation.
+    """Apply a Gaussian filter to a raster that may contain NaNs, using OpenCV's implementation.
     Arguments are for now hard-coded to be identical to scipy.
 
     N.B: kernel_size is set automatically based on sigma
@@ -141,8 +138,7 @@ def gaussian_filter_cv(array: NDArrayf, sigma: float) -> NDArrayf:
 
 
 def distance_filter(array: NDArrayf, radius: float, outlier_threshold: float) -> NDArrayf:
-    """
-    Filter out pixels whose value is distant more than a set threshold from the average value of all neighbor \
+    """Filter out pixels whose value is distant more than a set threshold from the average value of all neighbor \
 pixels within a given radius.
     Filtered pixels are set to NaN.
 

--- a/xdem/misc.py
+++ b/xdem/misc.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 import copy
 import functools
 import warnings
-from typing import Any, Callable
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
 
 from packaging.version import Version
 
@@ -47,10 +49,9 @@ from xdem._typing import NDArrayf
 
 
 def generate_random_field(
-    shape: tuple[int, int], corr_size: int, random_state: int | np.random.Generator | None = None
+    shape: tuple[int, int], corr_size: int, random_state: int | np.random.Generator | None = None,
 ) -> NDArrayf:
-    """
-    Generate a semi-random gaussian field (to simulate a DEM or DEM error)
+    """Generate a semi-random gaussian field (to simulate a DEM or DEM error)
 
     :param shape: The output shape of the field.
     :param corr_size: The correlation size of the field.
@@ -65,7 +66,6 @@ def generate_random_field(
 
     :returns: A numpy array of semi-random values from 0 to 1
     """
-
     rng = np.random.default_rng(random_state)
 
     if not _has_cv2:
@@ -91,9 +91,8 @@ def generate_random_field(
     return field
 
 
-def deprecate(removal_version: Version = None, details: str = None) -> Callable[[Any], Any]:
-    """
-    Trigger a DeprecationWarning for the decorated function.
+def deprecate(removal_version: Version = None, details: str | None = None) -> Callable[[Any], Any]:
+    """Trigger a DeprecationWarning for the decorated function.
 
     :param func: The function to be deprecated.
     :param removal_version: Optional. The version at which this will be removed.
@@ -156,8 +155,7 @@ def copy_doc(
     module_to_copy: object,
     remove_dem_res_params: bool = False,
 ) -> Callable:  # type: ignore
-    """
-    A decorator to copy docstring from a function to another one while replacing the docstring.
+    """A decorator to copy docstring from a function to another one while replacing the docstring.
     Used for copying xdem.terrain documentation to xdem.DEM.
 
     :param module_to_copy: Name of module to copy the function from
@@ -201,24 +199,22 @@ def copy_doc(
 
 
 def diff_environment_yml(
-    fn_env: str | dict[str, Any], fn_devenv: str | dict[str, Any], print_dep: str = "both", input_dict: bool = False
+    fn_env: str | dict[str, Any], fn_devenv: str | dict[str, Any], print_dep: str = "both", input_dict: bool = False,
 ) -> None:
-    """
-    Compute the difference between environment.yml and dev-environment.yml for setup of continuous integration,
+    """Compute the difference between environment.yml and dev-environment.yml for setup of continuous integration,
     while checking that all the dependencies listed in environment.yml are also in dev-environment.yml
     :param fn_env: Filename path to environment.yml
     :param fn_devenv: Filename path to dev-environment.yml
     :param print_dep: Whether to print conda differences "conda", pip differences "pip" or both.
     :param input_dict: Whether to consider the input as a dict (for testing purposes).
     """
-
     if not _has_yaml:
         raise ValueError("Test dependency needed. Install 'pyyaml'.")
 
     if not input_dict:
         # Load the yml as dictionaries
-        yaml_env = yaml.safe_load(open(fn_env))  # type: ignore
-        yaml_devenv = yaml.safe_load(open(fn_devenv))  # type: ignore
+        yaml_env = yaml.safe_load(Path(fn_env).open())  # type: ignore
+        yaml_devenv = yaml.safe_load(Path(fn_devenv).open())  # type: ignore
     else:
         # We need a copy as we'll pop things out and don't want to affect input
         # dict.copy() is shallow and does not work with embedded list in dicts (as is the case here)
@@ -246,7 +242,7 @@ def diff_environment_yml(
             diff_pip_check = list(set(pip_dep_env) - set(pip_dep_devenv))
             if len(diff_pip_check) != 0:
                 raise ValueError(
-                    "The following pip dependencies are listed in env but not dev-env: " + ",".join(diff_pip_check)
+                    "The following pip dependencies are listed in env but not dev-env: " + ",".join(diff_pip_check),
                 )
 
             # The diff below computes the dependencies that are in dev-env but not in env, to add during CI

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -822,7 +822,7 @@ def infer_heteroscedasticity_from_stable(
 
     # Get the arrays for proxy values and explanatory variables
     list_all_arr, gsd = _preprocess_values_with_mask_to_array(
-        values=[dvalues, list_var], include_mask=stable_mask, exclude_mask=unstable_mask, preserve_shape=False,
+        values=[dvalues] + list_var, include_mask=stable_mask, exclude_mask=unstable_mask, preserve_shape=False, # noqa: RUF005
     )
     dvalues_stable_arr = list_all_arr[0]
     list_var_stable_arr = list_all_arr[1:]
@@ -988,7 +988,7 @@ def _aggregate_pdist_empirical_variogram(
         # Define subsampling parameters
         list_inside_radius = []
         list_outside_radius: list[float | None] = []
-        binned_ranges = [0.0, pdist_multi_ranges]
+        binned_ranges = [0.0] + pdist_multi_ranges # noqa: RUF005
         for i in range(len(binned_ranges) - 1):
 
             # Radiuses need to be passed as pixel sizes, dividing by ground sampling distance
@@ -3027,7 +3027,7 @@ def plot_variogram(
                 first_xmin = np.min(df.lags) / 2
             else:
                 first_xmin = 0
-            xscale_range_split = [first_xmin, xscale_range_split]
+            xscale_range_split = [first_xmin] + xscale_range_split # noqa: RUF005
         # Add maximum distance if not in input
         if xscale_range_split[-1] != np.max(df.lags):
             xscale_range_split.append(np.max(df.lags))
@@ -3058,7 +3058,7 @@ def plot_variogram(
         ax0.set_xticks([])
 
         # Plot the histogram manually with fill_between
-        interval_var = [0, list(df.lags)]
+        interval_var = [0] + list(df.lags) # noqa: RUF005
         for i in range(len(df)):
             count = df["count"].values[i]
             ax0.fill_between(
@@ -3083,7 +3083,7 @@ def plot_variogram(
         ax1 = ax.inset_axes(grid[3:, xgridmin[k] : xgridmax[k]].get_position(fig).bounds)
 
         # Get the lags bin centers
-        bins_center = np.subtract(df.lags, np.diff([0, df.lags.tolist()]) / 2)
+        bins_center = np.subtract(df.lags, np.diff([0] + df.lags.tolist()) / 2) # noqa: RUF005
 
         # If all the estimated errors are all NaN (single run), simply plot the empirical variogram
         if np.all(np.isnan(df.err_exp)):

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -20,7 +20,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import Sized, overload
+from collections.abc import Sized
+from typing import overload
 
 import geoutils as gu
 import numba
@@ -53,16 +54,15 @@ def _get_quadric_coefficients(
     edge_method: str = "none",
     make_rugosity: bool = False,
 ) -> NDArrayf:
-    """
-    Run the pixel-wise analysis in parallel for a 3x3 window using the resolution.
+    """Run the pixel-wise analysis in parallel for a 3x3 window using the resolution.
 
     See the xdem.terrain.get_quadric_coefficients() docstring for more info.
     """
     # Rename the resolution
-    L = resolution
+    L = resolution # noqa: N806
 
     # Allocate the output.
-    output = np.full((12,) + dem.shape, fill_value=np.nan)
+    output = np.full((12,) + dem.shape, fill_value=np.nan) # noqa: RUF005
 
     # Convert the string to a number (fewer bytes to compare each iteration)
     if fill_method == "median":
@@ -87,7 +87,7 @@ def _get_quadric_coefficients(
 
         # Extract the pixel and its 8 immediate neighbours.
         # If the border is reached, just duplicate the closest neighbour to obtain 9 values.
-        Z = np.empty((9,), dtype=dem.dtype)
+        Z = np.empty((9,), dtype=dem.dtype) # noqa: N806
         count = 0
 
         # If edge_method == "none", validate that it's not near an edge. If so, leave the nans without filling.
@@ -177,28 +177,28 @@ def _get_quadric_coefficients(
             # pixels and 1 segment between surrounding pixels; pixel 4 is the center
             # above 4 the index of center-surrounding segment decrease by 1, as the center pixel was skipped
             # Triangle 1: pixels 3 and 0
-            T1 = [hsl[3], hsl[0], hsl[12]]
+            T1 = [hsl[3], hsl[0], hsl[12]] # noqa: N806
             # Triangle 2: pixels 0 and 1
-            T2 = [hsl[0], hsl[1], hsl[8]]
+            T2 = [hsl[0], hsl[1], hsl[8]] # noqa: N806
             # Triangle 3: pixels 1 and 2
-            T3 = [hsl[1], hsl[2], hsl[9]]
+            T3 = [hsl[1], hsl[2], hsl[9]] # noqa: N806
             # Triangle 4: pixels 2 and 5
-            T4 = [hsl[2], hsl[4], hsl[14]]
+            T4 = [hsl[2], hsl[4], hsl[14]] # noqa: N806
             # Triangle 5: pixels 5 and 8
-            T5 = [hsl[4], hsl[7], hsl[15]]
+            T5 = [hsl[4], hsl[7], hsl[15]] # noqa: N806
             # Triangle 6: pixels 8 and 7
-            T6 = [hsl[7], hsl[6], hsl[11]]
+            T6 = [hsl[7], hsl[6], hsl[11]] # noqa: N806
             # Triangle 7: pixels 7 and 6
-            T7 = [hsl[6], hsl[5], hsl[10]]
+            T7 = [hsl[6], hsl[5], hsl[10]] # noqa: N806
             # Triangle 8: pixels 6 and 3
-            T8 = [hsl[5], hsl[3], hsl[13]]
+            T8 = [hsl[5], hsl[3], hsl[13]] # noqa: N806
 
-            list_T = [T1, T2, T3, T4, T5, T6, T7, T8]
+            list_T = [T1, T2, T3, T4, T5, T6, T7, T8] # noqa: N806
 
             # Finally, we compute the 3D surface areas of the 8 triangles
-            A = np.empty((8,))
+            A = np.empty((8,)) # noqa: N806
             count = 0
-            for T in list_T:
+            for T in list_T: # noqa: N806
                 # Half sum of lengths
                 hs = sum(T) / 2
                 # Surface area of triangle
@@ -236,8 +236,7 @@ def get_quadric_coefficients(
     edge_method: str = "none",
     make_rugosity: bool = False,
 ) -> NDArrayf:
-    """
-    Computes quadric and other coefficients on a fixed 3x3 pixel window, and that depends on the resolution.
+    """Computes quadric and other coefficients on a fixed 3x3 pixel window, and that depends on the resolution.
     Returns the 9 coefficients of a quadric surface fit to every pixel in the raster, the 2 coefficients of optimized
     slope gradient, and the rugosity.
 
@@ -304,7 +303,7 @@ def get_quadric_coefficients(
     if len(dem_arr.shape) != 2:
         raise ValueError(
             f"Invalid input array shape: {dem.shape}, parsed into {dem_arr.shape}. "
-            "Expected 2D array or 3D array of shape (1, row, col)."
+            "Expected 2D array or 3D array of shape (1, row, col).",
         )
 
     if any(dim < 3 for dim in dem_arr.shape):
@@ -312,12 +311,12 @@ def get_quadric_coefficients(
 
     # Resolution is in other tools accepted as a tuple. Here, it must be just one number, so it's best to sanity check.
     if isinstance(resolution, Sized):
-        raise ValueError("Resolution must be the same for X and Y directions.")
+        raise TypeError("Resolution must be the same for X and Y directions.")
 
     allowed_fill_methods = ["median", "mean", "none"]
     allowed_edge_methods = ["nearest", "wrap", "none"]
     for value, name, allowed in zip(
-        [fill_method, edge_method], ["fill", "edge"], (allowed_fill_methods, allowed_edge_methods)
+        [fill_method, edge_method], ["fill", "edge"], (allowed_fill_methods, allowed_edge_methods), strict=False,
     ):
         if value.lower() not in allowed:
             raise ValueError(f"Invalid {name} method: '{value}'. Choices: {allowed}.")
@@ -345,14 +344,12 @@ def _get_windowed_indexes(
     window_size: int = 3,
     make_fractal_roughness: bool = False,
 ) -> NDArrayf:
-    """
-    Run the pixel-wise analysis in parallel for any window size without using the resolution.
+    """Run the pixel-wise analysis in parallel for any window size without using the resolution.
 
     See the xdem.terrain.get_windowed_indexes() docstring for more info.
     """
-
     # Allocate the outputs.
-    output = np.full((5,) + dem.shape, fill_value=np.nan)
+    output = np.full((5,) + dem.shape, fill_value=np.nan) # noqa: RUF005
 
     # Half window size
     hw = int(np.floor(window_size / 2))
@@ -380,7 +377,7 @@ def _get_windowed_indexes(
 
         # Extract the pixel and its 8 immediate neighbours.
         # If the border is reached, just duplicate the closest neighbour to obtain 9 values.
-        Z = np.empty((window_size**2,), dtype=dem.dtype)
+        Z = np.empty((window_size**2,), dtype=dem.dtype) # noqa: N806
         count = 0
 
         # If edge_method == "none", validate that it's not near an edge. If so, leave the nans without filling.
@@ -427,7 +424,7 @@ def _get_windowed_indexes(
         # Difference pixels between specific cells: only useful for Terrain Ruggedness Index
         count = 0
         index_middle_pixel = int((window_size**2 - 1) / 2)
-        S = np.empty((window_size**2,))
+        S = np.empty((window_size**2,)) # noqa: N806
         for _j in range(-hw, -hw + window_size):
             for _k in range(-hw, -hw + window_size):
                 S[count] = np.abs(Z[count] - Z[index_middle_pixel])
@@ -437,14 +434,14 @@ def _get_windowed_indexes(
             # Fractal roughness computation according to the box-counting method of Taud and Parrot (2005)
             # First, we compute the number of voxels for each pixel of Equation 4
             count = 0
-            V = np.empty((window_size, window_size))
+            V = np.empty((window_size, window_size)) # noqa: N806
             for j in range(-hw, -hw + window_size):
                 for k in range(-hw, -hw + window_size):
-                    T = Z[count] - Z[index_middle_pixel]
+                    T = Z[count] - Z[index_middle_pixel] # noqa: N806
                     # The following is the equivalent of np.clip, written like this for numba
                     if T < 0:
                         V[hw + j, hw + k] = 0
-                    elif T > window_size:
+                    elif window_size < T:
                         V[hw + j, hw + k] = window_size
                     else:
                         V[hw + j, hw + k] = T
@@ -454,19 +451,16 @@ def _get_windowed_indexes(
             # size, following Equation 5
 
             # Get all the divisors of the half window size
-            list_box_sizes = []
-            for j in range(1, hw + 1):
-                if hw % j == 0:
-                    list_box_sizes.append(j)
+            list_box_sizes = [j for j in range(1, hw + 1) if hw % j == 0]
 
-            Ns = np.empty((len(list_box_sizes),))
-            for l0 in range(0, len(list_box_sizes)):
+            Ns = np.empty((len(list_box_sizes),)) # noqa: N806
+            for l0 in range(len(list_box_sizes)):
                 # We loop over boxes of size q x q in the cube
                 q = list_box_sizes[l0]
-                sumNs = 0
-                for j in range(0, int((window_size - 1) / q)):
-                    for k in range(0, int((window_size - 1) / q)):
-                        sumNs += np.max(V[slice(j * q, (j + 1) * q), slice(k * q, (k + 1) * q)].flatten())
+                sumNs = 0 # noqa: N806
+                for j in range(int((window_size - 1) / q)):
+                    for k in range(int((window_size - 1) / q)):
+                        sumNs += np.max(V[slice(j * q, (j + 1) * q), slice(k * q, (k + 1) * q)].flatten()) # noqa: N806
                 Ns[l0] = sumNs / q
 
             # Finally, we calculate the slope of the logarithm of Ns with q
@@ -479,13 +473,13 @@ def _get_windowed_indexes(
             m_x = np.mean(x)
             m_y = np.mean(y)
             # Cross-deviation and deviation about x
-            SS_xy = np.sum(y * x) - n * m_y * m_x
-            SS_xx = np.sum(x * x) - n * m_x * m_x
+            SS_xy = np.sum(y * x) - n * m_y * m_x # noqa: N806
+            SS_xx = np.sum(x * x) - n * m_x * m_x # noqa: N806
             # Calculating slope
             b_1 = SS_xy / SS_xx
 
             # The fractal dimension D is the opposite of the slope
-            D = -b_1
+            D = -b_1 # noqa: N806
 
         # First output is the Terrain Ruggedness Index from Riley et al. (1999): squareroot of squared sum of
         # differences between center and neighbouring pixels
@@ -514,8 +508,7 @@ def get_windowed_indexes(
     window_size: int = 3,
     make_fractal_roughness: bool = False,
 ) -> NDArrayf:
-    """
-    Return terrain indexes based on a windowed calculation of variable size, independent of the resolution.
+    """Return terrain indexes based on a windowed calculation of variable size, independent of the resolution.
 
     Includes:
 
@@ -576,7 +569,7 @@ def get_windowed_indexes(
     if len(dem_arr.shape) != 2:
         raise ValueError(
             f"Invalid input array shape: {dem.shape}, parsed into {dem_arr.shape}. "
-            "Expected 2D array or 3D array of shape (1, row, col)"
+            "Expected 2D array or 3D array of shape (1, row, col)",
         )
 
     if any(dim < 3 for dim in dem_arr.shape):
@@ -588,7 +581,7 @@ def get_windowed_indexes(
     allowed_fill_methods = ["median", "mean", "none"]
     allowed_edge_methods = ["nearest", "wrap", "none"]
     for value, name, allowed in zip(
-        [fill_method, edge_method], ["fill", "edge"], (allowed_fill_methods, allowed_edge_methods)
+        [fill_method, edge_method], ["fill", "edge"], (allowed_fill_methods, allowed_edge_methods), strict=False,
     ):
         if value.lower() not in allowed:
             raise ValueError(f"Invalid {name} method: '{value}'. Choices: {allowed}")
@@ -690,8 +683,7 @@ def get_terrain_attribute(
     edge_method: str = "none",
     window_size: int = 3,
 ) -> NDArrayf | list[NDArrayf] | RasterType | list[RasterType]:
-    """
-    Derive one or multiple terrain attributes from a DEM.
+    """Derive one or multiple terrain attributes from a DEM.
     The attributes are based on:
 
     - Slope, aspect, hillshade (first method) from Horn (1981), http://dx.doi.org/10.1109/PROC.1981.11918,
@@ -709,7 +701,6 @@ def get_terrain_attribute(
     More details on the equations in the functions get_quadric_coefficients() and get_windowed_indexes().
 
     Attributes:
-
     * 'slope': The slope in degrees or radians (degs: 0=flat, 90=vertical). Default method: "Horn".
     * 'aspect': The slope aspect in degrees or radians (degs: 0=N, 90=E, 180=S, 270=W).
     * 'hillshade': The shaded slope in relation to its aspect.
@@ -759,6 +750,7 @@ def get_terrain_attribute(
                [0., 0., 0.]])
 
     :returns: One or multiple arrays of the requested attribute(s)
+
     """
     if isinstance(dem, gu.Raster):
         if resolution is None:
@@ -842,7 +834,7 @@ def get_terrain_attribute(
         if resolution[0] != resolution[1]:
             raise ValueError(
                 f"Quadric surface fit requires the same X and Y resolution ({resolution} was given). "
-                f"This was required by: {attributes_requiring_surface_fit}"
+                f"This was required by: {attributes_requiring_surface_fit}",
             )
         terrain_attributes["surface_fit"] = get_quadric_coefficients(
             dem=dem_arr,
@@ -859,7 +851,7 @@ def get_terrain_attribute(
             # http://dx.doi.org/10.1109/PROC.1981.11918.
             terrain_attributes["slope"] = np.arctan(
                 (terrain_attributes["surface_fit"][9, :, :] ** 2 + terrain_attributes["surface_fit"][10, :, :] ** 2)
-                ** 0.5
+                ** 0.5,
             )
 
         elif slope_method == "ZevenbergThorne":
@@ -868,7 +860,7 @@ def get_terrain_attribute(
             # SLOPE = ARCTAN((G²+H²)**(1/2))
             terrain_attributes["slope"] = np.arctan(
                 (terrain_attributes["surface_fit"][6, :, :] ** 2 + terrain_attributes["surface_fit"][7, :, :] ** 2)
-                ** 0.5
+                ** 0.5,
             )
 
     if make_aspect:
@@ -881,7 +873,7 @@ def get_terrain_attribute(
                 # This uses the estimates from Horn (1981).
                 terrain_attributes["aspect"] = (
                     -np.arctan2(
-                        -terrain_attributes["surface_fit"][9, :, :], terrain_attributes["surface_fit"][10, :, :]
+                        -terrain_attributes["surface_fit"][9, :, :], terrain_attributes["surface_fit"][10, :, :],
                     )
                     - np.pi
                 ) % (2 * np.pi)
@@ -1044,8 +1036,7 @@ def slope(
     degrees: bool = True,
     resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | Raster:
-    """
-    Generate a slope map for a DEM, returned in degrees by default.
+    """Generate a slope map for a DEM, returned in degrees by default.
 
     Based on Horn (1981), http://dx.doi.org/10.1109/PROC.1981.11918 and on Zevenbergen and Thorne (1987),
     http://dx.doi.org/10.1002/esp.3290120107.
@@ -1092,8 +1083,7 @@ def aspect(
     method: str = "Horn",
     degrees: bool = True,
 ) -> NDArrayf | Raster:
-    """
-    Calculate the aspect of each cell in a DEM, returned in degrees by default. The aspect of flat slopes is 180° by
+    """Calculate the aspect of each cell in a DEM, returned in degrees by default. The aspect of flat slopes is 180° by
     default (as in GDAL).
 
     Based on Horn (1981), http://dx.doi.org/10.1109/PROC.1981.11918 and on Zevenbergen and Thorne (1987),
@@ -1156,8 +1146,7 @@ def hillshade(
     z_factor: float = 1.0,
     resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Generate a hillshade from the given DEM. The value 0 is used for nodata, and 1 to 255 for hillshading.
+    """Generate a hillshade from the given DEM. The value 0 is used for nodata, and 1 to 255 for hillshading.
 
     Based on Horn (1981), http://dx.doi.org/10.1109/PROC.1981.11918.
 
@@ -1203,8 +1192,7 @@ def curvature(
     dem: NDArrayf | MArrayf | RasterType,
     resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Calculate the terrain curvature (second derivative of elevation) in m-1 multiplied by 100.
+    """Calculate the terrain curvature (second derivative of elevation) in m-1 multiplied by 100.
 
     Based on Zevenbergen and Thorne (1987), http://dx.doi.org/10.1002/esp.3290120107.
 
@@ -1248,8 +1236,7 @@ def planform_curvature(
     dem: NDArrayf | MArrayf | RasterType,
     resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Calculate the terrain curvature perpendicular to the direction of the slope in m-1 multiplied by 100.
+    """Calculate the terrain curvature perpendicular to the direction of the slope in m-1 multiplied by 100.
 
     Based on Zevenbergen and Thorne (1987), http://dx.doi.org/10.1002/esp.3290120107.
 
@@ -1284,10 +1271,9 @@ def profile_curvature(dem: RasterType, resolution: float | tuple[float, float] |
 
 
 def profile_curvature(
-    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None
+    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Calculate the terrain curvature parallel to the direction of the slope in m-1 multiplied by 100.
+    """Calculate the terrain curvature parallel to the direction of the slope in m-1 multiplied by 100.
 
     Based on Zevenbergen and Thorne (1987), http://dx.doi.org/10.1002/esp.3290120107.
 
@@ -1322,10 +1308,9 @@ def maximum_curvature(dem: RasterType, resolution: float | tuple[float, float] |
 
 
 def maximum_curvature(
-    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None
+    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Calculate the signed maximum profile or planform curvature parallel to the direction of the slope in m-1
+    """Calculate the signed maximum profile or planform curvature parallel to the direction of the slope in m-1
     multiplied by 100.
 
     Based on Zevenbergen and Thorne (1987), http://dx.doi.org/10.1002/esp.3290120107.
@@ -1349,8 +1334,7 @@ def topographic_position_index(dem: RasterType, window_size: int = 3) -> RasterT
 
 
 def topographic_position_index(dem: NDArrayf | MArrayf | RasterType, window_size: int = 3) -> NDArrayf | RasterType:
-    """
-    Calculates the Topographic Position Index, the difference to the average of neighbouring pixels. Output is in the
+    """Calculates the Topographic Position Index, the difference to the average of neighbouring pixels. Output is in the
     unit of the DEM (typically meters).
 
     Based on: Weiss (2001), http://www.jennessent.com/downloads/TPI-poster-TNC_18x22.pdf.
@@ -1386,10 +1370,9 @@ def terrain_ruggedness_index(dem: RasterType, method: str = "Riley", window_size
 
 
 def terrain_ruggedness_index(
-    dem: NDArrayf | MArrayf | RasterType, method: str = "Riley", window_size: int = 3
+    dem: NDArrayf | MArrayf | RasterType, method: str = "Riley", window_size: int = 3,
 ) -> NDArrayf | RasterType:
-    """
-    Calculates the Terrain Ruggedness Index, the cumulated differences to neighbouring pixels. Output is in the
+    """Calculates the Terrain Ruggedness Index, the cumulated differences to neighbouring pixels. Output is in the
     unit of the DEM (typically meters).
 
     Based either on:
@@ -1420,7 +1403,7 @@ def terrain_ruggedness_index(
     :returns: The terrain ruggedness index array of the DEM (unit of the DEM).
     """
     return get_terrain_attribute(
-        dem=dem, attribute="terrain_ruggedness_index", tri_method=method, window_size=window_size
+        dem=dem, attribute="terrain_ruggedness_index", tri_method=method, window_size=window_size,
     )
 
 
@@ -1433,9 +1416,8 @@ def roughness(dem: RasterType, window_size: int = 3) -> RasterType: ...
 
 
 def roughness(dem: NDArrayf | MArrayf | RasterType, window_size: int = 3) -> NDArrayf | RasterType:
-    """
-    Calculates the roughness, the maximum difference between neighbouring pixels, for any window size. Output is in the
-    unit of the DEM (typically meters).
+    """Calculates the roughness, the maximum difference between neighbouring pixels, for any window size.
+    Output is in the unit of the DEM (typically meters).
 
     Based on: Dartnell (2000), https://environment.sfsu.edu/node/11292.
 
@@ -1476,10 +1458,9 @@ def rugosity(
 
 
 def rugosity(
-    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None
+    dem: NDArrayf | MArrayf | RasterType, resolution: float | tuple[float, float] | None = None,
 ) -> NDArrayf | RasterType:
-    """
-    Calculates the rugosity, the ratio between real area and planimetric area. Only available for a 3x3 window. The
+    """Calculates the rugosity, the ratio between real area and planimetric area. Only available for a 3x3 window. The
     output is unitless.
 
     Based on: Jenness (2004), https://doi.org/10.2193/0091-7648(2004)032[0829:CLSAFD]2.0.CO;2.
@@ -1515,8 +1496,7 @@ def fractal_roughness(dem: RasterType, window_size: int = 13) -> RasterType: ...
 
 
 def fractal_roughness(dem: NDArrayf | MArrayf | RasterType, window_size: int = 13) -> NDArrayf | RasterType:
-    """
-    Calculates the fractal roughness, the local 3D fractal dimension. Can only be computed on window sizes larger or
+    """Calculates the fractal roughness, the local 3D fractal dimension. Can only be computed on window sizes larger or
     equal to 5x5, defaults to 13x13. Output unit is a fractal dimension between 1 and 3.
 
     Based on: Taud et Parrot (2005), https://doi.org/10.4000/geomorphologie.622.


### PR DESCRIPTION
Resolves [#550](https://github.com/GlacioHack/xdem/issues/550)

## Description : 

The Pull Request implements linting on xDEM in order to guarantee the same code quality as demcompare. 
The idea was to limit the number of tools and to apply the same rules as demcompare. 
That's why we choose to implement Ruff in Xdem, a fast python linter and code formatter gathering a lot of functionalities and replacing pylint, black, flake8 and isort. 

## Key changes : 

- Ruff configuration : 


    - [x] ruff.toml file addded including the following rules : 

       - Target version of python : 3.10 
       - The formatter will wraps lines at a length of 120 and use 4 spaces per tabulation when a line exceed 120 characters. 
       - Ruff will ignore 46 lint rules (for now)

    - [x] Ruff added in makefile 
    - [x] Ruff added in CI file 
    - [x] Ruff added in setup.cfg file 
    

- Code correction : 

    Ruff returned a lot of errors related to 108 lint rules : 

    - [x] 62 of them has been fixed, the remaining is ignored and can be fixed later

     