### PR TITLE
Update documentation for ROI and stats

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - tqdm
   - scikit-image=0.*
   - scikit-gstat>=1.0.18,<1.1
-  - geoutils=0.1.12
+  - geoutils=0.1.13
   - affine
   - pandas
   - pyogrio

--- a/doc/source/dem_class.md
+++ b/doc/source/dem_class.md
@@ -136,6 +136,38 @@ slope.plot(cmap="Reds", cbar_title="Slope (°)")
 For the full list of terrain attributes, see the {ref}`terrain-attributes` page.
 ```
 
+## Statistics
+The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std.
+Callable functions are supported as well.
+
+- Get all statistics in a dict:
+```{code-cell} ipython3
+dem.get_stats()
+```
+
+- Get a single statistic (e.g., 'mean') as a float:
+```{code-cell} ipython3
+dem.get_stats("mean")
+```
+
+- Get multiple statistics in a dict:
+```{code-cell} ipython3
+dem.get_stats(["mean", "max", "rmse"])
+```
+
+- Using a custom callable statistic:
+```{code-cell} ipython3
+def custom_stat(data):
+    return np.nansum(data > 100)  # Count the number of pixels above 100
+dem.get_stats(custom_stat)
+```
+
+Note : as `get_stats()` is a raster method, it can also be used for terrain attributes:
+```{code-cell} ipython3
+slope.get_stats()
+```
+
 ## Coregistration
 
 3D coregistration is performed with {func}`~xdem.DEM.coregister_3d`, which aligns the

--- a/doc/source/dem_class.md
+++ b/doc/source/dem_class.md
@@ -138,7 +138,9 @@ For the full list of terrain attributes, see the {ref}`terrain-attributes` page.
 
 ## Statistics
 The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std.
+Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points,
+percentage valid points, valid points all data, percentage valid points all data.
+The RMSE is only relevant when the raster represents a difference of two objects.
 Callable functions are supported as well.
 
 - Get all statistics in a dict:
@@ -215,17 +217,7 @@ We use `random_state` to ensure a fixed randomized output. It is **only necessar
 For more details on quantifying random and structured errors, see the {ref}`uncertainty` page.
 ```
 
-## Region of interest (ROI)
-To limit DEM comparison to a Region Of Interest (ROI) one can set a bounding box in terrain geometry or part of the DEM with image coordinates:
+## Cropping a DEM
 
-The `roi` can be specified in two formats:
-- **Pixel-based ROI:** Defined by the pixel coordinates with the following keys: `x`, `y`, `w`, and `h`, where (`x`, `y`) top-left corner coordinates and (`w`, `h`) the dimensions (width, height) in pixels.
-- **Georeferenced ROI:** Defined by geographical coordinates with the following keys: `left`, `bottom`, `right`, `top` and optional `crs` (Coordinate Reference System, defaults to EPSG:4326 if not provided).
-
-```{code-cell} ipython3
-# Initialize a DEM with a pixel-based ROI
-dem = xdem.DEM(filename_dem, roi={'x': 50, 'y': 100, 'w': 400, 'h': 300})
-
-# Initialize a DEM with a georeferenced ROI
-dem = xdem.DEM(filename_dem, roi={'left': 503810, 'bottom': 8666030, 'top': 8672030, 'right': 511810, 'crs': 'EPSG:25833'})
-```
+The DEM cropping functionalities in `xdem` are based on those in `geoutils`.
+For more information on using cropping functions, please refer to the [`geoutils` documentation](https://geoutils.readthedocs.io/en/latest/raster_class.html#crop).

--- a/doc/source/dem_class.md
+++ b/doc/source/dem_class.md
@@ -163,7 +163,7 @@ def custom_stat(data):
 dem.get_stats(custom_stat)
 ```
 
-Note : as `get_stats()` is a raster method, it can also be used for terrain attributes:
+Note: as `get_stats()` is a raster method, it can also be used for terrain attributes:
 ```{code-cell} ipython3
 slope.get_stats()
 ```
@@ -213,4 +213,19 @@ print("Elevation errors at a distance of 1 km are correlated at {:.2f} %.".forma
 We use `random_state` to ensure a fixed randomized output. It is **only necessary if you need your results to be exactly reproductible**.
 
 For more details on quantifying random and structured errors, see the {ref}`uncertainty` page.
+```
+
+## Region of interest (ROI)
+To limit DEM comparison to a Region Of Interest (ROI) one can set a bounding box in terrain geometry or part of the DEM with image coordinates:
+
+The `roi` can be specified in two formats:
+- **Pixel-based ROI:** Defined by the pixel coordinates with the following keys: `x`, `y`, `w`, and `h`, where (`x`, `y`) top-left corner coordinates and (`w`, `h`) the dimensions (width, height) in pixels.
+- **Georeferenced ROI:** Defined by geographical coordinates with the following keys: `left`, `bottom`, `right`, `top` and optional `crs` (Coordinate Reference System, defaults to EPSG:4326 if not provided).
+
+```{code-cell} ipython3
+# Initialize a DEM with a pixel-based ROI
+dem = xdem.DEM(filename_dem, roi={'x': 50, 'y': 100, 'w': 400, 'h': 300})
+
+# Initialize a DEM with a georeferenced ROI
+dem = xdem.DEM(filename_dem, roi={'left': 503810, 'bottom': 8666030, 'top': 8672030, 'right': 511810, 'crs': 'EPSG:25833'})
 ```

--- a/doc/source/dem_class.md
+++ b/doc/source/dem_class.md
@@ -137,35 +137,18 @@ For the full list of terrain attributes, see the {ref}`terrain-attributes` page.
 ```
 
 ## Statistics
-The `get_stats()` method allows to extract key statistical information from a raster in a dictionary.
-Supported statistics are : mean, median, max, mean, sum, sum of squares, 90th percentile, nmad, rmse, std, valid points,
-percentage valid points, valid points all data, percentage valid points all data.
-The RMSE is only relevant when the raster represents a difference of two objects.
-Callable functions are supported as well.
+The [`get_stats()`](https://geoutils.readthedocs.io/en/latest/gen_modules/geoutils.Raster.get_stats.html) method allows to extract key statistical information from a raster in a dictionary.
 
 - Get all statistics in a dict:
 ```{code-cell} ipython3
 dem.get_stats()
 ```
 
-- Get a single statistic (e.g., 'mean') as a float:
-```{code-cell} ipython3
-dem.get_stats("mean")
-```
+The DEM statistics functionalities in `xdem` are based on those in `geoutils`.
+For more information on computing statistics, please refer to the [`geoutils` documentation](https://geoutils.readthedocs.io/en/latest/raster_class.html#obtain-statistics).
 
-- Get multiple statistics in a dict:
-```{code-cell} ipython3
-dem.get_stats(["mean", "max", "rmse"])
-```
 
-- Using a custom callable statistic:
-```{code-cell} ipython3
-def custom_stat(data):
-    return np.nansum(data > 100)  # Count the number of pixels above 100
-dem.get_stats(custom_stat)
-```
-
-Note: as `get_stats()` is a raster method, it can also be used for terrain attributes:
+Note: as [`get_stats()`](https://geoutils.readthedocs.io/en/latest/gen_modules/geoutils.Raster.get_stats.html) is a raster method, it can also be used for terrain attributes:
 ```{code-cell} ipython3
 slope.get_stats()
 ```
@@ -219,5 +202,5 @@ For more details on quantifying random and structured errors, see the {ref}`unce
 
 ## Cropping a DEM
 
-The DEM cropping functionalities in `xdem` are based on those in `geoutils`.
+The DEM cropping functionalities in `xdem` are based on those in `geoutils` ([`crop()`](https://geoutils.readthedocs.io/en/latest/gen_modules/geoutils.Raster.crop.html#geoutils.Raster.crop), [`icrop()`](https://geoutils.readthedocs.io/en/latest/gen_modules/geoutils.Raster.icrop.html#geoutils.Raster.icrop)).
 For more information on using cropping functions, please refer to the [`geoutils` documentation](https://geoutils.readthedocs.io/en/latest/raster_class.html#crop).

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - tqdm
   - scikit-image=0.*
   - scikit-gstat>=1.0.18,<1.1
-  - geoutils=0.1.12
+  - geoutils=0.1.13
   - pip
   - affine
   - pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ scipy==1.*
 tqdm
 scikit-image==0.*
 scikit-gstat>=1.0.18,<1.1
-geoutils==0.1.12
+geoutils==0.1.13
 pip
 affine
 pandas

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -92,7 +92,6 @@ class DEM(Raster):  # type: ignore
         silent: bool = True,
         downsample: int = 1,
         nodata: int | float | None = None,
-        roi: dict[str, float | int] | None = None,
     ) -> None:
         """
         Instantiate a digital elevation model.
@@ -110,8 +109,6 @@ class DEM(Raster):  # type: ignore
         :param silent: Whether to display vertical reference parsing.
         :param downsample: Downsample the array once loaded by a round factor. Default is no downsampling.
         :param nodata: Nodata value to be used (overwrites the metadata). Default reads from metadata.
-        :param roi: Optional region of interest. Can be pixel-based (dict with keys: 'x', 'y', 'w', 'h')
-            or georeferenced (dict with keys: left', 'bottom', 'right', 'top', optional 'crs').
         """
 
         self.data: NDArrayf
@@ -135,7 +132,6 @@ class DEM(Raster):  # type: ignore
                     silent=silent,
                     downsample=downsample,
                     nodata=nodata,
-                    roi=roi,
                 )
 
         # Ensure DEM has only one band: self.bands can be None when data is not loaded through the Raster class
@@ -196,7 +192,6 @@ class DEM(Raster):  # type: ignore
         area_or_point: Literal["Area", "Point"] | None = None,
         tags: dict[str, Any] = None,
         cast_nodata: bool = True,
-        roi: dict[str, float | int] = None,
         vcrs: (
             Literal["Ellipsoid"] | Literal["EGM08"] | Literal["EGM96"] | str | pathlib.Path | VerticalCRS | int | None
         ) = None,
@@ -212,8 +207,6 @@ class DEM(Raster):  # type: ignore
         :param tags: Metadata stored in a dictionary.
         :param cast_nodata: Automatically cast nodata value to the default nodata for the new array type if not
             compatible. If False, will raise an error when incompatible.
-        :param roi: Optional region of interest. Can be pixel-based (dict with keys: 'x', 'y', 'w', 'h')
-            or georeferenced (dict with keys: left', 'bottom', 'right', 'top', optional 'crs').
         :param vcrs: Vertical coordinate reference system.
 
 
@@ -228,7 +221,6 @@ class DEM(Raster):  # type: ignore
             area_or_point=area_or_point,
             tags=tags,
             cast_nodata=cast_nodata,
-            roi=roi,
         )
         # Then add the vcrs to the class call (that builds on top of the parent class)
         return cls(filename_or_dataset=rast, vcrs=vcrs)

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -92,6 +92,7 @@ class DEM(Raster):  # type: ignore
         silent: bool = True,
         downsample: int = 1,
         nodata: int | float | None = None,
+        roi: dict[str, float | int] | None = None,
     ) -> None:
         """
         Instantiate a digital elevation model.
@@ -109,6 +110,8 @@ class DEM(Raster):  # type: ignore
         :param silent: Whether to display vertical reference parsing.
         :param downsample: Downsample the array once loaded by a round factor. Default is no downsampling.
         :param nodata: Nodata value to be used (overwrites the metadata). Default reads from metadata.
+        :param roi: Optional region of interest. Can be pixel-based (dict with keys: 'x', 'y', 'w', 'h')
+            or georeferenced (dict with keys: left', 'bottom', 'right', 'top', optional 'crs').
         """
 
         self.data: NDArrayf
@@ -132,6 +135,7 @@ class DEM(Raster):  # type: ignore
                     silent=silent,
                     downsample=downsample,
                     nodata=nodata,
+                    roi=roi,
                 )
 
         # Ensure DEM has only one band: self.bands can be None when data is not loaded through the Raster class
@@ -192,6 +196,7 @@ class DEM(Raster):  # type: ignore
         area_or_point: Literal["Area", "Point"] | None = None,
         tags: dict[str, Any] = None,
         cast_nodata: bool = True,
+        roi: dict[str, float | int] = None,
         vcrs: (
             Literal["Ellipsoid"] | Literal["EGM08"] | Literal["EGM96"] | str | pathlib.Path | VerticalCRS | int | None
         ) = None,
@@ -207,7 +212,10 @@ class DEM(Raster):  # type: ignore
         :param tags: Metadata stored in a dictionary.
         :param cast_nodata: Automatically cast nodata value to the default nodata for the new array type if not
             compatible. If False, will raise an error when incompatible.
+        :param roi: Optional region of interest. Can be pixel-based (dict with keys: 'x', 'y', 'w', 'h')
+            or georeferenced (dict with keys: left', 'bottom', 'right', 'top', optional 'crs').
         :param vcrs: Vertical coordinate reference system.
+
 
         :returns: DEM created from the provided array and georeferencing.
         """
@@ -220,6 +228,7 @@ class DEM(Raster):  # type: ignore
             area_or_point=area_or_point,
             tags=tags,
             cast_nodata=cast_nodata,
+            roi=roi,
         )
         # Then add the vcrs to the class call (that builds on top of the parent class)
         return cls(filename_or_dataset=rast, vcrs=vcrs)


### PR DESCRIPTION
Resolves #602.
Completes GlacioHack/geoutils#642.
Completes GlacioHack/geoutils#638.

## Description
This PR introduces the ability to use a Region of Interest (ROI) when working with `xdem.DEM`, which is a subclass of `geoutils.Raster`. This functionality allows users to focus on specific regions within the raster data without having to load or process the entire dataset.

## Documentation
- A section about statistics has been added to the `DEM` class documentation.
- A section about the ROI has been added to the `DEM` class documentation.

## Example
1. Statistics:
- Get all statistics in a dict:
```{code-cell} ipython3
dem.get_stats()
```

- Get a single statistic (e.g., 'mean') as a float:
```{code-cell} ipython3
dem.get_stats("mean")
```

- Get multiple statistics in a dict:
```{code-cell} ipython3
dem.get_stats(["mean", "max", "rmse"])
```

- Using a custom callable statistic:
```{code-cell} ipython3
def custom_stat(data):
    return np.nansum(data > 100)  # Count the number of pixels above 100
dem.get_stats(custom_stat)
```

Note: as `get_stats()` is a raster method, it can also be used for terrain attributes:
```{code-cell} ipython3
dem.slope().get_stats()
```

## Note
- This PR has to be merged after the next release of geoutils containing GlacioHack/geoutils#642, GlacioHack/geoutils#638.
- The geoutils version in the virtual environment configuration files (`environment.yml`, `dev-environment.yml`, ...) would have to be updated.