### PR TITLE
Adapt overlap size for out-of-memory terrain attributes

### DIFF
--- a/tests/test_terrain/test_terrain.py
+++ b/tests/test_terrain/test_terrain.py
@@ -233,7 +233,7 @@ class TestTerrainAttribute:
         slope_lowres = xdem.terrain.get_terrain_attribute(self.dem.data, "slope", resolution=self.dem.res[0] * 2)
         assert np.nanmean(slope) > np.nanmean(slope_lowres)
 
-    @pytest.mark.parametrize("surfit_windowsize", [("Florinsky", 3), ("ZevenbergThorne", 7)])
+    @pytest.mark.parametrize("surfit_windowsize", [("Florinsky", 3), ("ZevenbergThorne", 7)])  # type: ignore
     @pytest.mark.parametrize("attribute", xdem.terrain.available_attributes)  # type: ignore
     def test_attributes__multiproc(self, attribute, surfit_windowsize) -> None:
         """
@@ -319,7 +319,6 @@ class TestTerrainAttribute:
         hillshade_classic = self.dem.hillshade()
         assert np.allclose(slope.data, slope_classic.data, rtol=1e-7)
         assert np.allclose(hillshade.data, hillshade_classic.data, rtol=1e-7)
-
 
     def test_get_terrain_attribute__errors(self) -> None:
         """Test the get_terrain_attribute function raises appropriate errors."""

--- a/xdem/terrain/terrain.py
+++ b/xdem/terrain/terrain.py
@@ -327,10 +327,13 @@ def get_terrain_attribute(
 
     # Warn if default window size for fractal roughness
     if "fractal_roughness" in attribute and window_size == 3:
-        warnings.warn(category=UserWarning, stacklevel=2,
-                      message="Fractal roughness results with window size of less than 13 can be inaccurate."
-                              "Consider deriving it separately from other attributes that use a default window size of "
-                              "3.")
+        warnings.warn(
+            category=UserWarning,
+            stacklevel=2,
+            message="Fractal roughness results with window size of less than 13 can be inaccurate."
+            "Consider deriving it separately from other attributes that use a default window size of "
+            "3.",
+        )
 
     attributes_requiring_resolution = attributes_requiring_surface_fit + (
         ["rugosity"] if "rugosity" in attribute else []
@@ -461,7 +464,7 @@ def get_terrain_attribute(
 def _get_terrain_attribute(
     dem: NDArrayf,
     attribute: list[str],
-    resolution: tuple[float, float] | float | None = None,
+    resolution: float,
     degrees: bool = True,
     hillshade_altitude: float = 45.0,
     hillshade_azimuth: float = 315.0,
@@ -480,7 +483,7 @@ def _get_terrain_attribute(
 def _get_terrain_attribute(
     dem: RasterType,
     attribute: list[str],
-    resolution: tuple[float, float] | float | None = None,
+    resolution: float,
     degrees: bool = True,
     hillshade_altitude: float = 45.0,
     hillshade_azimuth: float = 315.0,
@@ -494,10 +497,11 @@ def _get_terrain_attribute(
     out_dtype: DTypeLike | None = None,
 ) -> list[RasterType]: ...
 
+
 def _get_terrain_attribute(
     dem: NDArrayf | RasterType,
     attribute: list[str],
-    resolution: tuple[float, float] | float | None = None,
+    resolution: float,
     degrees: bool = True,
     hillshade_altitude: float = 45.0,
     hillshade_azimuth: float = 315.0,


### PR DESCRIPTION
This PR properly defines `depth` for `map_overlap` applied to chunked terrain attributes (out-of-memory).

It also re-organizes the user-input checks, moving them out of `_get_terrain_attributes()` and into `get_terrain_attributes()` (parent function), so that they happen before Dask/Multiprocessing and are easier to debug for users.

Resolves #844 

TO-DO:
- [x] Move input check logic out of subfunction and into parent function (containing multiproc + normal call),
- [x] Add multiprocessing tests for all attributes.