### PR TITLE
Use sklearn instead of pyransac3d

### DIFF
--- a/.github/workflows/pip-checks.yml
+++ b/.github/workflows/pip-checks.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install project
         run: |
           python -m pip install . -vv
-          pip install pyransac3d
 
       # Check import works
       - name: Check import works with base environment

--- a/NOTICE
+++ b/NOTICE
@@ -125,7 +125,3 @@ noisyopt: Library for optimizing noisy functions in Python.
 Copyright (c) 2016-2017 Andreas Mayer.
 Website: https://pypi.org/project/noisyopt/
 License: MIT.
-
-pyransac3d: Implementation of Random sample consensus (RANSAC) method
-Website: https://pypi.org/project/pyransac3d/
-License: Apache License 2.0

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -53,7 +53,6 @@ dependencies:
     - noisyopt
     # "Headless" needed for opencv to install without requiring system dependencies
     - opencv-contrib-python-headless
-    - pyransac3d
 
     # To run CI against latest GeoUtils
 #    - git+https://github.com/rhugonnet/geoutils.git

--- a/environment.yml
+++ b/environment.yml
@@ -19,8 +19,6 @@ dependencies:
   - pyogrio
   - shapely
   - pip
-  - pip:
-    - pyransac3d
 
   # To run CI against latest GeoUtils
 #  - pip:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,3 @@ pandas
 pyogrio
 shapely
 pip
-pyransac3d

--- a/tests/test_coreg/test_blockwise.py
+++ b/tests/test_coreg/test_blockwise.py
@@ -101,8 +101,10 @@ class TestBlockwiseCoreg:
         y = np.array([1, 2, 3, 4, 5])
         z = np.array([2, 4, 6, 8, 10])
 
-        with pytest.raises(ValueError):
-            blockwise_coreg._ransac(x, y, z)
+        min_inliers = 10
+
+        with pytest.raises(ValueError, match="Not enough valid points in RANSAC: got 5, need at least 10"):
+            blockwise_coreg._ransac(x, y, z, min_inliers=min_inliers)
 
     def test_wrapper_apply_epc(self, blockwise_coreg, example_data) -> None:
         """Test point cloud coefficient application via _wrapper_apply_epc."""
@@ -150,4 +152,4 @@ class TestBlockwiseCoreg:
         expected = nuth_kaab.fit_and_apply(ref, tba, mask)
 
         valid = (expected.data.data != expected.nodata) & (aligned.data.data != aligned.nodata)
-        assert np.allclose(expected.data.data[valid], aligned.data.data[valid], atol=50)
+        assert np.allclose(expected.data.data[valid], aligned.data.data[valid], atol=20)

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -40,7 +40,11 @@ from geoutils.raster.distributed_computing import (
     map_overlap_multiproc_save,
 )
 from geoutils.raster.tiling import compute_tiling
-from sklearn.linear_model import LinearRegression, RANSACRegressor
+
+try:
+    from sklearn.linear_model import LinearRegression, RANSACRegressor
+except ImportError:
+    raise ValueError("Optional dependency needed. Install 'scikit-learn'.")
 
 from xdem._typing import MArrayf, NDArrayb, NDArrayf
 from xdem.coreg.affine import NuthKaab

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -43,8 +43,10 @@ from geoutils.raster.tiling import compute_tiling
 
 try:
     from sklearn.linear_model import LinearRegression, RANSACRegressor
+
+    _has_sklearn = True
 except ImportError:
-    raise ValueError("Optional dependency needed. Install 'scikit-learn'.")
+    _has_sklearn = False
 
 from xdem._typing import MArrayf, NDArrayb, NDArrayf
 from xdem.coreg.affine import NuthKaab
@@ -227,6 +229,8 @@ class BlockwiseCoreg:
         :param max_iterations: Maximum number of iterations to run the RANSAC algorithm.
         :return: Estimated transformation coefficients (a, b, c) such as shift = a * x + b * y + c.
         """
+        if not _has_sklearn:
+            raise ValueError("Optional dependency needed. Install 'scikit-learn'.")
 
         # Assemble input data
         points = np.squeeze(np.dstack([x_coords, y_coords, shifts]))


### PR DESCRIPTION
# Context

This PR includes the change from pyransac3d to the sklearn.linear\_model module.

# Dependencies

We have removed all calls to and references to pyransac3d.

# Code

We have refactored the ransac function, which now appears less non-deterministic than before.

# Tests

We have updated the unit tests.