### PR TITLE
Fix setup of MyPy temporarily and add `pre-commit` to dev-environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,7 +72,7 @@ repos:
                         --disable-error-code=no-any-return
 
                   ]
-                  additional_dependencies: [tokenize-rt, numpy==2]
+                  additional_dependencies: [tokenize-rt, numpy==2.0.*]
                   files: ^(xdem|tests|doc/code)
 
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -31,6 +31,7 @@ dependencies:
   - pyyaml
   - flake8
   - pylint
+  - pre-commit
 
   # Doc dependencies
   - sphinx


### PR DESCRIPTION
This PR fixes the setup of Mypy which was breaking locally due to the NumPy plugin (and soon in CI), by pinning NumPy 2.0.X.
This PR also adds `pre-commit` to `dev-environment.yml` to have it already setup after a dev install.

We'll have to remove the NumPy plugin in time due to deprecation, see #782.
But this involves updating to NumPy 2.3.X, which triggers many more static typing checks, so let's do this in a PR updating most of the static typing.

