### PR TITLE
Add Option to Disable Vertical Shift in Nuth and Kääb Coregistration

### DIFF
--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -449,8 +449,8 @@ class TestAffineCoreg:
         ref, tba = load_examples(crop=False)[0:2]
 
         # Compare Nuth and Kaab method with and without applying vertical shift
-        coreg_method1 = NuthKaab(apply_vertical_shift=True)
-        coreg_method2 = NuthKaab(apply_vertical_shift=False)
+        coreg_method1 = NuthKaab(vertical_shift=True)
+        coreg_method2 = NuthKaab(vertical_shift=False)
 
         coreg_method1.fit(ref, tba, random_state=42)
         coreg_method2.fit(ref, tba, random_state=42)

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -17,7 +17,7 @@ from geoutils.raster.geotransformations import _translate
 from scipy.ndimage import binary_dilation
 
 from xdem import coreg, examples
-from xdem.coreg.affine import AffineCoreg, _reproject_horizontal_shift_samecrs
+from xdem.coreg.affine import AffineCoreg, NuthKaab, _reproject_horizontal_shift_samecrs
 
 
 def load_examples(crop: bool = True) -> tuple[RasterType, RasterType, Vector]:
@@ -444,3 +444,24 @@ class TestAffineCoreg:
         fit_shifts_rotations = tuple(np.concatenate((fit_shifts, fit_rotations)))
 
         assert fit_shifts_rotations == pytest.approx(expected_shifts_rots, abs=10e-6)
+
+    def test_nuthkaab_no_vertical_shift(self) -> None:
+        ref, tba = load_examples(crop=False)[0:2]
+
+        # Compare Nuth and Kaab method with and without applying vertical shift
+        coreg_method1 = NuthKaab(apply_vertical_shift=True)
+        coreg_method2 = NuthKaab(apply_vertical_shift=False)
+
+        coreg_method1.fit(ref, tba, random_state=42)
+        coreg_method2.fit(ref, tba, random_state=42)
+
+        # Recover the shifts computed by coregistration in matrix form
+        matrix1 = coreg_method1.to_matrix()
+        matrix2 = coreg_method2.to_matrix()
+
+        # Assert vertical shift is 0 for the 2nd coreg method
+        assert matrix2[2, 3] == 0
+
+        # Assert horizontal shifts are the same
+        matrix2[2, 3] = matrix1[2, 3]
+        assert np.array_equal(matrix1, matrix2)

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -1320,8 +1320,12 @@ class NuthKaab(AffineCoreg):
             bin_before_fit=bin_before_fit, fit_optimizer=fit_optimizer, bin_sizes=bin_sizes, bin_statistic=bin_statistic
         )
 
-        # Define iterative parameters
-        meta_input_iterative = {"max_iterations": max_iterations, "tolerance": offset_threshold}
+        # Define iterative parameters and vertical shift
+        meta_input_iterative = {
+            "max_iterations": max_iterations,
+            "tolerance": offset_threshold,
+            "apply_vshift": apply_vertical_shift,
+        }
 
         # Define parameters exactly as in BiasCorr, but with only "fit" or "bin_and_fit" as option, so a bin_before_fit
         # boolean, no bin apply option, and fit_func is predefined

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -116,6 +116,7 @@ dict_key_to_str = {
     "best_poly_order": "Best polynomial order",
     "best_nb_sin_freq": "Best number of sinusoid frequencies",
     "vshift_reduc_func": "Reduction function used to remove vertical shift",
+    "apply_vshift": "Vertical shift activated",
     "centroid": "Centroid found for affine rotation",
     "shift_x": "Eastward shift estimated (georeferenced unit)",
     "shift_y": "Northward shift estimated (georeferenced unit)",
@@ -1578,6 +1579,8 @@ class InAffineDict(TypedDict, total=False):
 
     # Vertical shift reduction function for methods focusing on translation coregistration
     vshift_reduc_func: Callable[[NDArrayf], np.floating[Any]]
+    # Vertical shift activated
+    apply_vshift: bool
 
 
 class OutAffineDict(TypedDict, total=False):


### PR DESCRIPTION
Resolves #686.

## Summary

This PR introduces a new feature to the Nuth and Kääb (2011) coregistration method, allowing users to optionally disable the vertical shift during the coregistration process. A new boolean parameter `apply_vertical_shift` has been added to control whether the vertical translation (shift in the z-axis) should be applied.


## Key Changes

- Added `apply_vertical_shift` to the constructor of the NuthKaab class, defaulting to True to maintain the current behavior (vertical shift enabled by default).
- Modified method `_nuth_kaab_iteration_step` to conditionally apply the vertical shift based on the value of `apply_vertical_shift`.
If the parameter is not provided, the default behavior (applying the vertical shift) remains unchanged, ensuring no impact on existing usage.

## Usage example
```python
coreg_method = xdem.coreg.NuthKaab(apply_vertical_shift=False)
coreg_method.fit(dem, dem_tba)
aligned_dem = coreg_method.apply(dem_tba)
```
in `coreg_method.info()`:
![image](https://github.com/user-attachments/assets/420419bb-af6a-47fe-8218-724c5e7ce479)
