### PR TITLE
[WIP] Add info() function to blockwise

### DIFF
--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2159,6 +2159,11 @@ class Coreg:
                             f"    {dict_key_to_str[k]}:".ljust(tab) + f"{format_coregdict_values(v, tab)}\n"
                             for k, v in existing_level_keys
                         ]
+            if "0_0" in self._meta["outputs"]:
+                for bloc in self._meta["outputs"].keys():
+                    shifts = [f"{v:.2f}" for v in self._meta["outputs"][bloc].values()]
+                    outputs_str += f"    {bloc}: [{', '.join(shifts)}]\n"
+
         elif not self._fit_called:
             outputs_str += ["  None yet (fit not called)"]
         # Not sure this case can happen, but just in case

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2173,40 +2173,33 @@ class Coreg:
                 keys = self._meta["outputs"]["0_0"].keys()
 
                 for key in keys:
-                    outputs_str += f"    shift_x:".ljust(tab) + f"{format_coregdict_values(dict_key_to_str[key], tab)}\n"
-
+                    outputs_str += f"    {key}:".ljust(tab) + f"{format_coregdict_values(dict_key_to_str[key], tab)}\n"
 
                 shifts = []
-                for key in keys:
-                    shifts_key = []
-                    for bloc in blocks:
-                        shifts_key.append(str(float(self._meta["outputs"][bloc][key])))
-                    shifts.append(shifts_key)
+                for b, bloc in enumerate(blocks):
+                    shifts_bloc = []
+                    for key in keys:
+                        shifts_bloc.append(str(float(self._meta["outputs"][bloc][key])))
+                    shifts.append(shifts_bloc)
 
-                shifts = [list(colonne) for colonne in zip(*shifts)]
+                #shifts = [list(colonne) for colonne in zip(*shifts)]
 
 
-                largeurs = [
+                tab_shifts = [
                     max(len(str(ligne[j])) for ligne in shifts)
                     for j in range(len(shifts[0]))
                 ]
-                print (largeurs)
-                """
-                outputs_str += f"    Shift:".ljust(tab) + ", ".join(
-                        str(val).rjust(largeurs[k])
-                        for k, key in enumerate(shifts[b])
-                    ) + "\n"
-                """
+
 
                 outputs_str += f"    Blocks".ljust(tab) + ", ".join(
-                    str(key).rjust(largeurs[k])
+                    str(key).rjust(tab_shifts[k])
                     for k, key in enumerate(keys)
                 ) + "\n"
 
                 for b, bloc in enumerate(blocks):
 
                     outputs_str += f"      {bloc}:".ljust(tab) + ", ".join(
-                        str(key).rjust(largeurs[k])
+                        str(key).rjust(tab_shifts[k])
                         for k, key in enumerate(shifts[b])
                     ) + "\n"
 

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2065,7 +2065,14 @@ class Coreg:
         """Summarize information about this coregistration."""
 
         # Define max tabulation: longest name + 2 spaces
-        tab = np.max([len(v) for v in dict_key_to_str.values()]) + 2
+        keys_ = list(dict_key_to_str.values())
+
+        if "0_0" in self._meta["outputs"]:
+            keys_.remove(dict_key_to_str["shift_x"])
+            keys_.remove(dict_key_to_str["shift_y"])
+            keys_.remove(dict_key_to_str["shift_z"])
+
+        tab = np.max([len(v) for v in dict_key_to_str.values()]) + 4
 
         # Get list of existing deepest level keys in this coreg metadata
         def recursive_items(dictionary: Mapping[str, Any]) -> Iterable[tuple[str, Any]]:
@@ -2160,9 +2167,52 @@ class Coreg:
                             for k, v in existing_level_keys
                         ]
             if "0_0" in self._meta["outputs"]:
-                for bloc in self._meta["outputs"].keys():
-                    shifts = [f"{v:.2f}" for v in self._meta["outputs"][bloc].values()]
-                    outputs_str += f"    {bloc}: [{', '.join(shifts)}]\n"
+                outputs_str += f"  Affine\n"
+
+                blocks = self._meta["outputs"].keys()
+                keys = self._meta["outputs"]["0_0"].keys()
+
+                for key in keys:
+                    outputs_str += f"    shift_x:".ljust(tab) + f"{format_coregdict_values(dict_key_to_str[key], tab)}\n"
+
+
+                shifts = []
+                for key in keys:
+                    shifts_key = []
+                    for bloc in blocks:
+                        shifts_key.append(str(float(self._meta["outputs"][bloc][key])))
+                    shifts.append(shifts_key)
+
+                shifts = [list(colonne) for colonne in zip(*shifts)]
+
+
+                largeurs = [
+                    max(len(str(ligne[j])) for ligne in shifts)
+                    for j in range(len(shifts[0]))
+                ]
+                print (largeurs)
+                """
+                outputs_str += f"    Shift:".ljust(tab) + ", ".join(
+                        str(val).rjust(largeurs[k])
+                        for k, key in enumerate(shifts[b])
+                    ) + "\n"
+                """
+
+                outputs_str += f"    Blocks".ljust(tab) + ", ".join(
+                    str(key).rjust(largeurs[k])
+                    for k, key in enumerate(keys)
+                ) + "\n"
+
+                for b, bloc in enumerate(blocks):
+
+                    outputs_str += f"      {bloc}:".ljust(tab) + ", ".join(
+                        str(key).rjust(largeurs[k])
+                        for k, key in enumerate(shifts[b])
+                    ) + "\n"
+
+
+
+                #outputs_str += f"    Block {bloc}: [{', '.join(shifts)}]\n"
 
         elif not self._fit_called:
             outputs_str += ["  None yet (fit not called)"]

--- a/xdem/coreg/base.py
+++ b/xdem/coreg/base.py
@@ -2167,7 +2167,7 @@ class Coreg:
                             for k, v in existing_level_keys
                         ]
             if "0_0" in self._meta["outputs"]:
-                outputs_str += f"  Affine\n"
+                outputs_str += "  Affine\n"
 
                 blocks = self._meta["outputs"].keys()
                 keys = self._meta["outputs"]["0_0"].keys()
@@ -2176,36 +2176,29 @@ class Coreg:
                     outputs_str += f"    {key}:".ljust(tab) + f"{format_coregdict_values(dict_key_to_str[key], tab)}\n"
 
                 shifts = []
-                for b, bloc in enumerate(blocks):
-                    shifts_bloc = []
+                for block in blocks:
+                    shifts_block = []
                     for key in keys:
-                        shifts_bloc.append(str(float(self._meta["outputs"][bloc][key])))
-                    shifts.append(shifts_bloc)
+                        shifts_block.append(str(float(self._meta["outputs"][block][key])))
+                    shifts.append(shifts_block)
 
-                #shifts = [list(colonne) for colonne in zip(*shifts)]
+                # shifts = [list(colonne) for colonne in zip(*shifts)]
 
+                tab_shifts = [max(len(str(ligne[j])) for ligne in shifts) for j in range(len(shifts[0]))]
 
-                tab_shifts = [
-                    max(len(str(ligne[j])) for ligne in shifts)
-                    for j in range(len(shifts[0]))
-                ]
+                outputs_str += (
+                    "    Blocks".ljust(tab)
+                    + ", ".join(str(key).rjust(tab_shifts[k]) for k, key in enumerate(keys))
+                    + "\n"
+                )
 
+                for b, block in enumerate(blocks):
 
-                outputs_str += f"    Blocks".ljust(tab) + ", ".join(
-                    str(key).rjust(tab_shifts[k])
-                    for k, key in enumerate(keys)
-                ) + "\n"
-
-                for b, bloc in enumerate(blocks):
-
-                    outputs_str += f"      {bloc}:".ljust(tab) + ", ".join(
-                        str(key).rjust(tab_shifts[k])
-                        for k, key in enumerate(shifts[b])
-                    ) + "\n"
-
-
-
-                #outputs_str += f"    Block {bloc}: [{', '.join(shifts)}]\n"
+                    outputs_str += (
+                        f"      {block}:".ljust(tab)
+                        + ", ".join(str(key).rjust(tab_shifts[k]) for k, key in enumerate(shifts[b]))
+                        + "\n"
+                    )
 
         elif not self._fit_called:
             outputs_str += ["  None yet (fit not called)"]

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -111,7 +111,8 @@ class BlockwiseCoreg:
 
         self.output_path_aligned = self.parent_path / self.mp_config.outfile
 
-        self.meta = {"inputs": {}, "outputs": {}}
+        blockwise_dict = {"block_size_fit": self.block_size_fit, "block_size_apply": self.block_size_apply}
+        self.meta = {"inputs": {"blockwise": blockwise_dict}, "outputs": {}}
         self.shape_tiling_grid = (0, 0, 0)
 
     @staticmethod
@@ -169,7 +170,7 @@ class BlockwiseCoreg:
         :return: None. Updates internal model parameters.
         """
 
-        self.meta["inputs"] = self.procstep.meta["inputs"]  # type: ignore
+        self.meta["inputs"].update(self.procstep.meta["inputs"])  # type: ignore
 
         outputs_coreg = map_multiproc_collect(
             self._coreg_wrapper,

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -26,12 +26,11 @@ import logging
 import math
 import os
 import warnings
+from pathlib import Path
 from typing import (
     Literal,
     overload,
 )
-
-from pathlib import Path
 
 import geopandas as gpd
 import geoutils as gu

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -233,7 +233,6 @@ class BlockwiseCoreg:
         # Flag that the fitting function has been called.
         self.procstep._fit_called = True
 
-
     @staticmethod
     def _ransac(
         x_coords: NDArrayf,
@@ -427,32 +426,29 @@ class BlockwiseCoreg:
     def info(self, as_str: bool = False) -> None | str:
         """Summarize information about this blockwise."""
 
-
         header_str = [
             "Blockwise information \n",
             f"  Block size fit:       {self.block_size_fit} \n",
             f"  Block size apply:     {self.block_size_apply} \n",
-            f"  Blocks repartition:    \n",
+            "  Blocks repartition:    \n",
         ]
 
-        blocs = []
-        for b, bloc in enumerate(self.procstep._meta["outputs"]):
-            blocs.append( [f"{bloc} :", f"X:{self.xy_blocks[b][0]}-{self.xy_blocks[b][1]}", f"Y:{self.xy_blocks[b][2]}-{self.xy_blocks[b][3]}"])
-        print (blocs)
-        tab_coords = [
-            max(len(str(col[j])) for col in blocs) + 4
-            for j in range(len(blocs[0]))
-        ]
-        print (tab_coords)
+        blocks = []
+        for b, block in enumerate(self.procstep._meta["outputs"]):
+            blocks.append(
+                [
+                    f"{block} :",
+                    f"X:{self.xy_blocks[b][0]}-{self.xy_blocks[b][1]}",
+                    f"Y:{self.xy_blocks[b][2]}-{self.xy_blocks[b][3]}",
+                ]
+            )
 
-        for b, bloc in enumerate(blocs):
-            header_str += f"    " + "".join(
-                str(v).rjust(tab_coords[b])
-                for b, v in enumerate(bloc)
-            ) + "\n"
+        tab_coords = [max(len(str(col[j])) for col in blocks) + 4 for j in range(len(blocks[0]))]
+
+        for block in blocks:
+            header_str += "    " + "".join(str(v).rjust(tab_coords[b]) for b, v in enumerate(block)) + "\n"
 
         step_str_tab = self.procstep.info(as_str=True).split("\n")
-        #step_str_tab.insert(step_str_tab.index("Inputs"), f"  Blockwise?    True")
 
         # Return as string or print (default)
         if as_str:

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -204,10 +204,10 @@ class BlockwiseCoreg:
             shift_y = coreg.meta["outputs"]["affine"].get("shift_y", np.nan)
             shift_z = coreg.meta["outputs"]["affine"].get("shift_z", np.nan)
 
-            x, y = (
+            x, y = to_be_aligned_elev.transform * (
                 tile_coords[2] + self.block_size_fit / 2,
                 tile_coords[0] + self.block_size_fit / 2,
-            ) * to_be_aligned_elev.transform  # type: ignore
+            )  # type: ignore
 
             self.x_coords.append(x)
             self.y_coords.append(y)

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -197,9 +197,9 @@ class BlockwiseCoreg:
         self.shifts_x = []  # type: ignore
         self.shifts_y = []  # type: ignore
         self.shifts_z = []  # type: ignore
+        self.xy_blocks = []  # type: ignore
 
         for idx, (coreg, tile_coords) in enumerate(outputs_coreg):
-
             shift_x = coreg.meta["outputs"]["affine"].get("shift_x", np.nan)
             shift_y = coreg.meta["outputs"]["affine"].get("shift_y", np.nan)
             shift_z = coreg.meta["outputs"]["affine"].get("shift_z", np.nan)
@@ -216,7 +216,10 @@ class BlockwiseCoreg:
             self.shifts_y.append(shift_y)
             self.shifts_z.append(shift_z)
 
+            self.xy_blocks.append(tile_coords)
+
             tile_str = f"{rows_cols[idx][0]}_{rows_cols[idx][1]}"
+
             self.procstep._meta["outputs"][tile_str] = {  # type: ignore
                 "shift_x": shift_x,
                 "shift_y": shift_y,
@@ -229,6 +232,7 @@ class BlockwiseCoreg:
 
         # Flag that the fitting function has been called.
         self.procstep._fit_called = True
+
 
     @staticmethod
     def _ransac(
@@ -423,14 +427,32 @@ class BlockwiseCoreg:
     def info(self, as_str: bool = False) -> None | str:
         """Summarize information about this blockwise."""
 
+
         header_str = [
             "Blockwise information \n",
             f"  Block size fit:       {self.block_size_fit} \n",
             f"  Block size apply:     {self.block_size_apply} \n",
+            f"  Blocks repartition:    \n",
         ]
 
+        blocs = []
+        for b, bloc in enumerate(self.procstep._meta["outputs"]):
+            blocs.append( [f"{bloc} :", f"X:{self.xy_blocks[b][0]}-{self.xy_blocks[b][1]}", f"Y:{self.xy_blocks[b][2]}-{self.xy_blocks[b][3]}"])
+        print (blocs)
+        tab_coords = [
+            max(len(str(col[j])) for col in blocs) + 4
+            for j in range(len(blocs[0]))
+        ]
+        print (tab_coords)
+
+        for b, bloc in enumerate(blocs):
+            header_str += f"    " + "".join(
+                str(v).rjust(tab_coords[b])
+                for b, v in enumerate(bloc)
+            ) + "\n"
+
         step_str_tab = self.procstep.info(as_str=True).split("\n")
-        step_str_tab.insert(step_str_tab.index("Inputs"), f"  Blockwise?    True")
+        #step_str_tab.insert(step_str_tab.index("Inputs"), f"  Blockwise?    True")
 
         # Return as string or print (default)
         if as_str:

--- a/xdem/coreg/blockwise.py
+++ b/xdem/coreg/blockwise.py
@@ -26,6 +26,11 @@ import logging
 import math
 import os
 import warnings
+from typing import (
+    Literal,
+    overload,
+)
+
 from pathlib import Path
 
 import geopandas as gpd
@@ -213,7 +218,7 @@ class BlockwiseCoreg:
             self.shifts_z.append(shift_z)
 
             tile_str = f"{rows_cols[idx][0]}_{rows_cols[idx][1]}"
-            self.meta["outputs"][tile_str] = {  # type: ignore
+            self.procstep._meta["outputs"][tile_str] = {  # type: ignore
                 "shift_x": shift_x,
                 "shift_y": shift_y,
                 "shift_z": shift_z,
@@ -222,6 +227,9 @@ class BlockwiseCoreg:
         self.x_coords, self.y_coords, self.shifts_x, self.shifts_y, self.shifts_z = map(  # type: ignore
             np.array, (self.x_coords, self.y_coords, self.shifts_x, self.shifts_y, self.shifts_z)
         )
+
+        # Flag that the fitting function has been called.
+        self.procstep._fit_called = True
 
     @staticmethod
     def _ransac(
@@ -406,3 +414,28 @@ class BlockwiseCoreg:
         )
 
         return aligned_dem
+
+    @overload
+    def info(self, as_str: Literal[False] = ...) -> None: ...
+
+    @overload
+    def info(self, as_str: Literal[True]) -> str: ...
+
+    def info(self, as_str: bool = False) -> None | str:
+        """Summarize information about this blockwise."""
+
+        header_str = [
+            "Blockwise information \n",
+            f"  Block size fit:       {self.block_size_fit} \n",
+            f"  Block size apply:     {self.block_size_apply} \n",
+        ]
+
+        step_str_tab = self.procstep.info(as_str=True).split("\n")
+        step_str_tab.insert(step_str_tab.index("Inputs"), f"  Blockwise?    True")
+
+        # Return as string or print (default)
+        if as_str:
+            return "".join(header_str) + "\n".join(step_str_tab)
+        else:
+            print("".join(header_str) + "\n".join(step_str_tab))
+            return None


### PR DESCRIPTION
Introduced the possibility to have `Blockwise.info()` from the result of `Coreg.info(`) supplemented by information from the blocks like this : 

```
Blockwise information 
  Block size fit:       40 
  Block size apply:     40 
  Blocks repartition:    
        0_0 :     X:0-40     Y:0-40
        0_1 :     X:0-40    Y:40-70
        1_0 :    X:40-54     Y:0-40
        1_1 :    X:40-54    Y:40-70
Generic coregistration information 
  Method:       NuthKaab 
  Is affine?    True 
  Fit called?   True 
Inputs
  Randomization
    Subsample size requested:                       500000.0
  Fitting and binning
    Fit, bin or bin+fit:                            bin_and_fit
    Function to fit:                                _nuth_kaab_fit_func
    Optimizer for fitting:                          ols
    Bin sizes or edges:                             72
    Binning statistic:                              nanmedian
  Affine
    Vertical shift activated:                       True
  Iterative
    Maximum number of iterations:                   10
    Tolerance to reach (pixel size):                0.001
Outputs
  Affine
    shift_x:                                        Eastward shift estimated (georeferenced unit)
    shift_y:                                        Northward shift estimated (georeferenced unit)
    shift_z:                                        Vertical shift estimated (elevation unit)
    subsample_final:                                Subsample size drawn from valid values
    Blocks                                                      shift_x,             shift_y,             shift_z, subsample_final
      0_0:                                            22.21456656578529,    7.07320473203152,  -2.926849365234375, 1340.0
      0_1:                                           6.8680468695955135,   1.654925549141062,    -4.9129638671875, 1200.0
      1_0:                                            9.271700310847379, -109.84026636059008, -0.2936859130859375,  560.0
      1_1:                                          -57.900147043976965, -196.32170429144566,  21.019805908203125,  420.0
```
To do this, I proposed to add a section blockwise to the meta["input"] with: 
 - `block_size_fit` (performed at initialization) 
 - `block_size_apply` (performed at initialization) 
 - `blocks` : another dict with a list of `name : {'start_x': ..., 'end_x': ..., 'start_y':..., 'end_y': ...}` (performed after the `fit()`) 

Plus, to save the `subsample_final` of each bloc, I kept the full result of `coreg.meta["outputs]` (coreg of each blocks is is not stored anywhere after its use) directly then pick out the right values.

Before the `fit()`, it gives something like this: 

```
Blockwise information 
  Block size fit:       40 
  Block size apply:     40 
  Blocks repartition:    
Generic coregistration information 
  Method:       NuthKaab 
  Is affine?    True 
  Fit called?   False 
Inputs
  Randomization
    Subsample size requested:                       500000.0
  Fitting and binning
    Fit, bin or bin+fit:                            bin_and_fit
    Function to fit:                                _nuth_kaab_fit_func
    Optimizer for fitting:                          ols
    Bin sizes or edges:                             72
    Binning statistic:                              nanmedian
  Affine
    Vertical shift activated:                       True
  Iterative
    Maximum number of iterations:                   10
    Tolerance to reach (pixel size):                0.001
Outputs
  None yet (fit not called)
```

### Dev info 

To be alble to have coregpipeline in blockwise, I took the opportunity to ... [to finish]