### PR TITLE
Draft of AI contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,12 @@ The technical steps to contributing to xDEM are:
 9. Push to your fork,
 10. Open a pull request from GitHub to discuss and eventually merge.
 
+These steps are detailed in sections further below!
+
 ## AI-assisted contribution policy
+
+“AI” herein refers to generative AI tools like large language models (LLMs) that can generate, edit, 
+and review software code, create and manipulate images, or generate text for communication.
 
 We welcome AI-assisted contributions under the following conditions:
 
@@ -36,13 +41,13 @@ We welcome AI-assisted contributions under the following conditions:
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
   design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
   sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license
-  with [xDEM's LICENSE](./LICENSE), and flag it to maintainers.
+  with [xDEM's LICENSE](./LICENSE), and flag such material explicitly to maintainers.
 
 Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient
 human understanding and validation, or attention to copyright and source.
 
-This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of Sept 2026,
-which was itself inspired by that of [SymPy](https://www.sympy.org/en/index.html).
+This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of September 2026,
+which were themselves inspired by that of [SymPy]([https://www.sympy.org/en/index.html](https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html)).
 
 ## Development environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ We welcome AI-assisted contributions under the following conditions:
 - **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
   design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
-  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
+  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license
   with [xDEM's LICENSE](./LICENSE), and flag it to maintainers.
 
 Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,19 @@ We welcome AI-assisted contributions under the following conditions:
   lists, tables, or other displays, but must not replace your own explanation. The same principle
   applies to comments during PR review, and opening an issue or discussion.
 
-- **Human review and accountability.** Personally review, understand, and validate the entire contribution,
+- **Human review and responsibility.** Personally review, understand, and validate the entire contribution,
   including code, tests, and documentation, before requesting review. Run relevant tests and accurately report
-  what you checked. You remain accountable for the contribution and must be able to explain your choices and address
+  what you checked. You remain responsible for the contribution and must be able to explain your choices and address
   review feedback.
 
 - **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
   design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
-  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license
-  and retains required attribution and notices. Flag unresolved provenance or licensing concerns to maintainers.
+  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
+  with [xDEM's LICENSE](./LCENSE), and flag it to maintainers.
 
 Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient
-human understanding, validation, or attention to source.
+human understanding and validation, or attention to copyright and source.
 
 This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of Sept 2026,
 which was itself inspired by that of [SymPy](https://www.sympy.org/en/index.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We welcome AI-assisted contributions under the following conditions:
   what you checked. You remain accountable for the contribution and must be able to explain your choices and address
   review feedback.
 
-- **References and licensing.** AI-generated code may reproduce or adapt existing copyrighted implementations 
+- **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations 
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
   design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant 
   sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
@@ -40,6 +40,9 @@ We welcome AI-assisted contributions under the following conditions:
 
 Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient 
 human understanding, validation, or attention to source.
+
+This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of Sept 2026, 
+which was itself inspired by that of [SymPy](https://www.sympy.org/en/index.html).
 
 ## Development environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,26 +22,26 @@ The technical steps to contributing to xDEM are:
 
 We welcome AI-assisted contributions under the following conditions:
 
-- **Human communication.** Write the core PR description yourself, explaining the motivation, approach, 
+- **Human communication.** Write the core PR description yourself, explaining the motivation, approach,
   and validation in your own words. AI may polish or translate your writing and help prepare supporting
-  lists, tables, or other displays, but must not replace your own explanation. The same principle 
+  lists, tables, or other displays, but must not replace your own explanation. The same principle
   applies to comments during PR review, and opening an issue or discussion.
 
-- **Human review and accountability.** Personally review, understand, and validate the entire contribution, 
-  including code, tests, and documentation, before requesting review. Run relevant tests and accurately report 
+- **Human review and accountability.** Personally review, understand, and validate the entire contribution,
+  including code, tests, and documentation, before requesting review. Run relevant tests and accurately report
   what you checked. You remain accountable for the contribution and must be able to explain your choices and address
   review feedback.
 
-- **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations 
+- **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
-  design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant 
-  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
+  design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
+  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license
   and retains required attribution and notices. Flag unresolved provenance or licensing concerns to maintainers.
 
-Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient 
+Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient
 human understanding, validation, or attention to source.
 
-This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of Sept 2026, 
+This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of Sept 2026,
 which was itself inspired by that of [SymPy](https://www.sympy.org/en/index.html).
 
 ## Development environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,29 @@ The technical steps to contributing to xDEM are:
 9. Push to your fork,
 10. Open a pull request from GitHub to discuss and eventually merge.
 
+## AI-assisted contribution policy
+
+We welcome AI-assisted contributions under the following conditions:
+
+- **Human communication.** Write the core PR description yourself, explaining the motivation, approach, 
+  and validation in your own words. AI may polish or translate your writing and help prepare supporting
+  lists, tables, or other displays, but must not replace your own explanation. The same principle 
+  applies to comments during PR review, and opening an issue or discussion.
+
+- **Human review and accountability.** Personally review, understand, and validate the entire contribution, 
+  including code, tests, and documentation, before requesting review. Run relevant tests and accurately report 
+  what you checked. You remain accountable for the contribution and must be able to explain your choices and address
+  review feedback.
+
+- **References and licensing.** AI-generated code may reproduce or adapt existing copyrighted implementations 
+  without identifying their sources. For major features or conceptual changes to methods, algorithms, or
+  design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant 
+  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
+  and retains required attribution and notices. Flag unresolved provenance or licensing concerns to maintainers.
+
+Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient 
+human understanding, validation, or attention to source.
+
 ## Development environment
 
 xDEM currently supports Python versions of 3.10 to 3.14 (see `dev-environment.yml` for detailed dependencies), which are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ These steps are detailed in sections further below!
 
 ## AI-assisted contribution policy
 
-“AI” herein refers to generative AI tools like large language models (LLMs) that can generate, edit, 
+“AI” herein refers to generative AI tools like large language models (LLMs) that can generate, edit,
 and review software code, create and manipulate images, or generate text for communication.
 
 We welcome AI-assisted contributions under the following conditions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ These steps are detailed in sections further below!
 
 ## AI-assisted contribution policy
 
-“AI” herein refers to generative AI tools like large language models (LLMs) that can generate, edit,
+“AI” herein refers to **generative AI tools like large language models (LLMs)** that can generate, edit,
 and review software code, create and manipulate images, or generate text for communication.
 
 We welcome AI-assisted contributions under the following conditions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We welcome AI-assisted contributions under the following conditions:
   without identifying their sources. For major features or conceptual changes to methods, algorithms, or
   design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
   sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license 
-  with [xDEM's LICENSE](./LCENSE), and flag it to maintainers.
+  with [xDEM's LICENSE](./LICENSE), and flag it to maintainers.
 
 Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient
 human understanding and validation, or attention to copyright and source.

--- a/doc/source/contributing.md
+++ b/doc/source/contributing.md
@@ -1,0 +1,41 @@
+(contributing)=
+# Contributing
+
+xDEM is evolving, and we welcome new contributions!
+
+## Guide and contact
+
+For direct contributions, don't hesitate to open an issue/PR on the main repository, following guidelines in our [CONTRIBUTING file](https://github.com/GlacioHack/xdem/blob/main/CONTRIBUTING.md).
+
+To get in touch with us to coordinate larger contributions, use either the GitHub discussions, or find our email contact in the [AUTHORS file](https://github.com/GlacioHack/xdem/blob/main/AUTHORS.md).
+
+## AI policy
+
+With the recent rise of AI-assisted contributions, we repeat our AI policy below (find its original version in the [CONTRIBUTING file](https://github.com/GlacioHack/xdem/blob/main/CONTRIBUTING.md)).
+
+“AI” herein refers to **generative AI tools like large language models (LLMs)** that can generate, edit,
+and review software code, create and manipulate images, or generate text for communication.
+
+We welcome AI-assisted contributions under the following conditions:
+
+- **Human communication.** Write the core PR description yourself, explaining the motivation, approach,
+  and validation in your own words. AI may polish or translate your writing and help prepare supporting
+  lists, tables, or other displays, but must not replace your own explanation. The same principle
+  applies to comments during PR review, and opening an issue or discussion.
+
+- **Human review and responsibility.** Personally review, understand, and validate the entire contribution,
+  including code, tests, and documentation, before requesting review. Run relevant tests and accurately report
+  what you checked. You remain responsible for the contribution and must be able to explain your choices and address
+  review feedback.
+
+- **References and licensing (copyright).** AI-generated code may reproduce or adapt existing copyrighted implementations
+  without identifying their sources. For major features or conceptual changes to methods, algorithms, or
+  design, make a reasonable search for relevant literature and existing implementations. Verify and cite relevant
+  sources, and check for potential code reuse. Ensure that any reused or adapted material has a compatible license
+  with [xDEM's LICENSE](./LICENSE), and flag such material explicitly to maintainers.
+
+Maintainers may decline PRs whose descriptions appear predominantly AI-generated, or that do not demonstrate sufficient
+human understanding and validation, or attention to copyright and source.
+
+This AI policy was inspired from that of [NumPy](https://numpy.org/devdocs/dev/ai_policy.html) and [SciPy](https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html) as of September 2026,
+which were themselves inspired by that of [SymPy]([https://www.sympy.org/en/index.html](https://docs.sympy.org/dev/contributing/ai-generated-code-policy.html)).


### PR DESCRIPTION
This PR adds a policy on AI-assisted contributions.

Resolves #945 

I tentatively drafted this based on our discussions, primarily at the dev meeting, and also using interesting examples from SciPy and NumPy (which are themselves inspired by that of SymPy):
https://docs.scipy.org/doc/scipy/dev/conduct/ai_policy.html
https://numpy.org/devdocs/dev/ai_policy.html
We also discussed that of GDAL last time, which goes in the same direction.

I liked the content but not their organization: Its long and hard to get an overview, and several subsections actually refer to the same topic.
So I summarized it into the three core element we touched on: **1/ Human communication**, **2/ Human review and responsibility** and **3/ References and licensing (copyright)**.

I specifically removed specific statements/subsections that felt either impossible to apply, or partially redundant.

In particular, I removed their "Disclosure" section which, in my opinion, will be impossible to do in practice.
The ask:
_You must disclose whether AI has been used to assist in the development of your pull request. If so, you must document which tool(s) have been used, how they were used, and specify what code or text is AI generated. We will reject any pull request that does not include the disclosure._
My problem is with: explaining which tool, how, what code exactly, etc... this is clearly an impossible task, which would take 10 times as much space as a PR itself. Given that a simple Google search triggering AI Overview is already AI-assisted usage, this becomes impossible to track. One has to be realistic there... :sweat_smile: 

And I removed their "AI Agent" section: If the PR is opened by AI or not is partly irrelevant to the main point for me, as long as all other things are respected. As far as I'm concerned, the Git-tools of various IDE that also facilitate pull/push/PR opening are not that different from AI-assist on this topic.

@belletva @marinebcht @adehecq What do you think?