### PR TITLE
Add Governance and code of conduct files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,34 +11,43 @@ contributions are subject to the project's copyright under the terms of the
 
 This file keeps track of authors contributions.
 
+## Maintainers / Steering Comittee
+
+---
+
+- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
+- **Amaury Dehecq** [@adehecq](https://github.com/adehecq)
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github.com/erikmannerfelt)
+- **Emmanuel Dubois** [@duboise-cnes](https://github.com/duboise-cnes) <emmanuel.dubois@cnes.fr>
+- **Valentine Bellet** [@Valentine-Bellet](https://github.com/valentine-bellet) <valentine.bellet@cnes.fr>
+- **Alice de Bardonnèche-Richard** [@adebardo](https://github.com/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
+
+
 ## Development Lead
 
 ---
 
 - **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
-- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
-- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
+- **Amaury Dehecq** [@adehecq](https://github.com/adehecq)
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github.com/erikmannerfelt)
+
 
 ## Contributors
 
 ---
 
-- **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
-- **Andrew Tedstone** [@atedstone](https://github/atedstone)
-- **Zhihao LIU** [@liuh886](https://github/liuh886)
-- **Diego Cusicanqui** [@cusicand](https://github/cusicand)
-- **Alessandro Gentilini** [@alessandro-gentilini](https://github/alessandro-gentilini)
-- **Ferdinand Schenck** [@fnands](https://github/fnands)
-- **Johannes Landmann** [@jlandmann](https://github/jlandmann)
-- **Valentin Schaffner** [@vschaffn](https://github/vschaffn) <valentin.schaffner@cs-soprasteria.com>
-- **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
-- **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
-- **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
+- **Friedrich Knuth** [@friedrichknuth](https://github.com/friedrichknuth)
+- **Andrew Tedstone** [@atedstone](https://github.com/atedstone)
+- **Zhihao LIU** [@liuh886](https://github.com/liuh886)
+- **Diego Cusicanqui** [@cusicand](https://github.com/cusicand)
+- **Alessandro Gentilini** [@alessandro-gentilini](https://github.com/alessandro-gentilini)
+- **Ferdinand Schenck** [@fnands](https://github.com/fnands)
+- **Johannes Landmann** [@jlandmann](https://github.com/jlandmann)
+- **Valentin Schaffner** [@vschaffn](https://github.com/vschaffn) <valentin.schaffner@cs-soprasteria.com>
+- **Bob McNabb** [@iamdonovan](https://github.com/iamdonovan)
 - **Enrico Mattea** [@MatteaE](https://github.com/MatteaE)
 - **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
 - **Simon Gascoin** [@sgascoin](https://github.com/sgascoin)
-
-Update here with new contributors.
 
 
 ## Original Developers/Designers/Supporters
@@ -46,5 +55,5 @@ Update here with new contributors.
 ---
 
 - **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
-- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
-- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
+- **Amaury Dehecq** [@adehecq](https://github.com/adehecq)
+- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github.com/erikmannerfelt)

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible, please refer to the "Steering
+Comittee" section in [AUTHORS.md](AUTHORS.md).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,64 @@
+# Governance Policy
+
+This document provides the governance policy for the Project. Maintainers agree to this policy and to abide by all Project polices,
+including the [code of conduct](./CODE-OF-CONDUCT.md) and by adding their name to the [AUTHORS.md file](./AUTHORS.md).
+
+## 1. Roles.
+
+This project may include the following roles. Additional roles may be adopted and documented by the Project.
+
+**1.1. Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating
+the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with
+the approval of the current Maintainers.
+
+**1.2. Contributors**. Contributors are those that have made contributions to the Project.
+
+## 2. Decisions.
+
+**2.1. Consensus-Based Decision Making**. Projects make decisions through consensus of the Maintainers. While explicit
+agreement of all Maintainers is preferred, it is not required for consensus. Rather, the Maintainers will determine
+consensus based on their good faith consideration of a number of factors, including the dominant view of the
+Contributors and nature of support and objections. The Maintainers will document evidence of consensus in accordance
+with these requirements.
+
+**2.2. Appeal Process**. Decisions may be appealed by opening an issue and that appeal will be considered by the
+Maintainers in good faith, who will respond in writing within a reasonable time. If the Maintainers deny the appeal,
+the appeal may be brought before the Organization Steering Committee, who will also respond in writing in a reasonable
+time.
+
+## 3. How We Work.
+
+**3.1. Openness**. Participation is open to anyone who is directly and materially affected by the activity in question.
+There shall be no undue financial barriers to participation.
+
+**3.2. Balance**. The development process should balance the interests of Contributors and other stakeholders.
+Contributors from diverse interest categories shall be sought with the objective of achieving balance.
+
+**3.3. Coordination and Harmonization**. Good faith efforts shall be made to resolve potential conflicts or
+incompatibility between releases in this Project.
+
+**3.4. Consideration of Views and Objections**. Prompt consideration shall be given to the written views and
+objections of all Contributors.
+
+**3.5. Written procedures**. This governance document and other materials documenting this project's development
+process shall be available to any interested person.
+
+## 4. No Confidentiality.
+
+Information disclosed in connection with any Project activity, including but not limited to meetings, contributions,
+and submissions, is not confidential, regardless of any markings or statements to the contrary.
+
+## 5. Trademarks.
+
+Any names, trademarks, logos, or goodwill developed by and associated with the Project (the "Marks") are controlled by
+the Organization. Maintainers may only use these Marks in accordance with the Organization's trademark policy. If a
+Maintainer resigns or is removed, any rights the Maintainer may have in the Marks revert to the Organization.
+
+## 6. Amendments.
+
+Amendments to this governance policy may be made by affirmative vote of 2/3 of all Maintainers, with approval by the
+Organization's Steering Committee.
+
+---
+Part of MVG-0.1-beta.
+Made with love by GitHub. Licensed under the [CC-BY 4.0 License](https://creativecommons.org/licenses/by/4.0/).

--- a/doc/source/authors.md
+++ b/doc/source/authors.md
@@ -1,5 +1,5 @@
 (authors)=
-# Authors
+## Authors
 
 © 2024 **xDEM developers**.
 
@@ -9,40 +9,4 @@ All contributors listed in this document are part of the **xDEM developers**, an
 contributions are subject to the project's copyright under the terms of the
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
-This section keeps track of authors contributions.
-
----
-
-## Development lead
-
-- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
-- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
-- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
-
----
-
-## Contributors
-
-
-- **Friedrich Knuth** [@friedrichknuth](https://github/friedrichknuth)
-- **Andrew Tedstone** [@atedstone](https://github/atedstone)
-- **Zhihao LIU** [@liuh886](https://github/liuh886)
-- **Diego Cusicanqui** [@cusicand](https://github/cusicand)
-- **Alessandro Gentilini** [@alessandro-gentilini](https://github/alessandro-gentilini)
-- **Ferdinand Schenck** [@fnands](https://github/fnands)
-- **Johannes Landmann** [@jlandmann](https://github/jlandmann)
-- **Valentin Schaffner** [@vschaffn](https://github/vschaffn) <valentin.schaffner@cs-soprasteria.com>
-- **Alice De Bardonnèche-Richard** [@adebardo](https://github/adebardo) <alice.de-bardonneche-richard@cs-soprasteria.com>
-- **Emmanuel Dubois** [@duboise-cnes](https://github/duboise-cnes) <emmanuel.dubois@cnes.fr>
-- **Bob McNabb** [@iamdonovan](https://github/iamdonovan)
-- **Enrico Mattea** [@MatteaE](https://github.com/MatteaE)
-- **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
-- **Simon Gascoin** [@sgascoin](https://github.com/sgascoin)
-
----
-
-## Original developers
-
-- **Romain Hugonnet** [@rhugonnet](https://github.com/rhugonnet) <romain.hugonnet@gmail.com>
-- **Amaury Dehecq** [@adehecq](https://github/adehecq) <amaury.dehecq@univ-grenoble-alpes.fr>
-- **Erik Schytt Mannerfelt** [@erikmannerfelt](https://github/erikmannerfelt)
+Please refer to [AUTHORS file](../../AUTHORS.md) for the complete and detailed list of authors and their contributions.


### PR DESCRIPTION
Now that CNES and GlacioHack are working together to maintain xDEM, it is necessary to propose a governance model to ensure that the current collaboration continues smoothly, and if possible, to increase the number of contributors who would feel reassured with the establishment of a structured working framework.

To this end, we have added two files: one for governance and one for the code of conduct.

These files are inspired by the MVG (Minimum Viable Governance) project [https://github.com/github/mvg](https://github.com/github/mvg) and [https://www.contributor-covenant.org/](https://www.contributor-covenant.org/).

We can use this PR to discuss any changes that need to be made.