### PR TITLE
Pin setuptools_scm max version to `9.0` to avoid build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=64",
-    "setuptools_scm[toml]>=8",
+    "setuptools_scm[toml]>=8,<9.0.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
# Context:

Currently, the CI is failing to find the xdem installations. This is due to a recent release of [setuptools_scm](https://github.com/pypa/setuptools-scm/releases/tag/v9.2.0) : 

While waiting for a 100% python CI without conda to be implemented, I suggest pinning the version of setuptools.

EDIT from @rhugonnet: See issue here: https://github.com/pypa/setuptools-scm/issues/1213