### PR TITLE
Fix SciPy warnings and errors

### DIFF
--- a/tests/test_coreg/test_biascorr.py
+++ b/tests/test_coreg/test_biascorr.py
@@ -321,7 +321,7 @@ class TestBiasCorr:
             scipy.optimize.curve_fit,
         ],
     )  # type: ignore
-    @pytest.mark.parametrize("bin_sizes", (10, {"elevation": np.arange(0, 1000, 100)}))  # type: ignore
+    @pytest.mark.parametrize("bin_sizes", (100, {"elevation": np.arange(0, 1000, 100)}))  # type: ignore
     @pytest.mark.parametrize("bin_statistic", [np.median, np.nanmean])  # type: ignore
     def test_biascorr__bin_and_fit_1d(self, fit_args, fit_func, fit_optimizer, bin_sizes, bin_statistic) -> None:
         """Test the _fit_func and apply_func methods of BiasCorr for the bin_and_fit case (called by all subclasses)."""
@@ -376,6 +376,10 @@ class TestBiasCorr:
     @pytest.mark.parametrize("bin_statistic", [np.median, np.nanmean])  # type: ignore
     def test_biascorr__bin_and_fit_2d(self, fit_args, fit_func, fit_optimizer, bin_sizes, bin_statistic) -> None:
         """Test the _fit_func and apply_func methods of BiasCorr for the bin_and_fit case (called by all subclasses)."""
+
+        # Curve fit can be unhappy in certain circumstances for numerical estimation of covariance
+        # We don't care for this test
+        warnings.filterwarnings("ignore", message="Covariance of the parameters could not be estimated*")
 
         # Create a bias correction object
         bcorr = biascorr.BiasCorr(


### PR DESCRIPTION
Resolves #677 

Silences the optimize covariance warning for `test_biascorr__bin_and_fit_2d` as it was done in other functions.

Adds more points to the binning in `test_biascorr__bin_and_fit_1d` to avoid the optimize error.