### PR TITLE
Fix documentation generation

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -29,7 +29,6 @@ dependencies:
   - cerberus  # For CLI
   - pyyaml  # For CLI
   - tqdm  # For progress bars
-  - plutoprint  # For CLI
 
   # Test dependencies
   - pytest
@@ -58,6 +57,8 @@ dependencies:
       # Optional dependencies with Pip
       # SciKit-GStat temporarily here until Conda version supports Python 3.13
       - scikit-gstat>=1.0.18
+      # For CLI
+      - plutoprint
 
       - -e ./
 


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/xdem/issues/981 

Fix ReadTheDoc error : 
<img width="935" height="759" alt="image" src="https://github.com/user-attachments/assets/51397799-c02d-44ff-8b2c-0733d8196c27" />


Tips to know if it worked : PlutoPrint is well mentionned here https://xdem-doc.readthedocs.io/en/981_pip/how_to_install.html