### PR TITLE
Add texture shading to available DEM terrain attributes 

### DIFF
--- a/doc/source/terrain.md
+++ b/doc/source/terrain.md
@@ -106,6 +106,9 @@ compilation is cached and can later be re-used in the same Python environment.
    * - {ref}`fractrough`
      - Fractal dimension number (1 to 3)
      - [Taud and Parrot (2005)](https://doi.org/10.4000/geomorphologie.622)
+   * - {ref}`texture-shading`
+     - Unitless
+     - [Brown (2010)](https://mountaincartography.icaci.org/activities/workshops/banff_canada/papers/brown.pdf)
 ```
 
 ```{note}
@@ -406,6 +409,32 @@ DEM pixels. Its unit is that of a dimension, and is always between 1 (dimension 
 ```{code-cell} ipython3
 fractal_roughness = dem.fractal_roughness()
 fractal_roughness.plot(cmap="Reds", cbar_title="Fractal roughness (dimensions)")
+```
+
+(texture-shading)=
+## Texture shading
+
+{func}`xdem.DEM.texture_shading`
+
+The texture shading technique produces an isotropic relief visualization that emphasizes the drainage network structure of terrain, including ridges and canyons. Unlike traditional hillshading, texture shading exhibits scale invariance and orientation independence, making it particularly effective for revealing the hierarchical structure of mountainous topography without directional bias.
+
+Texture shading is computed by applying a fractional Laplacian operator to the elevation data, which acts as a scale-independent high-pass filter. The technique produces relative elevation values where positive values correspond to ridges and peaks (higher than surrounding terrain) and negative values correspond to valleys and canyons (lower than surrounding terrain). The method includes a detail parameter α (typically 0.5-1.0) that controls the emphasis given to fine terrain features versus major landscape structure.
+
+The fractional Laplacian operator L^α is based on [Brown (2010)](https://mountaincartography.icaci.org/activities/workshops/banff_canada/papers/brown.pdf) and computed in the frequency domain as:
+
+L^α(f_x, f_y) = (2π)^α (f_x² + f_y²)^(α/2)
+
+where f_x and f_y are spatial frequencies, and α is the fractional order parameter.
+
+Unlike hillshading, texture shading maintains visual hierarchy across different scales - smaller terrain features automatically have lower contrast relative to larger features, creating a "self-generalizing" effect. This makes texture shading particularly valuable for displaying terrain at multiple zoom levels or for combining with traditional hillshading to enhance the visibility of drainage networks.
+
+Unlike curvature, which highlights local convexity and concavity based on the second derivative of elevation, texture shading emphasizes the multi-scale drainage network structure through a fractional Laplacian that preserves relationships across different spatial frequencies. While curvature is optimal for identifying specific geomorphological features like ridges and valley bottoms at a single scale, texture shading provides a scale-invariant visualization that simultaneously reveals both fine-scale terrain details and broad landscape patterns.
+
+For more information on texture shading, see the [official texture shading website](https://www.textureshading.com/Home.html) and the [Python implementation reference](https://github.com/fasiha/texshade-py).
+
+```{code-cell} ipython3
+texture_shading = dem.texture_shading(alpha=0.8)
+texture_shading.plot(cmap="Greys_r", cbar_title="Texture shading")
 ```
 
 ## Generating attributes in multiprocessing

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -483,6 +483,23 @@ class DEM(Raster):  # type: ignore
     def fractal_roughness(self, window_size: int = 13, mp_config: MultiprocConfig | None = None) -> RasterType:
 
         return terrain.fractal_roughness(self, window_size=window_size, mp_config=mp_config)
+    
+    @copy_doc(terrain, remove_dem_res_params=True)
+    def texture_shading(
+        self,
+        alpha: float = 0.8,
+        method: str = "fft",
+        window_size: int | None = None,
+        mp_config: MultiprocConfig | None = None,
+    ) -> RasterType:
+
+        return terrain.texture_shading(
+            self,
+            alpha=alpha,
+            method=method,
+            window_size=window_size,
+            mp_config=mp_config,
+        )
 
     @copy_doc(terrain, remove_dem_res_params=True)
     def get_terrain_attribute(self, attribute: str | list[str], **kwargs: Any) -> RasterType | list[RasterType]:

--- a/xdem/terrain.py
+++ b/xdem/terrain.py
@@ -25,6 +25,7 @@ from typing import Any, Literal, Sized, overload
 import geoutils as gu
 import numba
 import numpy as np
+import scipy.fft as fft
 from geoutils.raster import Raster, RasterType
 from geoutils.raster.distributed_computing import (
     MultiprocConfig,
@@ -48,6 +49,7 @@ available_attributes = [
     "roughness",
     "rugosity",
     "fractal_roughness",
+    "texture_shading",
 ]
 
 ##############################################################################
@@ -1243,6 +1245,9 @@ def get_terrain_attribute(
     * 'roughness': The roughness, i.e. maximum difference between neighbouring pixels.
     * 'rugosity': The rugosity, i.e. difference between real and planimetric surface area.
     * 'fractal_roughness': The roughness based on a volume box-counting estimate of the fractal dimension.
+    * 'texture_shading': Texture shaded relief using fractional Laplacian operator to enhance terrain texture and 
+        fine-scale topographic features.
+
 
     :param dem: Input DEM.
     :param attribute: Terrain attribute(s) to calculate.
@@ -1447,6 +1452,10 @@ def _get_terrain_attribute(
     ]
     attributes_requiring_windowed_index = [attr for attr in attribute if attr in list_requiring_windowed_index]
 
+    # Frequency domain attributes (texture shading)
+    list_requiring_frequency_domain = ["texture_shading"]
+    attributes_requiring_frequency_domain = [attr for attr in attribute if attr in list_requiring_frequency_domain]
+
     attributes_requiring_resolution = attributes_requiring_surface_fit + (
         ["rugosity"] if "rugosity" in attribute else []
     )
@@ -1470,7 +1479,7 @@ def _get_terrain_attribute(
     elif isinstance(resolution, Sized):
         resolution = resolution[0]
 
-    choices = list_requiring_surface_fit + list_requiring_windowed_index
+    choices = list_requiring_surface_fit + list_requiring_windowed_index + list_requiring_frequency_domain
     for attr in attribute:
         if attr not in choices:
             raise ValueError(f"Attribute '{attr}' is not supported. Choices: {choices}")
@@ -1558,9 +1567,21 @@ def _get_terrain_attribute(
     else:
         windowed_indexes = []  # type: ignore
 
+    # Process frequency domain attributes
+    if len(attributes_requiring_frequency_domain) > 0:
+        frequency_attributes = []
+        for attr in attributes_requiring_frequency_domain:
+            if attr == "texture_shading":
+                # Use default alpha=0.8 for texture shading
+                result = _texture_shading_fft(dem_arr, alpha=0.8)
+                frequency_attributes.append(result.astype(out_dtype))
+        frequency_attributes = [freq_attr for freq_attr in frequency_attributes]  # type: ignore
+    else:
+        frequency_attributes = []  # type: ignore
+
     # Convert 3D array output to list of 2D arrays
-    output_attributes = surface_attributes + windowed_indexes
-    order_indices = [attribute.index(a) for a in attributes_requiring_surface_fit + attributes_requiring_windowed_index]
+    output_attributes = surface_attributes + windowed_indexes + frequency_attributes
+    order_indices = [attribute.index(a) for a in attributes_requiring_surface_fit + attributes_requiring_windowed_index + attributes_requiring_frequency_domain]
     output_attributes[:] = [output_attributes[idx] for idx in order_indices]
 
     if isinstance(dem, gu.Raster):
@@ -2258,3 +2279,215 @@ def fractal_roughness(
         window_size=window_size,
         mp_config=mp_config,
     )
+
+def _nextprod_fft(n: int) -> int:
+    """
+    Find the next valid FFT size (power of 2, 3, 5, or 7).
+    
+    Based on MATLAB's nextpow2 and optimized for scipy.fft.
+    
+    :param n: Input size
+    :returns: Next valid FFT size
+    """
+    if n <= 1:
+        return 1
+    
+    # For small sizes, use powers of 2
+    if n <= 1024:
+        return int(2 ** np.ceil(np.log2(n)))
+    
+    # For larger sizes, find the smallest m >= n such that m = 2^a * 3^b * 5^c * 7^d
+    factors = [2, 3, 5, 7]
+    candidate = n
+    
+    while True:
+        temp = candidate
+        for factor in factors:
+            while temp % factor == 0:
+                temp //= factor
+        if temp == 1:
+            return candidate
+        candidate += 1
+
+
+def _texture_shading_fft(
+    dem: NDArrayf,
+    alpha: float = 0.8,
+    method: str = "fft",
+    window_size: int | None = None,
+) -> NDArrayf:
+    """
+    Core texture shading implementation using fractional Laplacian operator.
+    
+    Based on Leland Brown's texture shading technique from:
+    Brown, L. (2010). Texture Shading: A New Technique for Depicting Terrain Relief. 
+    Workshop on Mountain Cartography, Banff, Canada.
+    
+    :param dem: Input DEM array
+    :param alpha: Fractional exponent for Laplacian operator (0-2, default 0.8)
+    :param method: Method to use ("fft" for frequency domain)
+    :param window_size: Window size for local processing (None for global)
+    :returns: Texture shaded array
+    """
+    # Validate inputs
+    if not 0 <= alpha <= 2:
+        raise ValueError(f"Alpha must be between 0 and 2, got {alpha}")
+    
+    if method != "fft":
+        raise ValueError(f"Only 'fft' method is supported, got '{method}'")
+    
+    # Handle NaN values by creating a mask
+    valid_mask = np.isfinite(dem)
+    if not np.any(valid_mask):
+        return np.full_like(dem, np.nan)
+    
+    # Work with a copy to avoid modifying input
+    dem_work = dem.copy()
+    
+    # Fill NaN values with mean of valid values for processing
+    if not np.all(valid_mask):
+        dem_work[~valid_mask] = np.nanmean(dem)
+    
+    # Get dimensions
+    rows, cols = dem_work.shape
+    
+    # Determine FFT sizes for optimal performance
+    fft_rows = _nextprod_fft(rows)
+    fft_cols = _nextprod_fft(cols)
+    
+    # Pad the array for FFT
+    pad_rows = (fft_rows - rows) // 2
+    pad_cols = (fft_cols - cols) // 2
+    
+    # Use symmetric padding to reduce edge effects
+    dem_padded = np.pad(
+        dem_work, 
+        ((pad_rows, fft_rows - rows - pad_rows), 
+         (pad_cols, fft_cols - cols - pad_cols)), 
+        mode='symmetric'
+    )
+    
+    # Create frequency domain coordinates
+    freq_y = fft.fftfreq(fft_rows)
+    freq_x = fft.fftfreq(fft_cols)
+    
+    # Create 2D frequency grids
+    fy, fx = np.meshgrid(freq_y, freq_x, indexing='ij')
+    
+    # Calculate frequency magnitude (avoiding division by zero)
+    freq_magnitude = np.sqrt(fx**2 + fy**2)
+    freq_magnitude[0, 0] = 1.0  # Avoid log(0) later
+    
+    # Create fractional Laplacian filter in frequency domain
+    # For alpha=1, this is the standard Laplacian
+    # For alpha<1, it emphasizes low frequencies
+    # For alpha>1, it emphasizes high frequencies
+    laplacian_filter = freq_magnitude ** alpha
+    laplacian_filter[0, 0] = 0  # DC component should be zero
+    
+    # Apply FFT
+    dem_fft = fft.fft2(dem_padded)
+    
+    # Apply fractional Laplacian in frequency domain
+    result_fft = dem_fft * laplacian_filter
+    
+    # Transform back to spatial domain
+    result_padded = np.real(fft.ifft2(result_fft))
+    
+    # Extract the original size from padded result
+    result = result_padded[pad_rows:pad_rows+rows, pad_cols:pad_cols+cols]
+    
+    # Restore NaN values where original data was invalid
+    result[~valid_mask] = np.nan
+    
+    return result
+
+
+@overload
+def texture_shading(
+    dem: NDArrayf | MArrayf,
+    alpha: float = 0.8,
+    method: str = "fft",
+    window_size: int | None = None,
+    mp_config: MultiprocConfig | None = None,
+) -> NDArrayf: ...
+
+
+@overload
+def texture_shading(
+    dem: RasterType,
+    alpha: float = 0.8,
+    method: str = "fft", 
+    window_size: int | None = None,
+    mp_config: MultiprocConfig | None = None,
+) -> RasterType: ...
+
+
+def texture_shading(
+    dem: NDArrayf | MArrayf | RasterType,
+    alpha: float = 0.8,
+    method: str = "fft",
+    window_size: int | None = None,
+    mp_config: MultiprocConfig | None = None,
+) -> NDArrayf | RasterType:
+    """
+    Generate a texture shaded relief map using fractional Laplacian operator.
+    
+    This technique, developed by Leland Brown, applies a fractional Laplacian operator
+    in the frequency domain to enhance terrain texture and fine-scale topographic features.
+    It's particularly effective for visualizing subtle terrain variations that may not
+    be apparent in traditional hillshading.
+    
+    The fractional Laplacian operator is controlled by the alpha parameter:
+    - alpha = 0: No enhancement (returns original DEM)
+    - alpha = 1: Standard Laplacian operator (edge detection)
+    - alpha = 2: Enhanced high-frequency features
+    
+    Based on: Brown, L. (2010). Texture Shading: A New Technique for Depicting Terrain Relief. 
+    Workshop on Mountain Cartography, Banff, Canada.
+
+    Adapted from the Python implementation at https://github.com/fasiha/texshade-py
+    
+    :param dem: Input DEM array or Raster object
+    :param alpha: Fractional exponent for Laplacian operator (0-2, default 0.8).
+        Higher values enhance fine details, lower values provide smoother results.
+    :param method: Processing method, currently only "fft" (frequency domain) is supported
+    :param window_size: Window size for local processing (None for global processing)
+    :param mp_config: Multiprocessing configuration, run the function in multiprocessing if not None
+    
+    :raises ValueError: If alpha is not between 0 and 2, or if method is not supported
+    
+    :examples:
+        >>> import numpy as np
+        >>> # Create a simple test DEM with a ridge
+        >>> dem = np.zeros((50, 50))
+        >>> dem[20:30, :] = np.sin(np.linspace(0, np.pi, 50)) * 10
+        >>> textured = texture_shading(dem, alpha=0.8)
+        >>> textured.shape == dem.shape
+        True
+        >>> # Higher alpha enhances fine details
+        >>> textured_enhanced = texture_shading(dem, alpha=1.5)
+        
+    :returns: Texture shaded array with same shape as input DEM
+    """
+    # Get array from input
+    dem_arr = gu.raster.get_array_and_mask(dem)[0]
+    
+    # Apply texture shading
+    result = _texture_shading_fft(
+        dem_arr,
+        alpha=alpha,
+        method=method,
+        window_size=window_size,
+    )
+    
+    # If input was a Raster, return a Raster
+    if isinstance(dem, gu.Raster):
+        return gu.Raster.from_array(
+            result,
+            transform=dem.transform,
+            crs=dem.crs,
+            nodata=dem.nodata
+        )
+    
+    return result


### PR DESCRIPTION
Hi all :wave:

This PR adds `xdem.DEM.texture_shading()` to the available DEM terrain attributes.

The method is based on [Brown (2010)](https://mountaincartography.icaci.org/activities/workshops/banff_canada/papers/brown.pdf) and adapted from the Python implementation by @fasiha at https://github.com/fasiha/texshade-py. The corresponding [license](https://github.com/fasiha/texshade-py/blob/main/UNLICENSE) is quite permissive, so hopefully adapting it is welcomed and OK! 🙂 

## Files changed
- `xdem/terrain.py`
- `xdem/dem.py`
- `tests/test_terrain.py`
- `doc/source/terrain.md`

## Functions added
- `xdem.terrain._nextprod_fft()` - Helper function for optimal FFT sizes
- `xdem.terrain._texture_shading_fft()` - Core fractional Laplacian implementation using scipy.fft
- `xdem.terrain.texture_shading()` - Main texture shading function with parameter validation
- `xdem.DEM.texture_shading()` - DEM class method with alpha=0.8 default and parameter forwarding

## Tests added
- `test_texture_shading()` - Basic functionality and parameter validation
- `test_texture_shading_via_get_terrain_attribute()` - Integration with terrain attribute system
- `test_texture_shading_larger_dem()` - Performance testing on larger dataset
- `test_nextprod_fft()` - Helper function validation

## Documentation added
- Texture shading section in terrain attributes documentation
- Formulation of fractional Laplacian operator
- Comparison and description of complementary use with hillshading
- Basic usage example
- References to Brown (2010) and fasiha/texshade-py implementation

### Disclaimer
I am not an expert of FFT processing and used the Claude Sonnet 4 co-pilot to facilitate integration with `xdem`. There might be another way to handle `_nextprod_fft()` (e.g. `scipy.fft.next_fast_len(n)`?), but kept it close to the original python implementation for now.