### PR TITLE
Fix failure to show help with `xdem` CLI command and `Affine` class multiplication in blockwise

### DIFF
--- a/tests/test_workflows/test_cli.py
+++ b/tests/test_workflows/test_cli.py
@@ -39,7 +39,11 @@ pytest.importorskip("cerberus")
 
 
 def test_xdem():
-    subprocess.run(["xdem"])
+    """Check if running simply 'xdem' in CLI does indeed show the help, without failure."""
+    result = subprocess.run(["xdem"], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
 
 
 @pytest.mark.parametrize("help_arg", [[], ["-h"], ["--help"]])

--- a/tests/test_workflows/test_cli.py
+++ b/tests/test_workflows/test_cli.py
@@ -23,6 +23,7 @@ test for CLI class
 
 import logging
 import os
+import subprocess
 
 # mypy: disable-error-code=no-untyped-def
 from pathlib import Path
@@ -35,6 +36,10 @@ from xdem.workflows.schemas import COMPLETE_CONFIG_ACCURACY, COMPLETE_CONFIG_TOP
 
 pytestmark = pytest.mark.filterwarnings("ignore::UserWarning")
 pytest.importorskip("cerberus")
+
+
+def test_xdem():
+    subprocess.run(["xdem"])
 
 
 @pytest.mark.parametrize("help_arg", [[], ["-h"], ["--help"]])

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -112,11 +112,12 @@ def main(arg_list: list[str] | None = None) -> None:
         "--output",
         help="(Optional) Path to output folder (with --config, overrides configuration file)",
     )
-
-    if arg_list is not None and not len(arg_list):
-        arg_list = ["--help"]
-
+    
     args = parser.parse_args(args=arg_list)
+
+    if args.command is None:
+        parser.print_help()
+        return
 
     # Instance logger
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -115,9 +115,14 @@ def main(arg_list: list[str] | None = None) -> None:
 
     args = parser.parse_args(args=arg_list)
 
+    # Print help for 'xdem' without arguments
     if args.command is None:
         parser.print_help()
         return
+
+    # Raise error for xdem --output without a --config
+    if args.command is not None and args.output and not args.config:
+        parser.error("Argument --output requires --config.")
 
     # Instance logger
     log_level = getattr(logging, args.log_level.upper(), logging.INFO)

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -112,7 +112,7 @@ def main(arg_list: list[str] | None = None) -> None:
         "--output",
         help="(Optional) Path to output folder (with --config, overrides configuration file)",
     )
-    
+
     args = parser.parse_args(args=arg_list)
 
     if args.command is None:

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import sys
 import argparse
 import logging
 
@@ -113,12 +113,12 @@ def main(arg_list: list[str] | None = None) -> None:
         help="(Optional) Path to output folder (with --config, overrides configuration file)",
     )
 
-    args = parser.parse_args(args=arg_list)
-
     # Print help for 'xdem' without arguments
-    if args.command is None:
-        parser.print_help()
-        return
+    arg_list = sys.argv[1:] if arg_list is None else arg_list
+    if not arg_list:
+        arg_list = ["--help"]
+
+    args = parser.parse_args(args=arg_list)
 
     # Raise error for xdem --output without a --config
     if args.command is not None and args.output and not args.config:

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import argparse
 import logging
+import sys
 
 from xdem._misc import import_optional
 from xdem.workflows import Accuracy, Topo

--- a/xdem/cli.py
+++ b/xdem/cli.py
@@ -126,9 +126,6 @@ def main(arg_list: list[str] | None = None) -> None:
     logging.getLogger("fontTools").setLevel(logging.WARNING)
     logging.getLogger("fontTools").propagate = False
 
-    if args.output and not args.config:
-        parser.error("Argument --output requires --config.")
-
     if args.command == "topo":
         if args.template_config or args.template_config is None:
             if args.template_config is None:

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -199,10 +199,10 @@ class BlockwiseCoreg:
             shift_y = coreg.meta["outputs"]["affine"].get("shift_y", np.nan)
             shift_z = coreg.meta["outputs"]["affine"].get("shift_z", np.nan)
 
-            x, y = (
+            x, y = to_be_aligned_elev.transform * (
                 tile_coords[2] + self.block_size_fit / 2,
                 tile_coords[0] + self.block_size_fit / 2,
-            ) * to_be_aligned_elev.transform  # type: ignore
+            )  # type: ignore
 
             self.x_coords.append(x)
             self.y_coords.append(y)


### PR DESCRIPTION
I noticed that simply calling `xdem` causes an error instead of launching the help utility:

```
Traceback (most recent call last):
  File "/home/mbouchet/Documents/xDem_project/new_xdem/xdem/venv/bin/xdem", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/mbouchet/Documents/xDem_project/new_xdem/xdem/xdem/cli.py", line 129, in main
    if args.output and not args.config:
       ^^^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'output'
```
#### Correction

`output` belongs to the workflows and can't be use without so args.output does not exists.
I removed this line => if `--output` is called without topo/accuracy, it behaves like any  other `--xxx` provided option. 

#### Test

Indeed, the test verifying its proper functioning was insufficient, as the testing method did not fully simulate the call via the terminal in case of the parameter : https://github.com/marinebcht/xdem/blob/12ad5fbe16696c960a8b19d4966c5a6551cf4f2d/tests/test_workflows/test_cli.py#L45 

So I used subprocess module : https://github.com/marinebcht/xdem/blob/12ad5fbe16696c960a8b19d4966c5a6551cf4f2d/tests/test_workflows/test_cli.py#L41


## NOTES DEV


I took the opportunity to correct another error in the CI : https://github.com/marinebcht/xdem/blob/936c4341f6968ce3dc39812f673521535ccd662a/xdem/coreg/blockwise.py#L202

- `something` * `Affine` => KO see https://github.com/GlacioHack/xdem/actions/runs/32118791212/job/95654249902
- `Affine` * `something` => OK

