### PR TITLE
Don't force reprojection when it is possible in the CLI accuracy workflow

### DIFF
--- a/tests/test_workflows/test_accuracy.py
+++ b/tests/test_workflows/test_accuracy.py
@@ -230,24 +230,25 @@ def test_run_without_coreg(get_accuracy_inputs_test, tmp_path, level, generated_
 @pytest.mark.parametrize(
     "methods, raises_error",
     [
+        (["CPD", None, None], False),
+        (["ICP", None, None], False),
+        (["ICP", "CPD", None], False),
         (["NuthKaab", None, None], True),
         (["DhMinimize", None, None], True),
         (["VerticalShift", None, None], True),
         (["DirectionalBias", None, None], True),
         (["TerrainBias", None, None], True),
         (["LZD", None, None], True),
-        (["CPD", None, None], False),
-        (["ICP", None, None], False),
-        # ([None, "LZD", "ICP"], False),
         (["CPD", "VerticalShift", None], True),
     ],
 )
 def test_sampling_grid_is_None(get_accuracy_inputs_test, tmp_path, methods, raises_error):
     """
-    Test the behavior when sampling_grid = None with the different regulation methods.
+    Test the behavior when sampling_grid = None with the different coreg methods.
     """
-
     user_config = get_accuracy_inputs_test
+
+    user_config["inputs"]["reference_elev"]["path_to_mask"] = None
     user_config["outputs"] = {"path": str(tmp_path), "level": 2}
     user_config["inputs"]["sampling_grid"] = None
     user_config["coregistration"] = dict()
@@ -256,7 +257,8 @@ def test_sampling_grid_is_None(get_accuracy_inputs_test, tmp_path, methods, rais
     for m, step in enumerate(["step_one", "step_two", "step_three"]):
         user_config["coregistration"][step] = dict()
         user_config["coregistration"][step]["method"] = methods[m]
-        pipeline = pipeline + getattr(xdem.coreg, methods[m])() if pipeline else getattr(xdem.coreg, methods[m])()
+        if methods[m]:
+            pipeline = pipeline + getattr(xdem.coreg, methods[m])() if pipeline else getattr(xdem.coreg, methods[m])()
 
     if raises_error:
         with pytest.raises(ValueError, match="selected coregistration method need"):
@@ -264,18 +266,24 @@ def test_sampling_grid_is_None(get_accuracy_inputs_test, tmp_path, methods, rais
             workflows.run()
     else:
 
-        # tba_dem = xdem.DEM(user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"]).reproject(crs="EPSG:4326")
-        # tba_dem.to_file(tmp_path / "tba_4326.tif")
-        # user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"] = str(tmp_path / "tba_4326.tif")
+        ref_dem = xdem.DEM(user_config["inputs"]["reference_elev"]["path_to_elev"])
+
+        # Change the size of `tba_dem` to validate the absence of reprojection
+        tba_dem = xdem.DEM(user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"])
+        nrows, ncols = tba_dem.shape
+        tba_dem = tba_dem.icrop((0, 0, ncols - 10, nrows - 10))
+        tba_dem.to_file(tmp_path / "tba_cropped.tif")
+        user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"] = str(tmp_path / "tba_cropped.tif")
 
         workflows = Accuracy(user_config)
         workflows.run()
 
-        ref_dem = xdem.DEM(user_config["inputs"]["reference_elev"]["path_to_elev"])
-        tba_dem = xdem.DEM(user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"])
-
-        aligned_dem = pipeline.fit_and_apply(ref_dem, tba_dem)  # type: ignore
-        assert xdem.DEM(Path(tmp_path) / "rasters" / "aligned_elev.tif").raster_equal(aligned_dem)
+        aligned_dem = tba_dem.coregister_3d(ref_dem, pipeline, random_state=42)
+        aligned_dem.to_file(Path(tmp_path) / "rasters" / "res.tif")
+        aligned_dem = xdem.DEM(Path(tmp_path) / "rasters" / "res.tif")  # TODO CHANGE ISSUE GEOUTILS 900
+        assert xdem.DEM(Path(tmp_path) / "rasters" / "aligned_elev.tif").raster_equal(
+            aligned_dem, warn_failure_reason=True
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflows/test_accuracy.py
+++ b/tests/test_workflows/test_accuracy.py
@@ -228,14 +228,65 @@ def test_run_without_coreg(get_accuracy_inputs_test, tmp_path, level, generated_
 
 
 @pytest.mark.parametrize(
+    "methods, raises_error",
+    [
+        (["NuthKaab", None, None], True),
+        (["DhMinimize", None, None], True),
+        (["VerticalShift", None, None], True),
+        (["DirectionalBias", None, None], True),
+        (["TerrainBias", None, None], True),
+        (["LZD", None, None], True),
+        (["CPD", None, None], False),
+        (["ICP", None, None], False),
+        # ([None, "LZD", "ICP"], False),
+        (["CPD", "VerticalShift", None], True),
+    ],
+)
+def test_sampling_grid_is_None(get_accuracy_inputs_test, tmp_path, methods, raises_error):
+    """
+    Test the behavior when sampling_grid = None with the different regulation methods.
+    """
+
+    user_config = get_accuracy_inputs_test
+    user_config["outputs"] = {"path": str(tmp_path), "level": 2}
+    user_config["inputs"]["sampling_grid"] = None
+    user_config["coregistration"] = dict()
+
+    pipeline = None
+    for m, step in enumerate(["step_one", "step_two", "step_three"]):
+        user_config["coregistration"][step] = dict()
+        user_config["coregistration"][step]["method"] = methods[m]
+        pipeline = pipeline + getattr(xdem.coreg, methods[m])() if pipeline else getattr(xdem.coreg, methods[m])()
+
+    if raises_error:
+        with pytest.raises(ValueError, match="selected coregistration method need"):
+            workflows = Accuracy(user_config)
+            workflows.run()
+    else:
+
+        # tba_dem = xdem.DEM(user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"]).reproject(crs="EPSG:4326")
+        # tba_dem.to_file(tmp_path / "tba_4326.tif")
+        # user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"] = str(tmp_path / "tba_4326.tif")
+
+        workflows = Accuracy(user_config)
+        workflows.run()
+
+        ref_dem = xdem.DEM(user_config["inputs"]["reference_elev"]["path_to_elev"])
+        tba_dem = xdem.DEM(user_config["inputs"]["to_be_aligned_elev"]["path_to_elev"])
+
+        aligned_dem = pipeline.fit_and_apply(ref_dem, tba_dem)  # type: ignore
+        assert xdem.DEM(Path(tmp_path) / "rasters" / "aligned_elev.tif").raster_equal(aligned_dem)
+
+
+@pytest.mark.parametrize(
     "config",
     [
         (True, "reference_elev", "reference_elev", None),
         (False, "reference_elev", "reference_elev", None),
         (True, "to_be_aligned_elev", "to_be_aligned_elev", None),
         (False, "to_be_aligned_elev", "to_be_aligned_elev", None),
-        (True, None, None, "must be set to"),
-        (True, None, "reference_elev", "must be set to"),
+        (True, None, None, "selected coregistration method need"),
+        (True, None, "reference_elev", "selected coregistration method need"),
         (False, None, None, None),
         (False, None, "reference_elev", "same shape, transform and CRS"),
     ],

--- a/xdem/workflows/accuracy.py
+++ b/xdem/workflows/accuracy.py
@@ -23,7 +23,6 @@ Accuracy class from workflow
 import logging
 import time
 from datetime import datetime
-from functools import partial
 from pathlib import Path
 from typing import Any, Dict
 
@@ -64,9 +63,14 @@ class Accuracy(Workflows):
         if not self.compute_coreg:
             del self.config["coregistration"]["step_one"]
         else:
-            if self.config["inputs"]["sampling_grid"] is None:
+            coreg_config = self.config["coregistration"]
+            all_methods = [coreg_config[step]["method"] for step in coreg_config.keys() if step.startswith("step")]
+            methods_needed_sg = list(
+                set(all_methods) & {"NuthKaab", "DhMinimize", "VerticalShift", "DirectionalBias", "TerrainBias", "LZD"}
+            )
+            if self.config["inputs"]["sampling_grid"] is None and len(methods_needed_sg):
                 raise ValueError(
-                    'In case of a coregistration process, "sampling grid" must be set to '
+                    'At least one the selected coregistration method need "sampling grid" to be set to '
                     '"reference_elev" or "to_be_aligned_elev"'
                 )
 
@@ -137,22 +141,13 @@ class Accuracy(Workflows):
         coreg_steps = ["step_one", "step_two", "step_three"]
         coreg_functions = []
 
-        method_map = {
-            "NuthKaab": xdem.coreg.NuthKaab,
-            "DhMinimize": xdem.coreg.DhMinimize,
-            "VerticalShift": xdem.coreg.VerticalShift,
-            "DirectionalBias": xdem.coreg.DirectionalBias,
-            "TerrainBias": xdem.coreg.TerrainBias,
-            "LZD": xdem.coreg.LZD,
-        }
-
         for step in coreg_steps:
             config_coreg = self.config["coregistration"].get(step)
             if config_coreg:
                 method_name = config_coreg.get("method")
                 coreg_extra = config_coreg.get("extra_information", {})
-                coreg_fun = partial(method_map[method_name], **coreg_extra)
-                coreg_functions.append(coreg_fun())
+                coreg_fun = getattr(xdem.coreg, method_name)(**coreg_extra)
+                coreg_functions.append(coreg_fun)
         my_coreg = sum(coreg_functions[1:], coreg_functions[0]) if len(coreg_functions) > 1 else coreg_functions[0]
 
         # Coregister

--- a/xdem/workflows/accuracy.py
+++ b/xdem/workflows/accuracy.py
@@ -318,7 +318,12 @@ class Accuracy(Workflows):
 
         if self.compute_coreg:
 
-            self.diff_before = self.to_be_aligned_elev - self.reference_elev
+            # Reproject self.to_be_aligned_elev only if needed
+            try:
+                self.diff_before = self.to_be_aligned_elev - self.reference_elev
+            except ValueError:
+                self.to_be_aligned_elev = self.to_be_aligned_elev.reproject(self.reference_elev)
+                self.diff_before = self.to_be_aligned_elev - self.reference_elev
             self.stats_before = self.diff_before.get_stats(stats_keys)
 
             self.diff_after = aligned_elev.reproject(self.reference_elev) - self.reference_elev

--- a/xdem/workflows/schemas.py
+++ b/xdem/workflows/schemas.py
@@ -107,7 +107,8 @@ INPUTS_DEM = {
     "downsample": {"type": ["integer", "float"], "required": False, "default": 1, "min": 1},
 }
 
-COREG_METHODS = ["NuthKaab", "DhMinimize", "VerticalShift", "DirectionalBias", "TerrainBias", "LZD", None]
+
+COREG_METHODS = ["CPD", "ICP", "NuthKaab", "DhMinimize", "VerticalShift", "DirectionalBias", "TerrainBias", "LZD", None]
 
 
 MIN_STATS = [
@@ -215,7 +216,7 @@ ACCURACY_SCHEMA = {
             "to_be_aligned_elev": {"type": "dict", "schema": INPUTS_DEM, "required": True},
             "sampling_grid": {
                 "type": "string",
-                "allowed": ["reference_elev", "to_be_aligned_elev"],
+                "allowed": ["reference_elev", "to_be_aligned_elev", None],
                 "default": "reference_elev",
                 "nullable": True,
                 "required": False,


### PR DESCRIPTION
[Work In Progress]

Resolves #909 

`sampling_grid = None` can be possible:
- coreg with ICP and CPD (work even if datasets are not reprojected)
     - ICP/CPD methods only: OK 
     - Other method(s) only: KO
     - ICP/CPD + other method(s): KO
- no coreg : KO

Tests ne no resampling with : 
- overlapping dems: dem vs smaller dem
- no overlapping dems ?

/!\ Openned https://github.com/GlacioHack/geoutils/issues/900
