### PR TITLE
Cluster Classes and Testing Implementation

### DIFF
--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,58 @@
+""" Functions to test the clusters."""
+
+import time
+
+import pytest
+
+from xdem.cluster import BasicCluster, ClusterGenerator, MpCluster
+
+
+# Sample function for testing
+def sample_function(x: float, y: float) -> float:
+    return x + y
+
+
+# Function to simulate a long-running task
+def long_running_task(x: float) -> float:
+    time.sleep(1)
+    return x * 2
+
+
+class TestClusterGenerator:
+    def test_basic_cluster(self) -> None:
+        # Test that tasks are run synchronously in BasicCluster
+        cluster = ClusterGenerator(name="basic")
+        assert isinstance(cluster, BasicCluster)
+
+        result = cluster.launch_task(sample_function, args=[2, 3])
+        assert result == 5
+
+    def test_mp_cluster_task(self) -> None:
+        # Test that tasks are launched asynchronously in MpCluster
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        future = cluster.launch_task(sample_function, args=[2, 3])
+        result = cluster.get_res(future)
+        assert result == 5
+
+    def test_mp_cluster_parallelism(self) -> None:
+        # Test that multiple tasks are run in parallel
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        futures = [cluster.launch_task(long_running_task, args=[i]) for i in range(4)]
+        results = [cluster.get_res(f) for f in futures]
+        assert results == [0, 2, 4, 6]
+
+    def test_mp_cluster_termination(self) -> None:
+        # Test that the pool terminates correctly after closing
+        cluster = ClusterGenerator("multiprocessing", nb_workers=2)
+        assert isinstance(cluster, MpCluster)
+
+        # Close the cluster
+        cluster.close()
+
+        # Expect an error when trying to launch a task after closing
+        with pytest.raises(ValueError):
+            cluster.launch_task(sample_function, args=[2, 3])

--- a/xdem/cluster.py
+++ b/xdem/cluster.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2024 xDEM developers
+#
+# This file is part of the xDEM project:
+# https://github.com/glaciohack/xdem
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module defines the cluster configurations."""
+
+import multiprocessing
+from multiprocessing.pool import Pool
+from typing import Any, Callable, Dict, List, Optional
+
+
+class ClusterGenerator:
+    def __new__(cls, name: str, nb_workers: int = 2) -> "AbstractCluster":  # type: ignore
+        if name == "basic":
+            cluster: AbstractCluster = BasicCluster()
+        else:
+            cluster = MpCluster(conf={"nb_workers": nb_workers})
+        return cluster
+
+
+class AbstractCluster:
+    def __init__(self) -> None:
+        self.pool: Optional[Pool] = None
+
+    def __enter__(self) -> "AbstractCluster":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        pass
+
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        pass
+
+    def get_res(self, future: Any) -> Any:
+        return future
+
+    def return_wrapper(self) -> None:
+        pass
+
+    def tile_retriever(self, res: Any) -> None:
+        pass
+
+
+class BasicCluster(AbstractCluster):
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+        return fun(*args, **kwargs)
+
+
+class MpCluster(AbstractCluster):
+    def __init__(self, conf: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__()
+        nb_workers = 1
+        if conf is not None:
+            nb_workers = conf.get("nb_workers", 1)
+        ctx_in_main = multiprocessing.get_context("forkserver")
+        self.pool = ctx_in_main.Pool(processes=nb_workers, maxtasksperchild=10)
+
+    def close(self) -> None:
+        if self.pool is not None:
+            self.pool.terminate()
+            self.pool.join()
+
+    def launch_task(
+        self, fun: Callable[..., Any], args: Optional[List[Any]] = None, kwargs: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        if args is None:
+            args = []
+        if kwargs is None:
+            kwargs = {}
+        if self.pool is not None:
+            return self.pool.apply_async(fun, args=args, kwds=kwargs)
+
+    def get_res(self, future: Any) -> Any:
+        return future.get(timeout=5000)


### PR DESCRIPTION
Resolves #681.

## Overview
This PR introduces a set of classes designed to handle the execution of tasks in either a basic or a multi-processing cluster. It also includes a series of tests that verify the correct behavior of the cluster functionalities.

## Key changes
- `ClusterGenerator`: A factory class that decides which type of cluster to create based on the given configuration (`basic` or `multiprocessing`). It can initialize a `BasicCluster` or `MpCluster` with a specified number of worker processes.
- `AbstractCluster`: The base class for both `BasicCluster` and `MpCluster`. It defines methods to launch tasks, retrieve results, and manage resources such as opening and closing the cluster.
- `BasicCluster`: A subclass of `AbstractCluster` where tasks are run synchronously (i.e., in a single process). The launch_task method simply executes the provided function immediately.
- `MpCluster`: A subclass of `AbstractCluster` that utilizes Python’s `multiprocessing` module for parallel task execution. The cluster pool is initialized with a defined number of worker processes, and tasks are executed asynchronously using `apply_async`. The results of tasks can be retrieved via the `get_res` method.

## Test Suite
`TestClusterGenerator`: A test suite implemented with `pytest` to validate the functionality of the cluster system.
- `test_basic_cluster`: Verifies that tasks are executed synchronously in the `BasicCluster`.
- `test_mp_cluster_task`: Confirms that tasks are launched asynchronously in the `MpCluster`.
- `test_mp_cluster_parallelism`: Tests that multiple tasks can be executed concurrently with multiple workers in `MpCluster`.
- `test_mp_cluster_termination`: Ensures that the cluster terminates correctly and no tasks can be launched after termination.