### PR TITLE
Fix PDF documentation build by converting SVG images for LaTeX

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ sphinx:
 
 # Build the doc in offline formats
 formats:
+  - pdf
   - htmlzip
 
 conda:

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -50,6 +50,7 @@ dependencies:
   - sphinx-gallery
   - autovizwidget
   - graphviz
+  - imagemagick  # For sphinx.ext.imgconverter to convert SVG images during LaTeX/PDF builds
   - myst-nb
   - numpydoc
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,6 +49,7 @@ extensions = [
     "sphinx.ext.autosummary",  # Create API doc summary texts from the docstrings.
     "sphinx.ext.inheritance_diagram",  # For class inheritance diagrams (see coregistration.rst).
     "sphinx.ext.graphviz",  # To render graphviz diagrams.
+    "sphinx.ext.imgconverter",  # To convert SVG images to a LaTeX-compatible format in PDF builds.
     "sphinx_design",  # To render nice blocks
     "sphinx_autodoc_typehints",  # Include type hints in the API documentation.
     "sphinxcontrib.programoutput",


### PR DESCRIPTION
This fixes #938 by addressing the reason the PDF build was deactivated in March.

I reproduced the LaTeX writer output locally and the build does not fail on type hint links as originally suspected. It fails on the SVG images first: `\sphinxincludegraphics{...}.svg` cannot be read by xelatex or lualatex because SVG files carry no bounding box, so the compile stops with `Cannot determine size of graphic`. The doc uses SVG for the xDEM logo on the landing page, the funding agency logos (NASA, SNF, CNES), and the Zenodo DOI badge, so the error appears within the first pages of every engine I tried. With those images converted ahead of the LaTeX step, the full document compiles, including all 529 hyperlinked type hint references and the intersphinx links to GeoUtils, pyproj and the Python docs.

The second failure is the inheritance diagram in the coregistration page. When the `dot` executable is missing, sphinx.ext.graphviz logs a warning and emits `\sphinxincludegraphics[]{None}`, which kills the run the same way. The conda `graphviz` package listed in dev-environment.yml provides the executable, so this only bites environments where the binary is absent; worth keeping in mind for other contributors building the PDF locally.

Changes in this PR:
- Add `sphinx.ext.imgconverter` to conf.py so SVG images are converted to PNG during LaTeX builds only, HTML output is unchanged.
- Add `imagemagick` to dev-environment.yml since imgconverter shells out to `convert`, which is not otherwise present in the Read the Docs build image.
- Re-enable `pdf` in the Read the Docs formats list now that the build has a path to succeed.

I verified this end to end: after converting the seven SVG assets, the full 74 page document compiles cleanly through xelatex with the type hint hyperlinks intact. On the machine I tested, matplotlib figures generated as PNG by the gallery totaled around 300 MB, so the PDF artifact may end up large; if size becomes a problem on Read the Docs, that is a separate knob from the build failure itself and I am happy to look at it.

If the PDF still fails on Read the Docs after this, the next place to look is the `dot` warning described above, since the builder silences it and continues rather than failing loudly.
