### PR TITLE
Initial shift in case of CoregPipeline

### DIFF
--- a/doc/source/coregistration.md
+++ b/doc/source/coregistration.md
@@ -551,7 +551,7 @@ For both **inputs** and **outputs**, four consistent categories of metadata are 
 
 - An input `only_translation` to define if a coregistration should solve only for translations instead of a full rigid transformation (translations and rotations),
 - An input `standardize` to define if the input data should be standardized to the unit sphere before coregistration (to improve numerical convergence),
-- An input `initial_shift` that defines the estimated initial x and y shifts in georeferenced units, applied before fit step.
+- An input `initial_shift` that defines the estimated initial x and y shifts in georeferenced units, applied before fit step (when used within a CoregPipeline, only the initial offset specified in the first coregistration is applied, others are ignored),
 - An output `matrix` that stores the estimated affine matrix,
 - An output `centroid` that stores the centroid coordinates with which to apply the affine transformation,
 - Outputs `shift_x`, `shift_y` and `shift_z` that store the easting, northing and vertical offsets, respectively.

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -17,7 +17,7 @@ from geoutils._typing import Number
 from geoutils.raster.geotransformations import _translate
 from scipy.ndimage import binary_dilation
 
-from xdem import coreg, coregpipeline, examples
+from xdem import coreg, examples
 from xdem.coreg.affine import (
     AffineCoreg,
     _reproject_horizontal_shift_samecrs,
@@ -25,6 +25,7 @@ from xdem.coreg.affine import (
     matrix_from_translations_rotations,
     translations_rotations_from_matrix,
 )
+from xdem.coreg.base import CoregPipeline
 
 
 def load_examples() -> tuple[Raster, Raster, Vector]:
@@ -700,7 +701,7 @@ class TestAffineCoreg:
 
         is1, is2, is3 = initial_shifts
 
-        def test_results(pipeline: coregpipeline, is1: tuple[int, int, int] | None) -> None:
+        def test_results(pipeline: CoregPipeline, is1: tuple[int, int, int] | None) -> None:
             if is1 is None:
                 assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
             else:

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -673,32 +673,69 @@ class TestAffineCoreg:
 
     @pytest.mark.parametrize(
         "initial_shifts",
-        [[None, (8, 4, 0), None], [None, None, (8, 4, 0)], [(8, 4, 0), (8, 4, 0), None]],
+        [[None, (1, 1, 0), None], [None, None, (2, 2, 0)], [(3, 3, 0), (4, 4, 0), None]],
     )
-    @pytest.mark.parametrize("pre_coreg", [True, False])
-    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any], pre_coreg: bool) -> None:
+    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any]) -> None:
         """
         Test that coreg initial_shift management in function on its place in the pipeline
         """
-        is1, is2, is3 = initial_shifts
-        with pytest.warns(UserWarning, match="No initial shift can be"):
-            if pre_coreg:
-                pipeline = (
-                    coreg.VerticalShift()
-                    + coreg.NuthKaab(initial_shift=is1)
-                    + coreg.NuthKaab(initial_shift=is2)
-                    + coreg.NuthKaab(initial_shift=is3)
-                )
-            else:
-                pipeline = (
-                    coreg.NuthKaab(initial_shift=is1)
-                    + coreg.NuthKaab(initial_shift=is2)
-                    + coreg.NuthKaab(initial_shift=is3)
-                )
 
-        if is1 is not None and pre_coreg is False:
-            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
-        else:
+        is1, is2, is3 = initial_shifts
+
+        # Test N&K series
+        with pytest.warns(UserWarning, match="No initial shift can be"):
+            pipeline = (
+                coreg.NuthKaab(initial_shift=is1)
+                + coreg.NuthKaab(initial_shift=is2)
+                + coreg.NuthKaab(initial_shift=is3)
+            )
+
+        if is1 is None:
             assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+        else:
+            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
         assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
         assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+
+        # CoregPipeline with a list of N&K
+        with pytest.warns(UserWarning, match="No initial shift can be"):
+            pipeline = coreg.CoregPipeline(
+                [
+                    coreg.NuthKaab(initial_shift=is1),
+                    coreg.NuthKaab(initial_shift=is2),
+                    coreg.NuthKaab(initial_shift=is3),
+                ]
+            )
+
+        if is1 is None:
+            assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+        else:
+            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+
+        # Test N&K series with VerticalShift before
+        with pytest.warns(UserWarning, match="No initial shift can be"):
+            pipeline = (
+                coreg.VerticalShift()
+                + coreg.NuthKaab(initial_shift=is1)
+                + coreg.NuthKaab(initial_shift=is2)
+                + coreg.NuthKaab(initial_shift=is3)
+            )
+
+        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+
+        # Test nested CoregPipeline
+        with pytest.warns(UserWarning, match="No initial shift can be"):
+            pipeline = coreg.NuthKaab(initial_shift=is1) + coreg.CoregPipeline(
+                coreg.NuthKaab(initial_shift=is2) + coreg.NuthKaab(initial_shift=is3)
+            )
+
+            if is1 is None:
+                assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+            else:
+                assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+            assert "initial_shift" not in pipeline.pipeline[1].pipeline.pipeline[0].meta["inputs"]["affine"]
+            assert "initial_shift" not in pipeline.pipeline[1].pipeline.pipeline[1].meta["inputs"]["affine"]

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -674,9 +674,8 @@ class TestAffineCoreg:
     @pytest.mark.parametrize(
         "initial_shifts",
         [[None, (8, 4, 0), None], [None, None, (8, 4, 0)], [(8, 4, 0), (8, 4, 0), None]],
-        "pre_coreg",
-        [True, False],
     )
+    @pytest.mark.parametrize("pre_coreg", [True, False])
     def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any], pre_coreg: bool) -> None:
         """
         Test that coreg initial_shift management in function on its place in the pipeline

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -17,7 +17,7 @@ from geoutils._typing import Number
 from geoutils.raster.geotransformations import _translate
 from scipy.ndimage import binary_dilation
 
-from xdem import coreg, examples
+from xdem import coreg, coregpipeline, examples
 from xdem.coreg.affine import (
     AffineCoreg,
     _reproject_horizontal_shift_samecrs,
@@ -633,6 +633,23 @@ class TestAffineCoreg:
         assert dem_aligned_is.transform == dem_aligned.transform
         assert dem_aligned_is.crs == dem_aligned.crs
 
+    def test_pipeline_nested_coregpipeline(self) -> None:
+        """Test nested CoregPipeline"""
+
+        nk1 = coreg.NuthKaab()
+        nk2 = coreg.NuthKaab()
+        nk3 = coreg.NuthKaab()
+        nk4 = coreg.NuthKaab()
+        pipeline = coreg.CoregPipeline([nk1, coreg.CoregPipeline([nk2, nk3])])
+        assert len(pipeline.pipeline) == 3
+        for n, nk in enumerate([nk1, nk2, nk3]):
+            assert pipeline.pipeline[n] == nk
+
+        pipeline = coreg.CoregPipeline([coreg.CoregPipeline([nk1, nk2]), coreg.CoregPipeline([nk3, nk4])])
+        assert len(pipeline.pipeline) == 4
+        for n, nk in enumerate([nk1, nk2, nk3, nk4]):
+            assert pipeline.pipeline[n] == nk
+
     @pytest.mark.parametrize("initial_shift", [None, (8, 4, 0)])
     @pytest.mark.parametrize("array", [True, False])
     def test_pipeline_initial_shift(self, initial_shift: tuple[Number, Number, Number] | None, array: bool) -> None:
@@ -662,7 +679,8 @@ class TestAffineCoreg:
 
         # Automatic pipeline
         pipeline = coreg.NuthKaab(initial_shift=initial_shift) + coreg.NuthKaab(initial_shift=None)
-        if initial_shift:
+        print(initial_shift)
+        if initial_shift is not None:
             assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == initial_shift
         else:
             assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
@@ -675,12 +693,20 @@ class TestAffineCoreg:
         "initial_shifts",
         [[None, (1, 1, 0), None], [None, None, (2, 2, 0)], [(3, 3, 0), (4, 4, 0), None]],
     )
-    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any]) -> None:
+    def test_pipeline_initial_shift_errors(self, initial_shifts: list[tuple[int, int, int] | None]) -> None:
         """
         Test that coreg initial_shift management in function on its place in the pipeline
         """
 
         is1, is2, is3 = initial_shifts
+
+        def test_results(pipeline: coregpipeline, is1: tuple[int, int, int] | None) -> None:
+            if is1 is None:
+                assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+            else:
+                assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+            assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+            assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
 
         # Test N&K series
         with pytest.warns(UserWarning, match="No initial shift can be"):
@@ -689,13 +715,7 @@ class TestAffineCoreg:
                 + coreg.NuthKaab(initial_shift=is2)
                 + coreg.NuthKaab(initial_shift=is3)
             )
-
-        if is1 is None:
-            assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
-        else:
-            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
-        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+        test_results(pipeline, is1)
 
         # CoregPipeline with a list of N&K
         with pytest.warns(UserWarning, match="No initial shift can be"):
@@ -706,13 +726,7 @@ class TestAffineCoreg:
                     coreg.NuthKaab(initial_shift=is3),
                 ]
             )
-
-        if is1 is None:
-            assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
-        else:
-            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
-        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+        test_results(pipeline, is1)
 
         # Test N&K series with VerticalShift before
         with pytest.warns(UserWarning, match="No initial shift can be"):
@@ -722,10 +736,7 @@ class TestAffineCoreg:
                 + coreg.NuthKaab(initial_shift=is2)
                 + coreg.NuthKaab(initial_shift=is3)
             )
-
-        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+        test_results(pipeline, is1=None)
 
         # Test nested CoregPipeline
         with pytest.warns(UserWarning, match="No initial shift can be"):
@@ -735,10 +746,14 @@ class TestAffineCoreg:
                     coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is2), coreg.NuthKaab(initial_shift=is3)]),
                 ]
             )
-            if is1 is None:
-                assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
-            else:
-                assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+        test_results(pipeline, is1)
 
-            assert "initial_shift" not in pipeline.pipeline[1].pipeline[0].meta["inputs"]["affine"]
-            assert "initial_shift" not in pipeline.pipeline[1].pipeline[1].meta["inputs"]["affine"]
+        # Test nested CoregPipeline
+        with pytest.warns(UserWarning, match="No initial shift can be"):
+            pipeline = coreg.CoregPipeline(
+                [
+                    coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is1), coreg.NuthKaab(initial_shift=is3)]),
+                    coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is2), coreg.NuthKaab(initial_shift=is3)]),
+                ]
+            )
+        test_results(pipeline, is1)

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -681,7 +681,7 @@ class TestAffineCoreg:
         Test that coreg initial_shift management in function on its place in the pipeline
         """
         is1, is2, is3 = initial_shifts
-        with pytest.warns(UserWarning, match="No initial shift can be xxx"):
+        with pytest.warns(UserWarning, match="No initial shift can be"):
             if pre_coreg:
                 pipeline = (
                     coreg.VerticalShift()

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -672,22 +672,34 @@ class TestAffineCoreg:
         assert [pipeline.pipeline[1].meta["outputs"]["affine"][k] for k in shifts] == shifts_out_nk2  # type: ignore
 
     @pytest.mark.parametrize(
-        "initial_shifts", [[None, (8, 4, 0), None], [None, None, (8, 4, 0)], [(8, 4, 0), (8, 4, 0), None]]
+        "initial_shifts",
+        [[None, (8, 4, 0), None], [None, None, (8, 4, 0)], [(8, 4, 0), (8, 4, 0), None]],
+        "pre_coreg",
+        [True, False],
     )
-    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any]) -> None:
+    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any], pre_coreg: bool) -> None:
         """
-        Test that the initial_shift does not impact fit_and_apply process.
+        Test that coreg initial_shift management in function on its place in the pipeline
         """
         is1, is2, is3 = initial_shifts
         with pytest.warns(UserWarning, match="No initial shift can be xxx"):
-            pipeline = (
-                coreg.NuthKaab(initial_shift=is1)
-                + coreg.NuthKaab(initial_shift=is2)
-                + coreg.NuthKaab(initial_shift=is3)
-            )
-            if is1 is not None:
-                assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+            if pre_coreg:
+                pipeline = (
+                    coreg.VerticalShift()
+                    + coreg.NuthKaab(initial_shift=is1)
+                    + coreg.NuthKaab(initial_shift=is2)
+                    + coreg.NuthKaab(initial_shift=is3)
+                )
             else:
-                assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
-            assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-            assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]
+                pipeline = (
+                    coreg.NuthKaab(initial_shift=is1)
+                    + coreg.NuthKaab(initial_shift=is2)
+                    + coreg.NuthKaab(initial_shift=is3)
+                )
+
+        if is1 is not None and pre_coreg is False:
+            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+        else:
+            assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -679,6 +679,15 @@ class TestAffineCoreg:
         Test that the initial_shift does not impact fit_and_apply process.
         """
         is1, is2, is3 = initial_shifts
-        """pipeline = (
-            coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is3)
-        )"""
+        with pytest.warns(UserWarning, match="No initial shift can be xxx"):
+            pipeline = (
+                coreg.NuthKaab(initial_shift=is1)
+                + coreg.NuthKaab(initial_shift=is2)
+                + coreg.NuthKaab(initial_shift=is3)
+            )
+            if is1 is not None:
+                assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
+            else:
+                assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+            assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+            assert "initial_shift" not in pipeline.pipeline[2].meta["inputs"]["affine"]

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -729,16 +729,12 @@ class TestAffineCoreg:
 
         # Test nested CoregPipeline
         with pytest.warns(UserWarning, match="No initial shift can be"):
-            """pipeline = coreg.NuthKaab(initial_shift=is1) + coreg.CoregPipeline(
-                coreg.NuthKaab(initial_shift=is2) + coreg.NuthKaab(initial_shift=is3)
-            )"""
             pipeline = coreg.CoregPipeline(
                 [
                     coreg.NuthKaab(initial_shift=is1),
                     coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is2), coreg.NuthKaab(initial_shift=is3)]),
                 ]
             )
-
             if is1 is None:
                 assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
             else:

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -743,5 +743,6 @@ class TestAffineCoreg:
                 assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
             else:
                 assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == is1
-            assert "initial_shift" not in pipeline.pipeline[1].pipeline.pipeline[0].meta["inputs"]["affine"]
-            assert "initial_shift" not in pipeline.pipeline[1].pipeline.pipeline[1].meta["inputs"]["affine"]
+
+            assert "initial_shift" not in pipeline.pipeline[1].pipeline[0].meta["inputs"]["affine"]
+            assert "initial_shift" not in pipeline.pipeline[1].pipeline[1].meta["inputs"]["affine"]

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -680,7 +680,6 @@ class TestAffineCoreg:
 
         # Automatic pipeline
         pipeline = coreg.NuthKaab(initial_shift=initial_shift) + coreg.NuthKaab(initial_shift=None)
-        print(initial_shift)
         if initial_shift is not None:
             assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == initial_shift
         else:

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -13,6 +13,7 @@ import pytest
 import rasterio as rio
 import scipy.optimize
 from geoutils import Raster, Vector
+from geoutils._typing import Number
 from geoutils.raster.geotransformations import _translate
 from scipy.ndimage import binary_dilation
 
@@ -631,3 +632,46 @@ class TestAffineCoreg:
 
         assert dem_aligned_is.transform == dem_aligned.transform
         assert dem_aligned_is.crs == dem_aligned.crs
+
+    @pytest.mark.parametrize("initial_shift", [None, (8, 4, 0)])
+    def test_pipeline_initial_shift(self, initial_shift: tuple[Number, Number, Number] | None) -> None:
+        """
+        Test that the initial_shift does not impact fit_and_apply process.
+        """
+        ref = load_examples()[0]
+        shift = (10, 2, 0)
+        ref_shifted = ref.translate(shift[0], shift[1]) + shift[2]
+        shifts = ["shift_x", "shift_y", "shift_z"]
+
+        # Handmade NuthKaab pipeline
+        nk_1 = coreg.NuthKaab(initial_shift=initial_shift)
+        nk_1.fit(reference_elev=ref, to_be_aligned_elev=ref_shifted, random_state=42)
+        shifts_out_nk1 = [nk_1.meta["outputs"]["affine"][k] for k in shifts]  # type: ignore
+        output_tmp = nk_1.apply(elev=ref_shifted)
+        nk_2 = coreg.NuthKaab(initial_shift=None)
+        nk_2.fit(reference_elev=ref, to_be_aligned_elev=output_tmp, random_state=42)
+        shifts_out_nk2 = [nk_2.meta["outputs"]["affine"][k] for k in shifts]  # type: ignore
+
+        # Automatic pipeline
+        pipeline = coreg.NuthKaab(initial_shift=initial_shift) + coreg.NuthKaab(initial_shift=None)
+        if initial_shift:
+            assert pipeline.pipeline[0].meta["inputs"]["affine"]["initial_shift"] == initial_shift
+        else:
+            assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
+        assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
+        pipeline.fit(ref, ref_shifted, random_state=42)
+        assert [pipeline.pipeline[0].meta["outputs"]["affine"][k] for k in shifts] == shifts_out_nk1  # type: ignore
+        assert [pipeline.pipeline[1].meta["outputs"]["affine"][k] for k in shifts] == shifts_out_nk2  # type: ignore
+
+    @pytest.mark.parametrize(
+        "initial_shifts", [[None, (8, 4, 0), None], [None, None, (8, 4, 0)], [(8, 4, 0), (8, 4, 0), None]]
+    )
+    def test_pipeline_initial_shift_errors(self, initial_shifts: list[Any]) -> None:
+        """
+        Test that the initial_shift does not impact fit_and_apply process.
+        """
+        is1, is2, is3 = initial_shifts
+        pipeline = (
+            coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is3)
+        )
+        print(pipeline)

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -634,22 +634,30 @@ class TestAffineCoreg:
         assert dem_aligned_is.crs == dem_aligned.crs
 
     @pytest.mark.parametrize("initial_shift", [None, (8, 4, 0)])
-    def test_pipeline_initial_shift(self, initial_shift: tuple[Number, Number, Number] | None) -> None:
+    @pytest.mark.parametrize("array", [True, False])
+    def test_pipeline_initial_shift(self, initial_shift: tuple[Number, Number, Number] | None, array: bool) -> None:
         """
-        Test that the initial_shift does not impact fit_and_apply process.
+        Test that the initial_shift in the first coreg of a CoregPipeline works well
         """
         ref = load_examples()[0]
         shift = (10, 2, 0)
         ref_shifted = ref.translate(shift[0], shift[1]) + shift[2]
         shifts = ["shift_x", "shift_y", "shift_z"]
+        warnings.filterwarnings("ignore", category=UserWarning)
+
+        if array:
+            transform = ref.transform
+            ref = ref.data
+        else:
+            transform = None
 
         # Handmade NuthKaab pipeline
         nk_1 = coreg.NuthKaab(initial_shift=initial_shift)
-        nk_1.fit(reference_elev=ref, to_be_aligned_elev=ref_shifted, random_state=42)
+        nk_1.fit(reference_elev=ref, transform=transform, to_be_aligned_elev=ref_shifted, random_state=42)
         shifts_out_nk1 = [nk_1.meta["outputs"]["affine"][k] for k in shifts]  # type: ignore
         output_tmp = nk_1.apply(elev=ref_shifted)
         nk_2 = coreg.NuthKaab(initial_shift=None)
-        nk_2.fit(reference_elev=ref, to_be_aligned_elev=output_tmp, random_state=42)
+        nk_2.fit(reference_elev=ref, transform=transform, to_be_aligned_elev=output_tmp, random_state=42)
         shifts_out_nk2 = [nk_2.meta["outputs"]["affine"][k] for k in shifts]  # type: ignore
 
         # Automatic pipeline
@@ -659,7 +667,7 @@ class TestAffineCoreg:
         else:
             assert "initial_shift" not in pipeline.pipeline[0].meta["inputs"]["affine"]
         assert "initial_shift" not in pipeline.pipeline[1].meta["inputs"]["affine"]
-        pipeline.fit(ref, ref_shifted, random_state=42)
+        pipeline.fit(reference_elev=ref, to_be_aligned_elev=ref_shifted, transform=transform, random_state=42)
         assert [pipeline.pipeline[0].meta["outputs"]["affine"][k] for k in shifts] == shifts_out_nk1  # type: ignore
         assert [pipeline.pipeline[1].meta["outputs"]["affine"][k] for k in shifts] == shifts_out_nk2  # type: ignore
 
@@ -671,7 +679,6 @@ class TestAffineCoreg:
         Test that the initial_shift does not impact fit_and_apply process.
         """
         is1, is2, is3 = initial_shifts
-        pipeline = (
+        """pipeline = (
             coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is1) + coreg.NuthKaab(initial_shift=is3)
-        )
-        print(pipeline)
+        )"""

--- a/tests/test_coreg/test_affine.py
+++ b/tests/test_coreg/test_affine.py
@@ -729,8 +729,14 @@ class TestAffineCoreg:
 
         # Test nested CoregPipeline
         with pytest.warns(UserWarning, match="No initial shift can be"):
-            pipeline = coreg.NuthKaab(initial_shift=is1) + coreg.CoregPipeline(
+            """pipeline = coreg.NuthKaab(initial_shift=is1) + coreg.CoregPipeline(
                 coreg.NuthKaab(initial_shift=is2) + coreg.NuthKaab(initial_shift=is3)
+            )"""
+            pipeline = coreg.CoregPipeline(
+                [
+                    coreg.NuthKaab(initial_shift=is1),
+                    coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is2), coreg.NuthKaab(initial_shift=is3)]),
+                ]
             )
 
             if is1 is None:

--- a/tests/test_dem.py
+++ b/tests/test_dem.py
@@ -539,29 +539,6 @@ class TestDEM:
             # Output DEM
             assert dem_aligned.raster_equal(manually_aligned, warn_failure_reason=True)
 
-    @staticmethod
-    @pytest.mark.parametrize(
-        "pipeline",
-        [
-            xdem.coreg.NuthKaab() + xdem.coreg.VerticalShift(),
-            xdem.coreg.NuthKaab(initial_shift=(10, 5)) + xdem.coreg.VerticalShift(),
-            xdem.coreg.VerticalShift() + xdem.coreg.NuthKaab(initial_shift=(10, 5)),
-            xdem.coreg.NuthKaab(initial_shift=(10, 5))
-            + xdem.coreg.VerticalShift()
-            + xdem.coreg.NuthKaab(initial_shift=(10, 5)),
-            xdem.coreg.VerticalShift()
-            + xdem.coreg.NuthKaab(initial_shift=(10, 5))
-            + xdem.coreg.NuthKaab(initial_shift=(10, 5)),
-        ],
-    )
-    def test_nuthkaab_coregpipeline(pipeline: Any) -> None:
-        """
-        Test initial shift cancellation in coreg pipeline method
-        """
-
-        for method in pipeline.pipeline:
-            assert "initial_shift" not in method.meta["inputs"]["affine"]
-
     def test_estimate_uncertainty(self) -> None:
 
         # Import optional skgstat or skip test

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2010,11 +2010,6 @@ class Coreg:
         if not isinstance(other, Coreg):
             raise ValueError(f"Incompatible add type: {type(other)}. Expected 'Coreg' subclass")
 
-        # Cancel possible initial shift(s) in coreg(s) in "other"
-        if "affine" in other.meta["inputs"] and "initial_shift" in other.meta["inputs"]["affine"]:
-            warnings.warn(message="No initial shift can be xxx", category=UserWarning)
-            del other.meta["inputs"]["affine"]["initial_shift"]
-
         return CoregPipeline([self, other])
 
     @property
@@ -2892,7 +2887,26 @@ class CoregPipeline(Coreg):
 
         :param: Processing steps to run in the sequence they are given.
         """
-        self.pipeline = pipeline
+
+        def delete_is(pipeline: CoregPipeline, init: bool = False):
+            """Delete initial shift according to its place in the pipeline"""
+            for i, step in enumerate(pipeline):
+                if i == 0 and not init:
+                    continue
+
+                if not isinstance(step, CoregPipeline):
+                    if "affine" in step.meta["inputs"] and "initial_shift" in step.meta["inputs"]["affine"]:
+                        warnings.warn(
+                            message="No initial shift can be initialized in a coregistration pipeline other "
+                            "than for the first element.",
+                            category=UserWarning,
+                        )
+                        del step.meta["inputs"]["affine"]["initial_shift"]
+                else:
+                    delete_is(step, init=True)
+            return pipeline
+
+        self.pipeline = delete_is(pipeline)
 
         super().__init__()
 
@@ -3169,16 +3183,6 @@ class CoregPipeline(Coreg):
             other = [other]
 
         pipelines = self.pipeline + other
-
-        # Cancel possible initial shift(s) in coreg(s) in "other"
-        for method in pipelines[1:]:
-            if "affine" in method.meta["inputs"] and "initial_shift" in method.meta["inputs"]["affine"]:
-                warnings.warn(
-                    message="No initial shift can be initialized in a coregistration pipeline other "
-                    "than for the first element.",
-                    category=UserWarning,
-                )
-                del method.meta["inputs"]["affine"]["initial_shift"]
 
         return CoregPipeline(pipelines)
 

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -130,7 +130,6 @@ def _preprocess_coreg_fit_raster_raster(
     area_or_point: Literal["Area", "Point"] | None = None,
 ) -> tuple[NDArrayf, NDArrayf, NDArrayb, affine.Affine, rio.crs.CRS, Literal["Area", "Point"] | None]:
     """Pre-processing and checks of fit() for two raster input."""
-
     # Validate that both inputs are valid array-like (or Raster) types.
     if not all(isinstance(dem, (np.ndarray, gu.Raster)) for dem in (reference_dem, dem_to_be_aligned)):
         raise ValueError(
@@ -388,6 +387,7 @@ def _preprocess_coreg_fit(
 
     # If both inputs are points, simply reproject to the same CRS
     else:
+
         ref_elev = reference_elev if isinstance(reference_elev, gpd.GeoDataFrame) else reference_elev.ds  # type: ignore
         tba_elev = (
             to_be_aligned_elev
@@ -2010,11 +2010,11 @@ class Coreg:
         if not isinstance(other, Coreg):
             raise ValueError(f"Incompatible add type: {type(other)}. Expected 'Coreg' subclass")
 
-        # Cancel possible initial shift(s) in CoregPipeline case
+        """# Cancel possible initial shift(s) in CoregPipeline case
         if "affine" in self.meta["inputs"] and "initial_shift" in self.meta["inputs"]["affine"]:
             del self.meta["inputs"]["affine"]["initial_shift"]
         if "affine" in other.meta["inputs"] and "initial_shift" in other.meta["inputs"]["affine"]:
-            del other.meta["inputs"]["affine"]["initial_shift"]
+            del other.meta["inputs"]["affine"]["initial_shift"]"""
 
         return CoregPipeline([self, other])
 
@@ -2278,6 +2278,8 @@ class Coreg:
         :param random_state: Random state or seed number to use for calculations (to fix random sampling).
         """
 
+        print("def fit", random_state)
+
         if weights is not None:
             raise NotImplementedError("Weights have not yet been implemented")
 
@@ -2307,11 +2309,20 @@ class Coreg:
         # Apply the shift to the source dem if given
         initial_shift_apply = False
         if self._meta["inputs"]["affine"].get("initial_shift") is not None:
-            shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
-            shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
+
             # shift_z is currently always equal to zero
-            reference_elev = reference_elev.translate(-shift_x, -shift_y)  # type: ignore
-            initial_shift_apply = True
+            if isinstance(reference_elev, gu.Raster):
+                shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
+                shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
+                reference_elev = reference_elev.translate(-shift_x, -shift_y)  # type: ignore
+                initial_shift_apply = True
+
+            else:
+                shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
+                shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
+                transform = _translate(transform, xoff=-shift_x, yoff=-shift_y)
+
+                initial_shift_apply = True
 
         # Pre-process the inputs, by reprojecting and converting to arrays
         ref_elev, tba_elev, inlier_mask, transform, crs, area_or_point, z_name = _preprocess_coreg_fit(
@@ -2345,6 +2356,8 @@ class Coreg:
                 bias_vars[var] = gu.raster.get_array_and_mask(bias_vars[var])[0]
 
             main_args.update({"bias_vars": bias_vars})
+
+        main_args["area_or_point"] = "area"
 
         # Run the associated fitting function, which has fallback logic for "raster-raster", "raster-point" or
         # "point-point" depending on what is available for a certain Coreg function
@@ -2889,6 +2902,9 @@ class CoregPipeline(Coreg):
         :param: Processing steps to run in the sequence they are given.
         """
         self.pipeline = pipeline
+        for coreg in pipeline[1:]:
+            if "initial_shift" in coreg.meta["inputs"]["affine"]:
+                logging.warning("No initial shift can be xxx")
 
         super().__init__()
 
@@ -2985,6 +3001,7 @@ class CoregPipeline(Coreg):
         **kwargs: Any,
     ) -> CoregType:
 
+        print("def fit pipeline", type(reference_elev))
         # Check if subsample arguments are different from their default value for any of the coreg steps:
         # get default value in argument spec and "subsample" stored in meta, and compare both are consistent
         argspec = [inspect.getfullargspec(c.__class__) for c in self.pipeline]
@@ -3002,7 +3019,7 @@ class CoregPipeline(Coreg):
             # Filter warnings of individual pipelines now that the one above was raised
             warnings.filterwarnings("ignore", message="Subsample argument passed to*", category=UserWarning)
 
-        # Pre-process the inputs, by reprojecting and subsampling, without any subsampling (done in each step)
+        """# Pre-process the inputs, by reprojecting and subsampling, without any subsampling (done in each step)
         ref_dem, tba_dem, inlier_mask, transform, crs, area_or_point, z_name = _preprocess_coreg_fit(
             reference_elev=reference_elev,
             to_be_aligned_elev=to_be_aligned_elev,
@@ -3011,18 +3028,17 @@ class CoregPipeline(Coreg):
             crs=crs,
             area_or_point=area_or_point,
             z_name=z_name,
-        )
-        tba_dem_mod = tba_dem.copy()
-        out_transform = transform
+        )"""
+        to_be_aligned_elev_mod = to_be_aligned_elev.copy()
+        # out_transform = transform
 
         for i, coreg in enumerate(self.pipeline):
             logging.debug("Running pipeline step: %d / %d", i + 1, len(self.pipeline))
 
             main_args_fit = {
-                "reference_elev": ref_dem,
-                "to_be_aligned_elev": tba_dem_mod,
+                "reference_elev": reference_elev,
+                "to_be_aligned_elev": to_be_aligned_elev_mod,
                 "inlier_mask": inlier_mask,
-                "transform": out_transform,
                 "crs": crs,
                 "z_name": z_name,
                 "weights": weights,
@@ -3030,7 +3046,7 @@ class CoregPipeline(Coreg):
                 "random_state": random_state,
             }
 
-            main_args_apply = {"elev": tba_dem_mod, "transform": out_transform, "crs": crs, "z_name": z_name}
+            main_args_apply = {"elev": to_be_aligned_elev_mod, "crs": crs, "z_name": z_name}
 
             # If non-affine method that expects a bias_vars argument
             if coreg._needs_vars:
@@ -3045,10 +3061,10 @@ class CoregPipeline(Coreg):
             # Step apply: one output for a geodataframe, two outputs for array/transform
             # We only run this step if it's not the last, otherwise it is unused!
             if i != (len(self.pipeline) - 1):
-                if isinstance(tba_dem_mod, gpd.GeoDataFrame):
-                    tba_dem_mod = coreg.apply(**main_args_apply)
+                if isinstance(to_be_aligned_elev_mod, gpd.GeoDataFrame):
+                    to_be_aligned_elev_mod = coreg.apply(**main_args_apply)
                 else:
-                    tba_dem_mod, out_transform = coreg.apply(**main_args_apply)
+                    to_be_aligned_elev_mod = coreg.apply(**main_args_apply)
 
         # Flag that the fitting function has been called.
         self._fit_called = True

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2310,7 +2310,7 @@ class Coreg:
             shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
 
             # shift_z is currently always equal to zero
-            if isinstance(reference_elev, gu.Raster):
+            if isinstance(reference_elev, (gu.Raster, gpd.GeoDataFrame, gu.PointCloud)):
                 reference_elev = reference_elev.translate(-shift_x, -shift_y)  # type: ignore
                 initial_shift_apply = True
             else:

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2313,7 +2313,6 @@ class Coreg:
             if isinstance(reference_elev, gu.Raster):
                 reference_elev = reference_elev.translate(-shift_x, -shift_y)  # type: ignore
                 initial_shift_apply = True
-
             else:
                 transform = _translate(transform, xoff=-shift_x, yoff=-shift_y)
                 initial_shift_apply = True

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2278,7 +2278,7 @@ class Coreg:
         :param random_state: Random state or seed number to use for calculations (to fix random sampling).
         """
 
-        print("def fit", random_state)
+        print("def fit", random_state, transform)
 
         if weights is not None:
             raise NotImplementedError("Weights have not yet been implemented")
@@ -2320,8 +2320,8 @@ class Coreg:
             else:
                 shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
                 shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
-                transform = _translate(transform, xoff=-shift_x, yoff=-shift_y)
 
+                transform = _translate(transform, xoff=-shift_x, yoff=-shift_y)
                 initial_shift_apply = True
 
         # Pre-process the inputs, by reprojecting and converting to arrays
@@ -2451,6 +2451,8 @@ class Coreg:
 
         :returns: The transformed DEM.
         """
+        print("input apply", type(elev))
+
         if not self._fit_called and self._meta["outputs"]["affine"].get("matrix") is None:
             raise AssertionError(".fit() does not seem to have been called yet")
 
@@ -2486,6 +2488,7 @@ class Coreg:
         )
 
         # Only return object if raster or geodataframe, also return transform if object was an array
+        print("output apply", type(applied_elev))
         if isinstance(applied_elev, (Raster, gpd.GeoDataFrame, PointCloud)):
             return applied_elev
         else:
@@ -2903,7 +2906,7 @@ class CoregPipeline(Coreg):
         """
         self.pipeline = pipeline
         for coreg in pipeline[1:]:
-            if "initial_shift" in coreg.meta["inputs"]["affine"]:
+            if "affine" in coreg.meta["inputs"] and "initial_shift" in coreg.meta["inputs"]["affine"]:
                 logging.warning("No initial shift can be xxx")
 
         super().__init__()
@@ -3029,15 +3032,15 @@ class CoregPipeline(Coreg):
             area_or_point=area_or_point,
             z_name=z_name,
         )"""
-        to_be_aligned_elev_mod = to_be_aligned_elev.copy()
-        # out_transform = transform
+        tba_dem_mod = to_be_aligned_elev.copy()
 
         for i, coreg in enumerate(self.pipeline):
             logging.debug("Running pipeline step: %d / %d", i + 1, len(self.pipeline))
-
+            print("ici", i, type(reference_elev), transform is None)
             main_args_fit = {
                 "reference_elev": reference_elev,
-                "to_be_aligned_elev": to_be_aligned_elev_mod,
+                "to_be_aligned_elev": tba_dem_mod,
+                "transform": transform,
                 "inlier_mask": inlier_mask,
                 "crs": crs,
                 "z_name": z_name,
@@ -3046,7 +3049,7 @@ class CoregPipeline(Coreg):
                 "random_state": random_state,
             }
 
-            main_args_apply = {"elev": to_be_aligned_elev_mod, "crs": crs, "z_name": z_name}
+            main_args_apply = {"elev": tba_dem_mod, "transform": transform, "crs": crs, "z_name": z_name}
 
             # If non-affine method that expects a bias_vars argument
             if coreg._needs_vars:
@@ -3061,10 +3064,11 @@ class CoregPipeline(Coreg):
             # Step apply: one output for a geodataframe, two outputs for array/transform
             # We only run this step if it's not the last, otherwise it is unused!
             if i != (len(self.pipeline) - 1):
-                if isinstance(to_be_aligned_elev_mod, gpd.GeoDataFrame):
-                    to_be_aligned_elev_mod = coreg.apply(**main_args_apply)
+                print(main_args_apply)
+                if isinstance(tba_dem_mod, (Raster, gpd.GeoDataFrame, PointCloud)):
+                    tba_dem_mod = coreg.apply(**main_args_apply)
                 else:
-                    to_be_aligned_elev_mod = coreg.apply(**main_args_apply)
+                    tba_dem_mod, transform = coreg.apply(**main_args_apply)
 
         # Flag that the fitting function has been called.
         self._fit_called = True

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2888,25 +2888,31 @@ class CoregPipeline(Coreg):
         :param: Processing steps to run in the sequence they are given.
         """
 
-        def delete_is(pipeline: list[Coreg], init: bool = False) -> list[Coreg]:
-            """Delete initial shift according to its place in the pipeline"""
-            for i, step in enumerate(pipeline):
-                if i == 0 and not init:
-                    continue
+        def put_coreg_in_series(pipeline: list[Coreg]) -> list[Coreg]:
+            """
+            Translate all nested CoregPipeline in Coreg series
 
+            :param pipeline: Processing steps to run in the sequence they are given.
+            :return: list of simple Coreg(s).
+            """
+            list_coreg = []
+            for step in pipeline:
                 if not isinstance(step, CoregPipeline):
-                    if "affine" in step.meta["inputs"] and "initial_shift" in step.meta["inputs"]["affine"]:
-                        warnings.warn(
-                            message="No initial shift can be initialized in a coregistration pipeline other "
-                            "than for the first element.",
-                            category=UserWarning,
-                        )
-                        del step.meta["inputs"]["affine"]["initial_shift"]
+                    list_coreg.append(step)
                 else:
-                    delete_is(step, init=True)  # type: ignore
-            return pipeline
+                    list_coreg = list_coreg + put_coreg_in_series(step)  # type: ignore
+            return list_coreg
 
-        self.pipeline = delete_is(pipeline)
+        self.pipeline = put_coreg_in_series(pipeline)
+
+        for i, step in enumerate(self.pipeline):
+            if i > 0 and "affine" in step.meta["inputs"] and "initial_shift" in step.meta["inputs"]["affine"]:
+                warnings.warn(
+                    message="No initial shift can be initialized in a coregistration pipeline other "
+                    "than for the first element.",
+                    category=UserWarning,
+                )
+                del step.meta["inputs"]["affine"]["initial_shift"]
 
         super().__init__()
 

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -3173,7 +3173,11 @@ class CoregPipeline(Coreg):
         # Cancel possible initial shift(s) in coreg(s) in "other"
         for method in pipelines[1:]:
             if "affine" in method.meta["inputs"] and "initial_shift" in method.meta["inputs"]["affine"]:
-                warnings.warn(message="No initial shift can be xxx", category=UserWarning)
+                warnings.warn(
+                    message="No initial shift can be initialized in a coregistration pipeline other "
+                    "than for the first element.",
+                    category=UserWarning,
+                )
                 del method.meta["inputs"]["affine"]["initial_shift"]
 
         return CoregPipeline(pipelines)

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2908,8 +2908,9 @@ class CoregPipeline(Coreg):
         for i, step in enumerate(self.pipeline):
             if i > 0 and "affine" in step.meta["inputs"] and "initial_shift" in step.meta["inputs"]["affine"]:
                 warnings.warn(
-                    message="No initial shift can be initialized in a coregistration pipeline other "
-                    "than for the first element.",
+                    message="No initial shift can be defined in a coregistration pipeline other than for the first "
+                    f"step. Overidding to initial_shift=None for step number {i}. Remove initial shift parameters"
+                    " outside of the first step to silence this warning.",
                     category=UserWarning,
                 )
                 del step.meta["inputs"]["affine"]["initial_shift"]

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -130,6 +130,7 @@ def _preprocess_coreg_fit_raster_raster(
     area_or_point: Literal["Area", "Point"] | None = None,
 ) -> tuple[NDArrayf, NDArrayf, NDArrayb, affine.Affine, rio.crs.CRS, Literal["Area", "Point"] | None]:
     """Pre-processing and checks of fit() for two raster input."""
+
     # Validate that both inputs are valid array-like (or Raster) types.
     if not all(isinstance(dem, (np.ndarray, gu.Raster)) for dem in (reference_dem, dem_to_be_aligned)):
         raise ValueError(
@@ -387,7 +388,6 @@ def _preprocess_coreg_fit(
 
     # If both inputs are points, simply reproject to the same CRS
     else:
-
         ref_elev = reference_elev if isinstance(reference_elev, gpd.GeoDataFrame) else reference_elev.ds  # type: ignore
         tba_elev = (
             to_be_aligned_elev
@@ -2010,7 +2010,7 @@ class Coreg:
         if not isinstance(other, Coreg):
             raise ValueError(f"Incompatible add type: {type(other)}. Expected 'Coreg' subclass")
 
-        # Cancel possible initial shift(s) in "other" coreg(s)
+        # Cancel possible initial shift(s) in coreg(s) in "other"
         if "affine" in other.meta["inputs"] and "initial_shift" in other.meta["inputs"]["affine"]:
             warnings.warn(message="No initial shift can be xxx", category=UserWarning)
             del other.meta["inputs"]["affine"]["initial_shift"]
@@ -2306,18 +2306,15 @@ class Coreg:
         # Apply the shift to the source dem if given
         initial_shift_apply = False
         if self._meta["inputs"]["affine"].get("initial_shift") is not None:
+            shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
+            shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
 
             # shift_z is currently always equal to zero
             if isinstance(reference_elev, gu.Raster):
-                shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
-                shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
                 reference_elev = reference_elev.translate(-shift_x, -shift_y)  # type: ignore
                 initial_shift_apply = True
 
             else:
-                shift_x = self._meta["inputs"]["affine"]["initial_shift"][0]  # type: ignore
-                shift_y = self._meta["inputs"]["affine"]["initial_shift"][1]  # type: ignore
-
                 transform = _translate(transform, xoff=-shift_x, yoff=-shift_y)
                 initial_shift_apply = True
 
@@ -2353,8 +2350,6 @@ class Coreg:
                 bias_vars[var] = gu.raster.get_array_and_mask(bias_vars[var])[0]
 
             main_args.update({"bias_vars": bias_vars})
-
-        main_args["area_or_point"] = "area"
 
         # Run the associated fitting function, which has fallback logic for "raster-raster", "raster-point" or
         # "point-point" depending on what is available for a certain Coreg function
@@ -2448,7 +2443,6 @@ class Coreg:
 
         :returns: The transformed DEM.
         """
-
         if not self._fit_called and self._meta["outputs"]["affine"].get("matrix") is None:
             raise AssertionError(".fit() does not seem to have been called yet")
 
@@ -3013,16 +3007,6 @@ class CoregPipeline(Coreg):
             # Filter warnings of individual pipelines now that the one above was raised
             warnings.filterwarnings("ignore", message="Subsample argument passed to*", category=UserWarning)
 
-        """# Pre-process the inputs, by reprojecting and subsampling, without any subsampling (done in each step)
-        ref_dem, tba_dem, inlier_mask, transform, crs, area_or_point, z_name = _preprocess_coreg_fit(
-            reference_elev=reference_elev,
-            to_be_aligned_elev=to_be_aligned_elev,
-            inlier_mask=inlier_mask,
-            transform=transform,
-            crs=crs,
-            area_or_point=area_or_point,
-            z_name=z_name,
-        )"""
         tba_dem_mod = to_be_aligned_elev.copy()
 
         for i, coreg in enumerate(self.pipeline):
@@ -3187,7 +3171,7 @@ class CoregPipeline(Coreg):
 
         pipelines = self.pipeline + other
 
-        # Cancel possible initial shift(s) in CoregPipeline case
+        # Cancel possible initial shift(s) in coreg(s) in "other"
         for method in pipelines[1:]:
             if "affine" in method.meta["inputs"] and "initial_shift" in method.meta["inputs"]["affine"]:
                 warnings.warn(message="No initial shift can be xxx", category=UserWarning)

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2010,11 +2010,10 @@ class Coreg:
         if not isinstance(other, Coreg):
             raise ValueError(f"Incompatible add type: {type(other)}. Expected 'Coreg' subclass")
 
-        """# Cancel possible initial shift(s) in CoregPipeline case
-        if "affine" in self.meta["inputs"] and "initial_shift" in self.meta["inputs"]["affine"]:
-            del self.meta["inputs"]["affine"]["initial_shift"]
+        # Cancel possible initial shift(s) in "other" coreg(s)
         if "affine" in other.meta["inputs"] and "initial_shift" in other.meta["inputs"]["affine"]:
-            del other.meta["inputs"]["affine"]["initial_shift"]"""
+            warnings.warn(message="No initial shift can be xxx", category=UserWarning)
+            del other.meta["inputs"]["affine"]["initial_shift"]
 
         return CoregPipeline([self, other])
 
@@ -2278,8 +2277,6 @@ class Coreg:
         :param random_state: Random state or seed number to use for calculations (to fix random sampling).
         """
 
-        print("def fit", random_state, transform)
-
         if weights is not None:
             raise NotImplementedError("Weights have not yet been implemented")
 
@@ -2451,7 +2448,6 @@ class Coreg:
 
         :returns: The transformed DEM.
         """
-        print("input apply", type(elev))
 
         if not self._fit_called and self._meta["outputs"]["affine"].get("matrix") is None:
             raise AssertionError(".fit() does not seem to have been called yet")
@@ -2488,7 +2484,6 @@ class Coreg:
         )
 
         # Only return object if raster or geodataframe, also return transform if object was an array
-        print("output apply", type(applied_elev))
         if isinstance(applied_elev, (Raster, gpd.GeoDataFrame, PointCloud)):
             return applied_elev
         else:
@@ -2905,9 +2900,6 @@ class CoregPipeline(Coreg):
         :param: Processing steps to run in the sequence they are given.
         """
         self.pipeline = pipeline
-        for coreg in pipeline[1:]:
-            if "affine" in coreg.meta["inputs"] and "initial_shift" in coreg.meta["inputs"]["affine"]:
-                logging.warning("No initial shift can be xxx")
 
         super().__init__()
 
@@ -3004,7 +2996,6 @@ class CoregPipeline(Coreg):
         **kwargs: Any,
     ) -> CoregType:
 
-        print("def fit pipeline", type(reference_elev))
         # Check if subsample arguments are different from their default value for any of the coreg steps:
         # get default value in argument spec and "subsample" stored in meta, and compare both are consistent
         argspec = [inspect.getfullargspec(c.__class__) for c in self.pipeline]
@@ -3036,7 +3027,7 @@ class CoregPipeline(Coreg):
 
         for i, coreg in enumerate(self.pipeline):
             logging.debug("Running pipeline step: %d / %d", i + 1, len(self.pipeline))
-            print("ici", i, type(reference_elev), transform is None)
+
             main_args_fit = {
                 "reference_elev": reference_elev,
                 "to_be_aligned_elev": tba_dem_mod,
@@ -3064,7 +3055,6 @@ class CoregPipeline(Coreg):
             # Step apply: one output for a geodataframe, two outputs for array/transform
             # We only run this step if it's not the last, otherwise it is unused!
             if i != (len(self.pipeline) - 1):
-                print(main_args_apply)
                 if isinstance(tba_dem_mod, (Raster, gpd.GeoDataFrame, PointCloud)):
                     tba_dem_mod = coreg.apply(**main_args_apply)
                 else:
@@ -3198,8 +3188,9 @@ class CoregPipeline(Coreg):
         pipelines = self.pipeline + other
 
         # Cancel possible initial shift(s) in CoregPipeline case
-        for method in pipelines:
+        for method in pipelines[1:]:
             if "affine" in method.meta["inputs"] and "initial_shift" in method.meta["inputs"]["affine"]:
+                warnings.warn(message="No initial shift can be xxx", category=UserWarning)
                 del method.meta["inputs"]["affine"]["initial_shift"]
 
         return CoregPipeline(pipelines)

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2888,7 +2888,7 @@ class CoregPipeline(Coreg):
         :param: Processing steps to run in the sequence they are given.
         """
 
-        def delete_is(pipeline: CoregPipeline, init: bool = False):
+        def delete_is(pipeline: list[Coreg], init: bool = False) -> list[Coreg]:
             """Delete initial shift according to its place in the pipeline"""
             for i, step in enumerate(pipeline):
                 if i == 0 and not init:
@@ -2903,7 +2903,7 @@ class CoregPipeline(Coreg):
                         )
                         del step.meta["inputs"]["affine"]["initial_shift"]
                 else:
-                    delete_is(step, init=True)
+                    delete_is(step, init=True)  # type: ignore
             return pipeline
 
         self.pipeline = delete_is(pipeline)

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -199,10 +199,10 @@ class BlockwiseCoreg:
             shift_y = coreg.meta["outputs"]["affine"].get("shift_y", np.nan)
             shift_z = coreg.meta["outputs"]["affine"].get("shift_z", np.nan)
 
-            x, y = (
+            x, y = to_be_aligned_elev.transform * (
                 tile_coords[2] + self.block_size_fit / 2,
                 tile_coords[0] + self.block_size_fit / 2,
-            ) * to_be_aligned_elev.transform  # type: ignore
+            )  # type: ignore
 
             self.x_coords.append(x)
             self.y_coords.append(y)


### PR DESCRIPTION
Resolves https://github.com/GlacioHack/xdem/issues/801

This PR proposes to put at the same level every `Coreg` in a `CoregPipeline` (removing nested `CoregPipeline`) and the use the `initial_shift` parameter in it.

## Nested CoregPipeline(s)

### Behavior 

With the actual `CorePipeline` `__init__`, nested CoregPipeline(s) can be accepted.
ex : 
```
coreg.CoregPipeline(
                [
                    coreg.NuthKaab(initial_shift=is1),
                    coreg.CoregPipeline([coreg.NuthKaab(initial_shift=is2), coreg.NuthKaab(initial_shift=is3)])
                ]
            )
```
But they does not pass the `fit()` function. So, we now put all the coreg in it in series like this: 
```
coreg.CoregPipeline(
                [
                    coreg.NuthKaab(initial_shift=is1),
                    coreg.NuthKaab(initial_shift=is2),
                    coreg.NuthKaab(initial_shift=is3)])
                ]
            )
```
#### Dev info

This change was done in the `CorePipeline` `__init__` (recursive function).

## Initial shift management in CoregPipeline

### Behavior 

- Accepted : `initial_shift` in the first method of the Pipeline
- Not accepted : `initial_shift` in all other method after => delete it

Warning message : **No initial shift can be defined in a coregistration pipeline other than for the first step. Overidding to initial_shift=None for step number [i]. Remove initial shift parameters outside of the first step to silence this warning.**

#### Dev info

Currently, removing all the initial shift was done in: 

- `Coreg.__add__` : to manage `coreg1 + coreg2`
- `CoregPipeline.__add__` : to manage `coreg1 + coreg2 + coreg3` (= `coregPipeline1 + coreg3`) and `CoregPileline(list_of_coreg)`

The fact to keep only the first initial shift if exists in the FIRST coreg was done just after the first point.

#### Preprocessing 

Had to remove the preprocess in the `CoregPipeline.fit()` [here](https://github.com/GlacioHack/xdem/blob/58180c65925f0fff5d7456bce1a206a8b45a9438/xdem/coreg/base.py#L3006)  and only use the existing preprocess in the `Coreg.fit()` to have the same result between `coreg1 + x` and `coreg1` in case of an `initial_shift`
<img width="909" height="317" alt="image" src="https://github.com/user-attachments/assets/9ba5ad9e-57a0-4741-a33c-5ae0b783ee51" />


