### PR TITLE
Unpin old mamba version in CI tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -37,7 +37,7 @@ jobs:
         use-mamba: true
         channel-priority: strict
         activate-environment: xdem-dev
-        
+
     - name: Get month for resetting cache
       id: get-date
       run: echo "cache_date=$(/bin/date -u '+%Y%m')" >> $GITHUB_ENV

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,11 +35,9 @@ jobs:
         miniforge-version: latest
         auto-update-conda: true
         use-mamba: true
-        mamba-version: "2.0.5"
         channel-priority: strict
         activate-environment: xdem-dev
-        python-version:
-
+        
     - name: Get month for resetting cache
       id: get-date
       run: echo "cache_date=$(/bin/date -u '+%Y%m')" >> $GITHUB_ENV


### PR DESCRIPTION
Mirrors https://github.com/GlacioHack/geoutils/pull/908, to avoid failures in CI from deprecated Mamba versions