### PR TITLE
Include vcrs in DEM.info 

### DIFF
--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -369,10 +369,9 @@ class TestDEM:
 
         assert dem_class_attr.raster_equal(terrain_module_attr)
 
-    def test_info(self) -> None:
-        """Tests info function with the new Coordinate system line"""
+    def test_info_2Dcrs(self) -> None:
+        """Tests info function with the new Coordinate system line on dem with 2D CRS"""
 
-        # Test dem with 2D CRS
         dem_path = xdem.examples.get_path("longyearbyen_ref_dem")
         raster = gu.Raster(dem_path)
         dem = xdem.dem.DEM(dem_path)
@@ -407,15 +406,20 @@ class TestDEM:
         assert complete_line.startswith(crs_key)
         assert complete_line[len(crs_key) :].strip() == "['EPSG:25833', 'EPSG:5773']"
 
-        """
-        # Test dem with 3D CRS
-        dem_path = xdem.examples.get_path("pyramids_cars_ref_dem")
+    @pytest.mark.skip()  # type: ignore
+    def test_info_3Dcrs(self) -> None:
+        """Tests info function with the new Coordinate system line on dem with 3D CRS"""
+
+        dem_path = xdem.examples.get_path("gizeh")
         dem = xdem.dem.DEM(dem_path)
         dem_infos_array = dem.info(verbose=False).split("\n")
+
+        crs_key = "Coordinate system:"
+        crs_line = [dem_infos_array.index(line) for line in dem_infos_array if line.startswith(crs_key)]
+
         complete_line = dem_infos_array[crs_line[0]]
         assert complete_line.startswith(crs_key)
-        assert complete_line[len(crs_key) :].strip() == dem.crs
-        """
+        assert complete_line[len(crs_key) :].strip() == "['WGS 84 / UTM zone 36N + EGM96 height']"
 
     @staticmethod
     @pytest.mark.parametrize(  # type: ignore

--- a/xdem/dem.py
+++ b/xdem/dem.py
@@ -189,7 +189,7 @@ class DEM(Raster):  # type: ignore
 
         # Change crs values if not 3D
         if len(CRS(self.crs).axis_info) > 2:
-            new_crs = self.crs
+            new_crs = [CRS(self.crs).name]
         else:
             new_crs = [self.crs.to_string() if self.crs is not None else None, str(self.vcrs)]
 


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/xdem/issues/632 

Now, the DEM.info() prints the VCRS information, after the Coordinates System line : 

Results dem.info()

<img width="914" height="324" alt="image" src="https://github.com/user-attachments/assets/c98703cc-cffe-408a-966a-770df1ab03d3" />

<img width="915" height="344" alt="image" src="https://github.com/user-attachments/assets/9041395a-01e8-4512-b135-1b530ba85c0f" />

<img width="751" height="340" alt="image" src="https://github.com/user-attachments/assets/813272d8-fd66-4fab-8f5f-b85414d002c1" />

### Resolution

To do this, `Raster.infos()` was overwrited and a dynamic insertion was done on its results.
1. `info_str = super.info(stats=stats, verbose=False)`
2. Coordinates System line found
3. replace by  Coordinates System: [ crs.name ] if 3D ; [ crs , vrcs ]

#### Tests

Added test_info() with some checks (all inputs possibles) like the addition on the line and the line itself (when VRCS is None and when initialized).

/!\ need to add 3D vcrs to xdem-data and unskip the corresponding test