### PR TITLE
Make blockwise robust to block errors

### DIFF
--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -144,7 +144,14 @@ class BlockwiseCoreg:
         else:
             if inlier_mask:
                 inlier_mask = inlier_mask.crop(ref_dem_tiled)
-            return coreg_method.fit(ref_dem_tiled, tba_dem_tiled, inlier_mask)
+            try:
+                return coreg_method.fit(ref_dem_tiled, tba_dem_tiled, inlier_mask)
+            except (ValueError, TypeError) as e:
+                logging.error(f"Failed to fit coregistration. Reason: {e}")
+                coreg_method.meta["outputs"] = {"affine": {"shift_x": np.nan}}
+                coreg_method.meta["outputs"] = {"affine": {"shift_y": np.nan}}
+                coreg_method.meta["outputs"] = {"affine": {"shift_z": np.nan}}
+                return coreg_method
 
     def fit(
         self: BlockwiseCoreg,


### PR DESCRIPTION
This PR allows the blockwise process to continue even if on tile doesn't converge in fit. 
