### PR TITLE
Switch the `nmad` of xDEM to the `nmad` of GeoUtils

### DIFF
--- a/examples/advanced/plot_blockwise_coreg.py
+++ b/examples/advanced/plot_blockwise_coreg.py
@@ -98,5 +98,5 @@ plt.show()
 # We can compare the NMAD to validate numerically that there was an improvement:
 
 
-print(f"Error before: {xdem.spatialstats.nmad(diff_before[inlier_mask]):.2f} m")
-print(f"Error after: {xdem.spatialstats.nmad(diff_after[inlier_mask]):.2f} m")
+print(f"Error before: {gu.stats.nmad(diff_before[inlier_mask]):.2f} m")
+print(f"Error after: {gu.stats.nmad(diff_after[inlier_mask]):.2f} m")

--- a/examples/advanced/plot_deramp.py
+++ b/examples/advanced/plot_deramp.py
@@ -46,10 +46,10 @@ diff_after.plot(cmap="RdYlBu", vmin=-10, vmax=10, cbar_title="Elevation differen
 # %%
 # We compare the median and NMAD to validate numerically that there was an improvement (see :ref:`robuststats-meanstd`):
 inliers_before = diff_before[inlier_mask]
-med_before, nmad_before = np.ma.median(inliers_before), xdem.spatialstats.nmad(inliers_before)
+med_before, nmad_before = np.ma.median(inliers_before), gu.stats.nmad(inliers_before)
 
 inliers_after = diff_after[inlier_mask]
-med_after, nmad_after = np.ma.median(inliers_after), xdem.spatialstats.nmad(inliers_after)
+med_after, nmad_after = np.ma.median(inliers_after), gu.stats.nmad(inliers_after)
 
 print(f"Error before: median = {med_before:.2f} - NMAD = {nmad_before:.2f} m")
 print(f"Error after: median = {med_after:.2f} - NMAD = {nmad_after:.2f} m")

--- a/examples/advanced/plot_heterosc_estimation_modelling.py
+++ b/examples/advanced/plot_heterosc_estimation_modelling.py
@@ -59,7 +59,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[slope_arr, aspect_arr, planc_arr, profc_arr],
     list_var_names=["slope", "aspect", "planc", "profc"],
-    statistics=["count", xdem.spatialstats.nmad],
+    statistics=["count", gu.stats.nmad],
     list_var_bins=30,
 )
 
@@ -109,7 +109,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[profc_arr],
     list_var_names=["profc"],
-    statistics=["count", np.nanmedian, xdem.spatialstats.nmad],
+    statistics=["count", np.nanmedian, gu.stats.nmad],
     list_var_bins=[np.nanquantile(profc_arr, np.linspace(0, 1, 1000))],
 )
 xdem.spatialstats.plot_1d_binning(df, "profc", "nmad", "Profile curvature (100 m$^{-1}$)", "NMAD of dh (m)")
@@ -124,7 +124,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[planc_arr],
     list_var_names=["planc"],
-    statistics=["count", np.nanmedian, xdem.spatialstats.nmad],
+    statistics=["count", np.nanmedian, gu.stats.nmad],
     list_var_bins=[np.nanquantile(planc_arr, np.linspace(0, 1, 1000))],
 )
 xdem.spatialstats.plot_1d_binning(df, "planc", "nmad", "Planform curvature (100 m$^{-1}$)", "NMAD of dh (m)")
@@ -138,7 +138,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[maxc_arr],
     list_var_names=["maxc"],
-    statistics=["count", np.nanmedian, xdem.spatialstats.nmad],
+    statistics=["count", np.nanmedian, gu.stats.nmad],
     list_var_bins=[np.nanquantile(maxc_arr, np.linspace(0, 1, 1000))],
 )
 xdem.spatialstats.plot_1d_binning(df, "maxc", "nmad", "Maximum absolute curvature (100 m$^{-1}$)", "NMAD of dh (m)")
@@ -156,7 +156,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[slope_arr, maxc_arr],
     list_var_names=["slope", "maxc"],
-    statistics=["count", np.nanmedian, xdem.spatialstats.nmad],
+    statistics=["count", np.nanmedian, gu.stats.nmad],
     list_var_bins=30,
 )
 
@@ -200,7 +200,7 @@ df = xdem.spatialstats.nd_binning(
     values=dh_arr,
     list_var=[slope_arr, maxc_arr],
     list_var_names=["slope", "maxc"],
-    statistics=["count", np.nanmedian, xdem.spatialstats.nmad],
+    statistics=["count", np.nanmedian, gu.stats.nmad],
     list_var_bins=[custom_bin_slope, custom_bin_curvature],
 )
 xdem.spatialstats.plot_2d_binning(
@@ -244,9 +244,7 @@ dh_err_stable = unscaled_dh_err_fun((slope_arr, maxc_arr))
 
 print(
     "The spread of elevation difference is {:.2f} "
-    "compared to a mean predicted elevation error of {:.2f}.".format(
-        xdem.spatialstats.nmad(dh_arr), np.nanmean(dh_err_stable)
-    )
+    "compared to a mean predicted elevation error of {:.2f}.".format(gu.stats.nmad(dh_arr), np.nanmean(dh_err_stable))
 )
 
 # %%

--- a/examples/advanced/plot_norm_regional_hypso.py
+++ b/examples/advanced/plot_norm_regional_hypso.py
@@ -107,7 +107,7 @@ plt.show()
 
 difference = (ddem_filled - ddem)[random_nans]
 median = np.ma.median(difference)
-nmad = xdem.spatialstats.nmad(difference)
+nmad = gu.stats.nmad(difference)
 
 plt.title(f"Median: {median:.2f} m, NMAD: {nmad:.2f} m")
 plt.hist(difference.data, bins=np.linspace(-15, 15, 100))

--- a/examples/advanced/plot_standardization.py
+++ b/examples/advanced/plot_standardization.py
@@ -19,9 +19,9 @@ import geoutils as gu
 # sphinx_gallery_thumbnail_number = 4
 import matplotlib.pyplot as plt
 import numpy as np
+from geoutils.stats import nmad
 
 import xdem
-from xdem.spatialstats import nmad
 
 # %%
 # We start by estimating the elevation heteroscedasticity and deriving a terrain-dependent measurement error as a function of both

--- a/examples/advanced/plot_variogram_estimation_modelling.py
+++ b/examples/advanced/plot_variogram_estimation_modelling.py
@@ -26,9 +26,9 @@ import geoutils as gu
 # sphinx_gallery_thumbnail_number = 6
 import matplotlib.pyplot as plt
 import numpy as np
+from geoutils.stats import nmad
 
 import xdem
-from xdem.spatialstats import nmad
 
 # %%
 # We load example files.

--- a/examples/basic/plot_nuth_kaab.py
+++ b/examples/basic/plot_nuth_kaab.py
@@ -53,10 +53,10 @@ diff_after.plot(cmap="RdYlBu", vmin=-10, vmax=10, cbar_title="Elevation change (
 # %%
 # We compare the median and NMAD to validate numerically that there was an improvement (see :ref:`robuststats-meanstd`):
 inliers_before = diff_before[inlier_mask]
-med_before, nmad_before = np.ma.median(inliers_before), xdem.spatialstats.nmad(inliers_before)
+med_before, nmad_before = np.ma.median(inliers_before), gu.stats.nmad(inliers_before)
 
 inliers_after = diff_after[inlier_mask]
-med_after, nmad_after = np.ma.median(inliers_after), xdem.spatialstats.nmad(inliers_after)
+med_after, nmad_after = np.ma.median(inliers_after), gu.stats.nmad(inliers_after)
 
 print(f"Error before: median = {med_before:.2f} - NMAD = {nmad_before:.2f} m")
 print(f"Error after: median = {med_after:.2f} - NMAD = {nmad_after:.2f} m")

--- a/tests/test_coreg/test_blockwise.py
+++ b/tests/test_coreg/test_blockwise.py
@@ -8,9 +8,10 @@ import pytest
 import rasterio as rio
 from geoutils import Raster, Vector
 from geoutils.raster import RasterType
+from geoutils.stats import nmad
 
 import xdem
-from xdem import coreg, examples, misc, spatialstats
+from xdem import coreg, examples, misc
 from xdem.coreg import BlockwiseCoreg
 from xdem.coreg.base import Coreg
 
@@ -257,7 +258,7 @@ def test_warp_dem() -> None:
     )
     # Validate that the DEM is now more or less the same as the original.
     # Due to the randomness, the threshold is quite high, but would be something like 10+ if it was incorrect.
-    assert spatialstats.nmad(dem - untransformed_dem) < 0.5
+    assert nmad(dem - untransformed_dem) < 0.5
 
     # Test with Z-correction disabled
     transformed_dem_no_z = coreg.blockwise.warp_dem(
@@ -281,7 +282,7 @@ def test_warp_dem() -> None:
 
     # Validate that the DEM is now more or less the same as the original, with Z-correction disabled.
     # The result should be similar to the original, but with no Z-shift applied.
-    assert spatialstats.nmad(dem - untransformed_dem_no_z) < 0.5
+    assert nmad(dem - untransformed_dem_no_z) < 0.5
 
     # The difference between the two DEMs should be the vertical shift.
     # We expect the difference to be approximately equal to the average vertical shift.

--- a/tests/test_coreg/test_workflows.py
+++ b/tests/test_coreg/test_workflows.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 from geoutils import Raster, Vector
 from geoutils.raster import RasterType
+from geoutils.stats import nmad
 
 import xdem
 from xdem import examples
@@ -95,9 +96,7 @@ class TestWorkflows:
         # Test the nmad_factor filter only
         nmad_factor = 3
         ddem = tba - ref
-        inlier_mask_comp3 = (np.abs(ddem.data - np.median(ddem)) < nmad_factor * xdem.spatialstats.nmad(ddem)).filled(
-            False
-        )
+        inlier_mask_comp3 = (np.abs(ddem.data - np.median(ddem)) < nmad_factor * nmad(ddem)).filled(False)
         inlier_mask = create_inlier_mask(tba, ref, filtering=True, slope_lim=[0, 90], nmad_factor=nmad_factor)
         assert np.all(inlier_mask == inlier_mask_comp3)
 

--- a/tests/test_coreg/test_workflows.py
+++ b/tests/test_coreg/test_workflows.py
@@ -96,7 +96,7 @@ class TestWorkflows:
         # Test the nmad_factor filter only
         nmad_factor = 3
         ddem = tba - ref
-        inlier_mask_comp3 = (np.abs(ddem.data - np.median(ddem)) < nmad_factor * nmad(ddem)).filled(False)
+        inlier_mask_comp3 = (np.abs(ddem.data - np.median(ddem)) < nmad_factor * nmad(ddem.data)).filled(False)
         inlier_mask = create_inlier_mask(tba, ref, filtering=True, slope_lim=[0, 90], nmad_factor=nmad_factor)
         assert np.all(inlier_mask == inlier_mask_comp3)
 

--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -16,7 +16,7 @@ from geoutils import Raster, Vector
 import xdem
 from xdem import examples
 from xdem._typing import NDArrayf
-from xdem.spatialstats import EmpiricalVariogramKArgs, neff_hugonnet_approx, nmad
+from xdem.spatialstats import EmpiricalVariogramKArgs, neff_hugonnet_approx
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -35,28 +35,6 @@ def load_ref_and_diff() -> tuple[Raster, Raster, NDArrayf, Vector]:
     mask = outlines.create_mask(ddem)
 
     return reference_raster, ddem, mask, outlines
-
-
-class TestStats:
-
-    # Load data for the entire test class
-    ref, diff, mask, outlines = load_ref_and_diff()
-
-    def test_nmad(self) -> None:
-        """Test NMAD functionality runs on any type of input"""
-
-        # Check that the NMAD is computed the same with a raster, masked array or NaN array
-        nmad_raster = nmad(self.diff)
-        nmad_ma = nmad(self.diff.data)
-        nmad_array = nmad(self.diff.get_nanarray())
-
-        assert nmad_raster == nmad_ma == nmad_array
-
-        # Check that the scaling factor works
-        nmad_1 = nmad(self.diff, nfact=1)
-        nmad_2 = nmad(self.diff, nfact=2)
-
-        assert nmad_1 * 2 == nmad_2
 
 
 class TestBinning:
@@ -404,14 +382,14 @@ class TestBinning:
             values=self.diff[~self.mask],
             list_var=[self.slope[~self.mask], self.maximum_curv[~self.mask]],
             list_var_names=["var1", "var2"],
-            statistics=[xdem.spatialstats.nmad],
+            statistics=[gu.stats.nmad],
         )
         unscaled_fun = xdem.spatialstats.interp_nd_binning(
             df_binning, list_var_names=["var1", "var2"], statistic="nmad"
         )
         # The zscore spread should not be one right after binning
         zscores = self.diff[~self.mask] / unscaled_fun((self.slope[~self.mask], self.maximum_curv[~self.mask]))
-        scale_fac = xdem.spatialstats.nmad(zscores)
+        scale_fac = gu.stats.nmad(zscores)
         assert scale_fac != 1
 
         # Filter with a factor of 3 and the standard deviation (not default values) and check the function outputs

--- a/xdem/coreg/affine.py
+++ b/xdem/coreg/affine.py
@@ -38,6 +38,7 @@ import rasterio as rio
 import scipy.optimize
 from geoutils.interface.interpolate import _interp_points
 from geoutils.raster.georeferencing import _bounds, _coords, _res
+from geoutils.stats import nmad
 from tqdm import trange
 
 from xdem._typing import NDArrayb, NDArrayf
@@ -52,7 +53,6 @@ from xdem.coreg.base import (
     _preprocess_pts_rst_subsample,
     _reproject_horizontal_shift_samecrs,
 )
-from xdem.spatialstats import nmad
 
 try:
     import pytransform3d.rotations

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -55,6 +55,7 @@ from geoutils.raster._geotransformations import _resampling_method_from_str
 from geoutils.raster.array import get_array_and_mask
 from geoutils.raster.georeferencing import _cast_pixel_interpretation, _coords
 from geoutils.raster.geotransformations import _translate
+from geoutils.stats import nmad
 
 from xdem._typing import MArrayf, NDArrayb, NDArrayf
 from xdem.fit import (
@@ -63,7 +64,7 @@ from xdem.fit import (
     robust_norder_polynomial_fit,
     sumsin_1d,
 )
-from xdem.spatialstats import nd_binning, nmad
+from xdem.spatialstats import nd_binning
 
 try:
     import pytransform3d.rotations

--- a/xdem/coreg/workflows.py
+++ b/xdem/coreg/workflows.py
@@ -29,13 +29,13 @@ import pandas as pd
 import rasterio as rio
 from geoutils._typing import Number
 from geoutils.raster import RasterType
+from geoutils.stats import nmad
 
 from xdem._typing import NDArrayf
 from xdem.coreg import AffineCoreg, CoregPipeline
 from xdem.coreg.affine import NuthKaab, VerticalShift
 from xdem.coreg.base import Coreg
 from xdem.dem import DEM
-from xdem.spatialstats import nmad
 from xdem.terrain import slope
 
 

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -29,8 +29,8 @@ import rasterio as rio
 from affine import Affine
 from geoutils import Raster
 from geoutils.raster import Mask, RasterType
+from geoutils.raster.distributed_computing import MultiprocConfig
 from geoutils.stats import nmad
-from geoutils.raster.distributed_computing.multiproc import MultiprocConfig
 from pyproj import CRS
 from pyproj.crs import CompoundCRS, VerticalCRS
 from skgstat import Variogram

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -29,6 +29,7 @@ import rasterio as rio
 from affine import Affine
 from geoutils import Raster
 from geoutils.raster import Mask, RasterType
+from geoutils.stats import nmad
 from geoutils.raster.distributed_computing.multiproc import MultiprocConfig
 from pyproj import CRS
 from pyproj.crs import CompoundCRS, VerticalCRS
@@ -40,7 +41,6 @@ from xdem.misc import copy_doc
 from xdem.spatialstats import (
     infer_heteroscedasticity_from_stable,
     infer_spatial_correlation_from_stable,
-    nmad,
 )
 from xdem.vcrs import (
     _build_ccrs_from_crs_and_vcrs,

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -28,6 +28,7 @@ import warnings
 from typing import Any, Callable, Iterable, Literal, TypedDict, overload
 
 import geopandas as gpd
+import geoutils as gu
 import matplotlib
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
@@ -36,9 +37,9 @@ import numpy as np
 import pandas as pd
 from geoutils.raster import Mask, Raster, RasterType, subsample_array
 from geoutils.raster.array import get_array_and_mask
-from geoutils.stats import nmad
 from geoutils.vector.vector import Vector, VectorType
 from numpy.typing import ArrayLike
+from packaging.version import Version
 from scipy import integrate
 from scipy.interpolate import RegularGridInterpolator, griddata
 from scipy.optimize import curve_fit
@@ -48,10 +49,29 @@ from scipy.stats import binned_statistic, binned_statistic_2d, binned_statistic_
 from skimage.draw import disk
 
 from xdem._typing import NDArrayf
+from xdem.misc import deprecate
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import skgstat as skg
+
+
+@deprecate(
+    removal_version=Version("0.4"), details="xdem.spatialstats.nmad is being deprecated in favor of geoutils.stats.nmad"
+)
+def nmad(data: NDArrayf, nfact: float = 1.4826) -> np.floating[Any]:
+    """
+    Calculate the normalized median absolute deviation (NMAD) of an array.
+    Default scaling factor is 1.4826 to scale the median absolute deviation (MAD) to the dispersion of a normal
+    distribution (see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation, and
+    e.g. Höhle and Höhle (2009), http://dx.doi.org/10.1016/j.isprsjprs.2009.02.003)
+
+    :param data: Input array or raster
+    :param nfact: Normalization factor for the data
+
+    :returns nmad: (normalized) median absolute deviation of data.
+    """
+    return gu.stats.nmad(data, nfact)
 
 
 def nd_binning(

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -36,6 +36,7 @@ import numpy as np
 import pandas as pd
 from geoutils.raster import Mask, Raster, RasterType, subsample_array
 from geoutils.raster.array import get_array_and_mask
+from geoutils.stats import nmad
 from geoutils.vector.vector import Vector, VectorType
 from numpy.typing import ArrayLike
 from scipy import integrate
@@ -51,27 +52,6 @@ from xdem._typing import NDArrayf
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import skgstat as skg
-
-
-def nmad(data: NDArrayf | RasterType, nfact: float = 1.4826) -> np.floating[Any]:
-    """
-    Calculate the normalized median absolute deviation (NMAD) of an array.
-    Default scaling factor is 1.4826 to scale the median absolute deviation (MAD) to the dispersion of a normal
-    distribution (see https://en.wikipedia.org/wiki/Median_absolute_deviation#Relation_to_standard_deviation, and
-    e.g. Höhle and Höhle (2009), http://dx.doi.org/10.1016/j.isprsjprs.2009.02.003)
-
-    :param data: Input array or raster
-    :param nfact: Normalization factor for the data
-
-    :returns nmad: (normalized) median absolute deviation of data.
-    """
-    if isinstance(data, np.ma.masked_array):
-        data_arr = get_array_and_mask(data, check_shape=False)[0]
-    elif isinstance(data, Raster):
-        data_arr = data
-    else:
-        data_arr = np.asarray(data)
-    return nfact * np.nanmedian(np.abs(data_arr - np.nanmedian(data_arr)))
 
 
 def nd_binning(

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -26,7 +26,7 @@ import geoutils as gu
 import numba
 import numpy as np
 from geoutils.raster import Raster, RasterType
-from geoutils.raster.distributed_computing.multiproc import (
+from geoutils.raster.distributed_computing import (
     MultiprocConfig,
     map_overlap_multiproc_save,
 )


### PR DESCRIPTION
Resolves #715.

- Deletes `spatialstats.nmad`.
- Switches `xdem.spatialstats.nmad` to `geoutils.stats.nmad`.

## Note
- Needs GlacioHack/geoutils#678