### PR TITLE
Add min, max, mean and median filters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -48,7 +48,7 @@ This file keeps track of authors contributions.
 - **Enrico Mattea** [@MatteaE](https://github.com/MatteaE)
 - **Amelie Froessl** [@ameliefroessl](https://github.com/ameliefroessl)
 - **Simon Gascoin** [@sgascoin](https://github.com/sgascoin)
-
+- **Clara Quinto** [@quinto-clara](https://github.com/quinto-clara) <clara.quinto@cs-soprasteria.com>
 
 ## Original Developers/Designers/Supporters
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -65,6 +65,131 @@ class TestFilters:
         pytest.raises(ValueError, xdem.filters.gaussian_filter_scipy, data, sigma=5)
         pytest.raises(ValueError, xdem.filters.gaussian_filter_cv, data, sigma=5)
 
+    def test_median_filter(self) -> None:
+        """Test applying median filter on DEMs with/without NaNs"""
+
+        # Test applying scipy's median filter
+        # smoothing should not yield values below.above original DEM
+        dem_array = self.dem_1990.data
+        dem_filtered = xdem.filters.median_filter_scipy(dem_array, kernel_size=5)
+        assert np.min(dem_array) < np.min(dem_filtered)
+        assert np.max(dem_array) > np.max(dem_filtered)
+        assert dem_array.shape == dem_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_with_nans_filtered = xdem.filters.median_filter_scipy(dem_with_nans, kernel_size=5)
+        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
+        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
+        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
+        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
+
+        # Test that it works with 3D arrays
+        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
+        dem_filtered = xdem.filters.median_filter_scipy(array_3d, kernel_size=5)
+        assert array_3d.shape == dem_filtered.shape
+
+        # Tests that it fails with 1D arrays with appropriate error
+        data = dem_array[:, 0]
+        pytest.raises(ValueError, xdem.filters.median_filter_scipy, data, kernel_size=5)
+
+    def test_mean_filter(self) -> None:
+        """Test applying mean filter on DEMs with/without NaNs"""
+
+        # Test applying mean filter
+        # smoothing should not yield values below.above original DEM
+        dem_array = self.dem_1990.data
+        dem_filtered = xdem.filters.mean_filter(dem_array, kernel_size=5)
+        assert np.min(dem_array) < np.min(dem_filtered)
+        assert np.max(dem_array) > np.max(dem_filtered)
+        assert dem_array.shape == dem_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_with_nans_filtered = xdem.filters.mean_filter(dem_with_nans, kernel_size=5)
+        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
+        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
+        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
+        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
+
+    def test_min_filter(self) -> None:
+        """Test applying minimum filter on DEMs with/without NaNs"""
+
+        # Test applying scipy's minimum filter
+        # smoothing should not yield values below.above original DEM
+        dem_array = self.dem_1990.data
+        dem_filtered = xdem.filters.min_filter_scipy(dem_array, kernel_size=5)
+        assert np.min(dem_array) == np.min(dem_filtered)
+        assert np.max(dem_array) >= np.max(dem_filtered)
+        assert dem_array.shape == dem_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_with_nans_filtered = xdem.filters.min_filter_scipy(dem_with_nans, kernel_size=5)
+        assert np.nanmin(dem_with_nans) == np.nanmin(dem_with_nans_filtered)
+        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
+        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
+
+        # Test that it works with 3D arrays
+        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
+        dem_filtered = xdem.filters.min_filter_scipy(array_3d, kernel_size=5)
+        assert array_3d.shape == dem_filtered.shape
+
+        # Tests that it fails with 1D arrays with appropriate error
+        data = dem_array[:, 0]
+        pytest.raises(ValueError, xdem.filters.min_filter_scipy, data, kernel_size=5)
+
+    def test_max_filter(self) -> None:
+        """Test applying maximum filter on DEMs with/without NaNs"""
+
+        # Test applying scipy's minimum filter
+        # smoothing should not yield values below.above original DEM
+        dem_array = self.dem_1990.data
+        dem_filtered = xdem.filters.max_filter_scipy(dem_array, kernel_size=5)
+        assert np.min(dem_array) <= np.min(dem_filtered)
+        assert np.max(dem_array) == np.max(dem_filtered)
+        assert dem_array.shape == dem_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_with_nans_filtered = xdem.filters.max_filter_scipy(dem_with_nans, kernel_size=5)
+        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
+        assert np.nanmax(dem_with_nans) == np.nanmax(dem_with_nans_filtered)
+        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
+
+        # Test that it works with 3D arrays
+        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
+        dem_filtered = xdem.filters.max_filter_scipy(array_3d, kernel_size=5)
+        assert array_3d.shape == dem_filtered.shape
+
+        # Tests that it fails with 1D arrays with appropriate error
+        data = dem_array[:, 0]
+        pytest.raises(ValueError, xdem.filters.max_filter_scipy, data, kernel_size=5)
+
     def test_dist_filter(self) -> None:
         """Test that distance_filter works"""
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import geoutils as gu
 import numpy as np
 import pytest
 
 import xdem
+from xdem._typing import NDArrayf
 
 
 class TestFilters:
@@ -65,131 +68,6 @@ class TestFilters:
         pytest.raises(ValueError, xdem.filters.gaussian_filter_scipy, data, sigma=5)
         pytest.raises(ValueError, xdem.filters.gaussian_filter_cv, data, sigma=5)
 
-    def test_median_filter(self) -> None:
-        """Test applying median filter on DEMs with/without NaNs"""
-
-        # Test applying scipy's median filter
-        # smoothing should not yield values below.above original DEM
-        dem_array = self.dem_1990.data
-        dem_filtered = xdem.filters.median_filter_scipy(dem_array, kernel_size=5)
-        assert np.min(dem_array) < np.min(dem_filtered)
-        assert np.max(dem_array) > np.max(dem_filtered)
-        assert dem_array.shape == dem_filtered.shape
-
-        # Test that it works with NaNs too
-        nan_count = 1000
-        rng = np.random.default_rng(42)
-        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
-        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
-        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
-        dem_with_nans[rows, cols] = np.nan
-
-        dem_with_nans_filtered = xdem.filters.median_filter_scipy(dem_with_nans, kernel_size=5)
-        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
-        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
-        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
-        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
-
-        # Test that it works with 3D arrays
-        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
-        dem_filtered = xdem.filters.median_filter_scipy(array_3d, kernel_size=5)
-        assert array_3d.shape == dem_filtered.shape
-
-        # Tests that it fails with 1D arrays with appropriate error
-        data = dem_array[:, 0]
-        pytest.raises(ValueError, xdem.filters.median_filter_scipy, data, kernel_size=5)
-
-    def test_mean_filter(self) -> None:
-        """Test applying mean filter on DEMs with/without NaNs"""
-
-        # Test applying mean filter
-        # smoothing should not yield values below.above original DEM
-        dem_array = self.dem_1990.data
-        dem_filtered = xdem.filters.mean_filter(dem_array, kernel_size=5)
-        assert np.min(dem_array) < np.min(dem_filtered)
-        assert np.max(dem_array) > np.max(dem_filtered)
-        assert dem_array.shape == dem_filtered.shape
-
-        # Test that it works with NaNs too
-        nan_count = 1000
-        rng = np.random.default_rng(42)
-        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
-        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
-        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
-        dem_with_nans[rows, cols] = np.nan
-
-        dem_with_nans_filtered = xdem.filters.mean_filter(dem_with_nans, kernel_size=5)
-        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
-        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
-        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
-        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
-
-    def test_min_filter(self) -> None:
-        """Test applying minimum filter on DEMs with/without NaNs"""
-
-        # Test applying scipy's minimum filter
-        # smoothing should not yield values below.above original DEM
-        dem_array = self.dem_1990.data
-        dem_filtered = xdem.filters.min_filter_scipy(dem_array, kernel_size=5)
-        assert np.min(dem_array) == np.min(dem_filtered)
-        assert np.max(dem_array) >= np.max(dem_filtered)
-        assert dem_array.shape == dem_filtered.shape
-
-        # Test that it works with NaNs too
-        nan_count = 1000
-        rng = np.random.default_rng(42)
-        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
-        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
-        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
-        dem_with_nans[rows, cols] = np.nan
-
-        dem_with_nans_filtered = xdem.filters.min_filter_scipy(dem_with_nans, kernel_size=5)
-        assert np.nanmin(dem_with_nans) == np.nanmin(dem_with_nans_filtered)
-        assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
-        assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
-
-        # Test that it works with 3D arrays
-        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
-        dem_filtered = xdem.filters.min_filter_scipy(array_3d, kernel_size=5)
-        assert array_3d.shape == dem_filtered.shape
-
-        # Tests that it fails with 1D arrays with appropriate error
-        data = dem_array[:, 0]
-        pytest.raises(ValueError, xdem.filters.min_filter_scipy, data, kernel_size=5)
-
-    def test_max_filter(self) -> None:
-        """Test applying maximum filter on DEMs with/without NaNs"""
-
-        # Test applying scipy's minimum filter
-        # smoothing should not yield values below.above original DEM
-        dem_array = self.dem_1990.data
-        dem_filtered = xdem.filters.max_filter_scipy(dem_array, kernel_size=5)
-        assert np.min(dem_array) <= np.min(dem_filtered)
-        assert np.max(dem_array) == np.max(dem_filtered)
-        assert dem_array.shape == dem_filtered.shape
-
-        # Test that it works with NaNs too
-        nan_count = 1000
-        rng = np.random.default_rng(42)
-        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
-        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
-        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
-        dem_with_nans[rows, cols] = np.nan
-
-        dem_with_nans_filtered = xdem.filters.max_filter_scipy(dem_with_nans, kernel_size=5)
-        assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
-        assert np.nanmax(dem_with_nans) == np.nanmax(dem_with_nans_filtered)
-        assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
-
-        # Test that it works with 3D arrays
-        array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
-        dem_filtered = xdem.filters.max_filter_scipy(array_3d, kernel_size=5)
-        assert array_3d.shape == dem_filtered.shape
-
-        # Tests that it fails with 1D arrays with appropriate error
-        data = dem_array[:, 0]
-        pytest.raises(ValueError, xdem.filters.max_filter_scipy, data, kernel_size=5)
-
     def test_dist_filter(self) -> None:
         """Test that distance_filter works"""
 
@@ -217,3 +95,71 @@ class TestFilters:
         ddem.data[rows[:500], cols[:500]] = np.nan
         filtered_ddem = xdem.filters.distance_filter(ddem.data, radius=20, outlier_threshold=50)
         assert np.all(np.isnan(filtered_ddem[rows, cols]))
+
+    @pytest.mark.parametrize(
+        "name, filter_func",
+        [
+            ("median", lambda arr: xdem.filters.median_filter_scipy(arr, **{"size": 5})),  # type:ignore
+            ("mean", lambda arr: xdem.filters.mean_filter(arr, kernel_size=5)),  # type:ignore
+            ("min", lambda arr: xdem.filters.min_filter_scipy(arr, **{"size": 5})),  # type:ignore
+            ("max", lambda arr: xdem.filters.max_filter_scipy(arr, **{"size": 5})),  # type:ignore
+        ],
+    )
+    def test_filters(self, name: str, filter_func: Callable[[NDArrayf], NDArrayf]) -> None:
+        """Test that all the filters applied on DEMs with/without NaNs, work"""
+        dem_array = self.dem_1990.data
+        dem_filtered = filter_func(dem_array)
+
+        if name in ("median", "mean"):
+            assert np.min(dem_array) < np.min(dem_filtered)
+            assert np.max(dem_array) > np.max(dem_filtered)
+        elif name == "min":
+            assert np.min(dem_array) == np.min(dem_filtered)
+            assert np.max(dem_array) >= np.max(dem_filtered)
+        elif name == "max":
+            assert np.min(dem_array) <= np.min(dem_filtered)
+            assert np.max(dem_array) == np.max(dem_filtered)
+
+        assert dem_array.shape == dem_filtered.shape
+
+        # Test that it works with NaNs too
+        nan_count = 1000
+        rng = np.random.default_rng(42)
+        cols = rng.integers(0, high=self.dem_1990.width - 1, size=nan_count, dtype=int)
+        rows = rng.integers(0, high=self.dem_1990.height - 1, size=nan_count, dtype=int)
+        dem_with_nans = np.copy(self.dem_1990.data).squeeze()
+        dem_with_nans[rows, cols] = np.nan
+
+        dem_with_nans_filtered = filter_func(dem_with_nans)
+        if name in ("median", "mean"):
+            # smoothing should not yield values below.above original DEM
+            assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
+            assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
+            assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
+            assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
+        elif name == "min":
+            assert np.nanmin(dem_with_nans) == np.nanmin(dem_with_nans_filtered)
+            assert np.min(dem_filtered) == np.nanmin(dem_with_nans_filtered)
+            assert np.nanmax(dem_with_nans) > np.nanmax(dem_with_nans_filtered)
+        elif name == "max":
+            assert np.nanmin(dem_with_nans) < np.nanmin(dem_with_nans_filtered)
+            assert np.nanmax(dem_with_nans) == np.nanmax(dem_with_nans_filtered)
+            assert np.max(dem_filtered) == np.nanmax(dem_with_nans_filtered)
+
+        # Test that it works with 3D arrays
+        if name != "mean":
+            array_3d = np.vstack((dem_array[np.newaxis, :], dem_array[np.newaxis, :]))
+            dem_filtered = filter_func(array_3d)
+            assert array_3d.shape == dem_filtered.shape
+
+            # Tests that it fails with 1D arrays with appropriate error
+            data = dem_array[:, 0]
+            pytest.raises(ValueError, filter_func, data)
+
+    def test_generic_filter(self) -> None:
+        """Test that the generic filter applied on DEMs works"""
+
+        dem_array = self.dem_1990.data
+        dem_filtered = xdem.filters.generic_filter(dem_array, np.nanmin, **{"size": 5})  # type:ignore
+
+        assert np.nansum(dem_array) != np.nansum(dem_filtered)

--- a/xdem/filters.py
+++ b/xdem/filters.py
@@ -131,13 +131,89 @@ def gaussian_filter_cv(array: NDArrayf, sigma: float) -> NDArrayf:
     return gauss.reshape(orig_shape)
 
 
-# Median filters
+def median_filter_scipy(array: NDArrayf, kernel_size: int) -> NDArrayf:
+    """
+    Apply a median filter to a raster that may contain NaNs, using scipy's implementation.
 
-# To be added
+    :param array: the input array to be filtered.
+    :param kernel_size: the size of the kernel
 
-# Min/max filters
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
 
-# To be added
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by infinite values during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, np.inf, array)
+    array_nans_replaced_f = scipy.ndimage.median_filter(array_nans_replaced, size=kernel_size)
+    # In the end we want the filtered array without infinite values, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
+
+
+def mean_filter(array: NDArrayf, kernel_size: int) -> NDArrayf:
+    """
+    Apply a mean filter to a raster that may contain NaNs.
+
+    :param array: the input array to be filtered.
+    :param kernel_size: the size of the kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2
+    if np.ndim(array) not in [2]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D array.")
+
+    kernel = np.ones((kernel_size, kernel_size)) / kernel_size**2
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by zeros during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, 0, array)
+    array_nans_replaced_f = scipy.ndimage.convolve(array_nans_replaced, kernel)
+    # In the end we want the filtered array without the introduced zeros, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
+
+
+def min_filter_scipy(array: NDArrayf, kernel_size: int) -> NDArrayf:
+    """
+    Apply a minimum filter to a raster that may contain NaNs, using scipy's implementation.
+
+    :param array: the input array to be filtered.
+    :param kernel_size: the size of the kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by infinite values during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, np.inf, array)
+    array_nans_replaced_f = scipy.ndimage.minimum_filter(array_nans_replaced, size=kernel_size)
+    # In the end we want the filtered array without infinite values, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
+
+
+def max_filter_scipy(array: NDArrayf, kernel_size: int) -> NDArrayf:
+    """
+    Apply a maximum filter to a raster that may contain NaNs, using scipy's implementation.
+
+    :param array: the input array to be filtered.
+    :param kernel_size: the size of the kernel
+
+    :returns: the filtered array (same shape as input)
+    """
+    # Check that array dimension is 2 or 3
+    if np.ndim(array) not in [2, 3]:
+        raise ValueError(f"Invalid array shape given: {array.shape}. Expected 2D or 3D array.")
+
+    nans = np.isnan(array)
+    # We replace temporarily NaNs by negative infinite values during filtering to avoid spreading NaNs
+    array_nans_replaced = np.where(nans, -np.inf, array)
+    array_nans_replaced_f = scipy.ndimage.maximum_filter(array_nans_replaced, size=kernel_size)
+    # In the end we want the filtered array without negative infinite values, so we put back NaNs
+    return np.where(nans, array, array_nans_replaced_f)
 
 
 def distance_filter(array: NDArrayf, radius: float, outlier_threshold: float) -> NDArrayf:


### PR DESCRIPTION
# Context

This PR adds to the available filters minimum, maximum, median and mean filters useful for the CNES QI team. 
Each filter's function has a 2D/3D input array (`array`) and the size of the kernel (`kernel_size`) as parameters. We get the filtered array in output, with the same shape as the input array. The filters are robust to NaN values.

These additions are temporary in xDEM and will be moved to GeoUtils in the future.


# Changes

- New functions added into `filters.py` :

    - `median_filter_scipy()` for scipy median filter
    - `median_filter()` for mean filter
    - `min_filter_scipy()` for scipy minimum filter
    - `max_filter_scipy()` for scipy maximum filter

- Tests added into `test_filters.py` :

    - `test_median_filter()`
    - `test_mean_filter()`
    - `test_min_filter()`
    - `test_max_filter()`



