### PR TITLE
Fix `DEM` casting to `Mask` by removing `from_array` overloading

### DIFF
--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -158,6 +158,15 @@ class TestDEM:
         )
         assert dem.vcrs == CRS("EPSG:5773")
 
+    def test_from_array__cast_mask(self) -> None:
+        """Test that DEMs are cast into mask for a logical operation."""
+
+        transform = rio.transform.from_bounds(0, 0, 1, 1, 5, 5)
+        dem = DEM.from_array(data=np.ones((5, 5)), transform=transform, crs=CRS("EPSG:4326"), nodata=None)
+
+        mask_dem = dem > 1
+        assert isinstance(mask_dem, gu.Mask)
+
     def test_copy(self) -> None:
         """
         Test that the copy method works as expected for DEM. In particular

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -196,7 +196,7 @@ class DEM(Raster):  # type: ignore
         vcrs: (
             Literal["Ellipsoid"] | Literal["EGM08"] | Literal["EGM96"] | str | pathlib.Path | VerticalCRS | int | None
         ) = None,
-    ) -> DEM:
+    ) -> DEM | Mask:
         """Create a DEM from a numpy array and the georeferencing information.
 
         :param data: Input array.
@@ -210,7 +210,6 @@ class DEM(Raster):  # type: ignore
             compatible. If False, will raise an error when incompatible.
         :param vcrs: Vertical coordinate reference system.
 
-
         :returns: DEM created from the provided array and georeferencing.
         """
         # We first apply the from_array of the parent class
@@ -223,8 +222,13 @@ class DEM(Raster):  # type: ignore
             tags=tags,
             cast_nodata=cast_nodata,
         )
-        # Then add the vcrs to the class call (that builds on top of the parent class)
-        return cls(filename_or_dataset=rast, vcrs=vcrs)
+
+        # This is for casting to Mask to work
+        if not isinstance(rast, Mask):
+            # Then add the vcrs to the class call (that builds on top of the parent class)
+            return cls(filename_or_dataset=rast, vcrs=vcrs)
+        else:
+            return rast
 
     @property
     def vcrs(self) -> VerticalCRS | Literal["Ellipsoid"] | None:


### PR DESCRIPTION
Replaces #740 

This is an easier fix than #740: Simply an `if` statement depending on the output of `Raster.from_array`. 

Another way to do this for a future re-work (if we want users to more easily subclass `Raster`, for example) would be to separate `Raster.from_array()` into a non-public function that does the casting under-the-hood for all arithmetic ops (`Raster._from_array()`, which wouldn't be overloaded by `DEM.from_array()`) and a public function that works only for building a Raster as intended (refuses a `boolean` input).
Actually, we might have to already do this for the Xarray accessors, for consistency in the behaviour.

Resolves #739 