### PR TITLE
Avoid forking a multi-threaded parent in variogram sampling

### DIFF
--- a/tests/test_spatialstats.py
+++ b/tests/test_spatialstats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import threading
 import warnings
 from importlib.util import find_spec
 from typing import Any
@@ -539,6 +540,22 @@ class TestVariogram:
         # Test plotting of empirical variogram by itself
         if PLOT:
             xdem.spatialstats.plot_variogram(df2)
+
+    def test_sample_empirical_variogram_no_fork_warning(self) -> None:
+        """Forking a multi-threaded parent is deprecated and can deadlock the child."""
+
+        stop = threading.Event()
+        thread = threading.Thread(target=stop.wait)
+        thread.start()
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error", message=".*fork.*", category=DeprecationWarning)
+                xdem.spatialstats.sample_empirical_variogram(
+                    values=self.diff, subsample=10, random_state=42, n_variograms=2, n_jobs=2
+                )
+        finally:
+            stop.set()
+            thread.join()
 
     def test_sample_empirical_variogram_speed(self) -> None:
         """Verify that no speed is lost outside of routines on variogram sampling by comparing manually to skgstat"""

--- a/xdem/spatialstats.py
+++ b/xdem/spatialstats.py
@@ -1499,7 +1499,10 @@ def sample_empirical_variogram(
     else:
         logging.info("Using " + str(n_jobs) + " cores...")
 
-        pool = mp.Pool(n_jobs, maxtasksperchild=1)
+        # Forking a multi-threaded parent is deprecated and can deadlock the
+        # child, so fork from a clean process where that method exists.
+        start_method = "forkserver" if "forkserver" in mp.get_all_start_methods() else "spawn"
+        pool = mp.get_context(start_method).Pool(n_jobs, maxtasksperchild=1)
         list_argdict = [
             {"i": i, "imax": n_variograms, "random_state": list_random_state[i], **args, **kwargs}  # type: ignore
             for i in range(n_variograms)


### PR DESCRIPTION
Fixes #507

`sample_empirical_variogram` built its pool with `mp.Pool(...)`, which uses the default start method. On Linux that is `fork`, and forking a parent with live threads is what raises the `DeprecationWarning` in the issue. This uses `forkserver` where it exists and `spawn` otherwise, as suggested in the issue, so workers start from a process without threads.

Two things you should weigh, since they are not free:

- **Start-up cost.** `maxtasksperchild=1` recycles a worker after every variogram, so the method matters: `forkserver` forks from a pre-imported process and stays cheap, while `spawn` re-imports xdem each time. That is why the choice prefers `forkserver` rather than going straight to `spawn`.
- **Behaviour change for callers.** With `fork`, calling `sample_empirical_variogram(n_jobs>1)` from a plain script works; with `forkserver`/`spawn` the caller needs the `if __name__ == "__main__":` guard. Python 3.14 already changed the default on Linux, so this is where things are heading anyway, but it will affect scripts written against older behaviour.

On the test: it holds a thread open while sampling and turns the fork `DeprecationWarning` into an error, which reproduces the issue's conditions. I could not watch it fail locally — macOS already defaults to `spawn`, so the warning never appears here — but it should cover the regression on the Linux CI.