### PR TITLE
docs(spatial_stats): drop www from aspexit link (#951)

### DIFF
--- a/doc/source/spatial_stats.md
+++ b/doc/source/spatial_stats.md
@@ -35,7 +35,7 @@ elevation data, described in the **feature page {ref}`uncertainty`**.
 In spatial statistics, the covariance of a variable of interest is generally simplified into a spatial variogram, which
 **describes the covariance only as function of the spatial lag** (spatial distance between two variable values).
 However, to utilize this simplification of the covariance in subsequent analysis, the variable of interest must
-respect [the assumption of second-order stationarity](https://www.aspexit.com/en/fundamental-assumptions-of-the-variogram-second-order-stationarity-intrinsic-stationarity-what-is-this-all-about/).
+respect [the assumption of second-order stationarity](https://aspexit.com/en/fundamental-assumptions-of-the-variogram-second-order-stationarity-intrinsic-stationarity-what-is-this-all-about/).
 That is, verify the three following assumptions:
 
 > 1. The mean of the variable of interest is stationary in space, i.e. constant over sufficiently large areas,


### PR DESCRIPTION
Closes #951.

The aspexit.com host stopped serving the `www.` subdomain directly; the URL the issue reports as broken now 301-redirects from `https://www.aspexit.com/...` to `https://aspexit.com/...`. The redirect resolves to a working article (HTTP 200), but readers ran into a broken-link state during the transition, so point the spatial_stats reference directly at the canonical host so the link resolves with a single 200 instead of relying on the redirect.

The fallback PDF the issue mentions (`https://ec.europa.eu/eurostat/...`) is a different reference and isn't a like-for-like swap for "the assumption of second-order stationarity"; keeping the original article as the linked source preserves the existing intent.

### Change Type

- [x] Documentation